### PR TITLE
fix: add keyboard shortcuts tooltip

### DIFF
--- a/great_docs/assets/keyboard-nav.js
+++ b/great_docs/assets/keyboard-nav.js
@@ -589,6 +589,8 @@
         btn.type = 'button';
         btn.setAttribute('aria-label',
             _gdT('kb_show_help', 'Show keyboard shortcuts'));
+        btn.setAttribute('data-tippy-content',
+            _gdT('kb_show_help', 'Show keyboard shortcuts'));
         btn.innerHTML =
             '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" ' +
             'viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ' +
@@ -631,6 +633,19 @@
                     showOverlay();
                 }
             });
+
+            // Initialize tooltip directly — window.tippy is available from
+            // Quarto's bundle before any include-after-body scripts run.
+            if (window.tippy) {
+                window.tippy(btn, {
+                    content: btn.getAttribute('data-tippy-content'),
+                    placement: 'bottom',
+                    animation: 'shift-away',
+                    duration: [200, 150],
+                    delay: [0, 0],
+                    arrow: true,
+                });
+            }
         }
     }
 

--- a/great_docs/assets/tooltips.js
+++ b/great_docs/assets/tooltips.js
@@ -250,15 +250,15 @@
       var needsReinit = false;
 
       mutations.forEach(function (mutation) {
-        // Check added nodes for title attributes
+        // Check added nodes for title or data-tippy-content attributes
         mutation.addedNodes.forEach(function (node) {
           if (node.nodeType === Node.ELEMENT_NODE) {
-            if (node.hasAttribute && node.hasAttribute("title")) {
+            if (node.hasAttribute && (node.hasAttribute("title") || node.hasAttribute("data-tippy-content"))) {
               needsReinit = true;
             }
             // Also check descendants
             if (node.querySelectorAll) {
-              var withTitle = node.querySelectorAll("[title]");
+              var withTitle = node.querySelectorAll("[title], [data-tippy-content]");
               if (withTitle.length > 0) {
                 needsReinit = true;
               }
@@ -266,8 +266,9 @@
           }
         });
 
-        // Check for attribute changes (title being set)
-        if (mutation.type === "attributes" && mutation.attributeName === "title") {
+        // Check for attribute changes (title or data-tippy-content being set)
+        if (mutation.type === "attributes" &&
+            (mutation.attributeName === "title" || mutation.attributeName === "data-tippy-content")) {
           needsReinit = true;
         }
       });
@@ -283,7 +284,7 @@
       childList: true,
       subtree: true,
       attributes: true,
-      attributeFilter: ["title"],
+      attributeFilter: ["title", "data-tippy-content"],
     });
   }
 


### PR DESCRIPTION
This PR adds a 'keyboard shortcuts' tooltip and generally improves how tooltips are initialized and detected. The changes ensure that tooltips using the `data-tippy-content` attribute are consistently recognized and initialized, in addition to those using the standard `title` attribute. 