### PR TITLE
fix: enable horizontal scroll for top navbar items

### DIFF
--- a/great_docs/assets/great-docs.scss
+++ b/great_docs/assets/great-docs.scss
@@ -1690,12 +1690,16 @@ div.sourceCode:hover > .gd-code-nav .gd-code-copy,
 #quarto-header nav,
 #quarto-header .navbar,
 #quarto-header .container-fluid,
-#navbarCollapse,
-.navbar-nav,
 .navbar-nav.ms-auto,
 .navbar-nav.ms-auto > li,
 .navbar-nav.ms-auto > li > .nav-link {
     overflow: visible !important;
+}
+
+/* Allow horizontal scrolling for navbars with many items */
+#navbarCollapse > ul.navbar-nav.navbar-nav-scroll.me-auto {
+    text-wrap: nowrap;
+    overflow-x: auto !important;
 }
 
 /* Print styles - hide widget */

--- a/great_docs/assets/navbar-style.js
+++ b/great_docs/assets/navbar-style.js
@@ -169,11 +169,19 @@
     var search = document.getElementById("quarto-search");
     if (search) wrapper.appendChild(search);
 
-    // Remove the now-empty ul.ms-auto if it has no remaining children
+    // Remove the now-empty ul.ms-auto (or one left with only empty items)
     var msAuto = containerFluid.querySelector(
       "#navbarCollapse .navbar-nav.ms-auto"
     );
-    if (msAuto && msAuto.children.length === 0) msAuto.remove();
+    if (msAuto) {
+      // Remove child <li> items that have no meaningful content
+      Array.prototype.forEach.call(msAuto.querySelectorAll('li.nav-item'), function (li) {
+        if (!li.textContent.trim() && !li.querySelector('button, input, img, svg')) {
+          li.remove();
+        }
+      });
+      if (msAuto.children.length === 0) msAuto.remove();
+    }
 
     // Place inside .quarto-navbar-tools (the rightmost navbar slot)
     var tools = containerFluid.querySelector(".quarto-navbar-tools");


### PR DESCRIPTION
This PR improves the navigation bar's usability and robustness, especially when handling dynamic or crowded menus. The focus is on enhancing horizontal scrolling for large navbars and cleaning up any empty navigation items in the DOM.