### PR TITLE
fix: ensure GDLS works on non-reference pages

### DIFF
--- a/great_docs/assets/post-render.py
+++ b/great_docs/assets/post-render.py
@@ -641,7 +641,30 @@ def _resolve_interlink_name(name):
     return None
 
 
-def resolve_interlinks(html_content):
+def _make_relative_uri(uri, page_path):
+    """Convert a site-root-relative URI to a path relative to *page_path*.
+
+    *page_path* is relative to ``_site/`` (e.g. ``"reference/Foo.html"``,
+    ``"user-guide/intro.html"``, ``"index.html"``).
+
+    If *page_path* is ``None``, the legacy behaviour is used: strip the
+    ``reference/`` prefix (assumes the page lives inside ``reference/``).
+    """
+    if page_path is None:
+        # Legacy: reference-page context — just strip the shared prefix
+        if uri.startswith("reference/"):
+            return uri[len("reference/") :]
+        return uri
+
+    # Compute a relative path from the directory containing *page_path*
+    # to the URI (both relative to _site/).
+    import posixpath
+
+    page_dir = posixpath.dirname(page_path)  # e.g. "user-guide"
+    return posixpath.relpath(uri, page_dir)
+
+
+def resolve_interlinks(html_content, page_path=None):
     """Resolve interlink references in rendered HTML.
 
     Quarto renders interlink syntax as `<a>` tags with backtick-wrapped hrefs:
@@ -652,6 +675,10 @@ def resolve_interlinks(html_content):
     - ``[custom text](`~pkg.Name`)`` -> custom display text preserved
 
     This function resolves those links against the objects.json inventory.
+
+    *page_path* is the page's path relative to ``_site/`` (e.g.
+    ``"user-guide/intro.html"``).  When ``None``, the legacy
+    reference-page behaviour is used (strip ``reference/`` prefix).
     """
     if not _interlinks_inventory:
         return html_content
@@ -669,11 +696,8 @@ def resolve_interlinks(html_content):
         if result is None:
             return m.group(0)
         uri, short_name, role = result
-        # URIs from objects.json are root-relative (e.g. "reference/Name.html#...")
-        # but reference pages live inside reference/, so strip the prefix
-        # to get a sibling-relative path.
-        if uri.startswith("reference/"):
-            uri = uri[len("reference/") :]
+        # Convert site-root-relative URI to a path relative to this page
+        uri = _make_relative_uri(uri, page_path)
         # Determine display text:
         # 1. Custom text provided by user → keep it
         # 2. ~ prefix (shortened) → use short name
@@ -698,7 +722,7 @@ def resolve_interlinks(html_content):
     return html_content
 
 
-def autolink_code_references(html_content):
+def autolink_code_references(html_content, page_path=None):
     """Auto-convert inline code matching API names into clickable links.
 
     Scans `<code>` tags (outside `<pre>` blocks) for text that matches an entry in the objects.json
@@ -713,6 +737,10 @@ def autolink_code_references(html_content):
 
     Code with the `gd-no-link` class is never autolinked. Code inside `<pre>` blocks (fenced code)
     is never autolinked. Code containing spaces, operators, or arguments is never autolinked.
+
+    *page_path* is the page's path relative to ``_site/`` (e.g.
+    ``"user-guide/intro.html"``).  When ``None``, the legacy
+    reference-page behaviour is used (strip ``reference/`` prefix).
     """
     if not _interlinks_inventory:
         return html_content
@@ -766,8 +794,7 @@ def autolink_code_references(html_content):
             return full_tag
 
         uri, short_name, _role = result
-        if uri.startswith("reference/"):
-            uri = uri[len("reference/") :]
+        uri = _make_relative_uri(uri, page_path)
 
         # Determine display text based on prefix
         if prefix == "~~.":
@@ -2955,6 +2982,43 @@ for html_file in all_html_files:
             file.write(content)
 
 print("Finished processing all files")
+
+
+# ============================================================================
+# GDLS (Great Docs Linking System) — resolve interlinks on non-reference pages
+# ============================================================================
+# resolve_interlinks() and autolink_code_references() were already applied to
+# reference pages inside the reference-page loop above.  Here we apply them to
+# every *other* page (user guide, blog, recipes, homepage, etc.) so that the
+# [](`~pkg.Name`) shortcode syntax and inline-code autolinking work site-wide.
+
+if _interlinks_inventory:
+    # Pages already processed by the reference-page loop
+    _ref_pages = {os.path.normpath(f) for f in glob.glob("_site/reference/*.html")}
+    _gdls_count = 0
+
+    for html_file in all_html_files:
+        if os.path.normpath(html_file) in _ref_pages:
+            continue
+
+        with open(html_file, "r", encoding="utf-8") as file:
+            content = file.read()
+
+        # Compute the page path relative to _site/ for correct relative URIs
+        page_rel = os.path.relpath(html_file, "_site")
+
+        new_content = resolve_interlinks(content, page_path=page_rel)
+        new_content = autolink_code_references(new_content, page_path=page_rel)
+
+        if new_content != content:
+            with open(html_file, "w", encoding="utf-8") as file:
+                file.write(new_content)
+            _gdls_count += 1
+
+    print(f"GDLS: resolved interlinks on {_gdls_count} non-reference pages")
+else:
+    print("GDLS: no interlinks inventory loaded, skipping non-reference pages")
+
 
 # ── Translate autocomplete search-button title ──────────────────────────────
 # The Algolia autocomplete library (autocomplete.umd.js) ships with a

--- a/test-packages/synthetic/catalog.py
+++ b/test-packages/synthetic/catalog.py
@@ -343,6 +343,8 @@ ALL_PACKAGES: list[str] = [
     "gdtest_scale_min_scale",  # 169
     # 170: Wide homepage content with column-margin sidebar
     "gdtest_homepage_wide",  # 170
+    # 171: Interlinks and autolinking in user-guide pages (non-reference GDLS)
+    "gdtest_interlinks_userguide",  # 171
 ]
 
 
@@ -1938,6 +1940,12 @@ PACKAGE_DESCRIPTIONS: dict[str, str] = {
         "Tests that wide content on the homepage (code blocks, wide tables) "
         "renders at full width when the column-margin metadata sidebar is "
         "present. Verifies the gd-homepage body class and CSS grid fix."
+    ),
+    "gdtest_interlinks_userguide": (
+        "Three exports (Engine, Connection, execute) with user-guide pages "
+        "using [](`~pkg.Name`) interlinks and inline-code autolinking. "
+        "Tests that the GDLS resolves links on non-reference pages with "
+        "correct relative paths back to reference/."
     ),
 }
 

--- a/test-packages/synthetic/specs/gdtest_interlinks_userguide.py
+++ b/test-packages/synthetic/specs/gdtest_interlinks_userguide.py
@@ -1,0 +1,185 @@
+"""
+gdtest_interlinks_userguide — interlink references in user-guide pages.
+
+Dimensions: A1, D1, F1, L26
+Focus: Tests that the GDLS (Great Docs Linking System) resolves interlinks
+       and autolinking in user guide pages, not just reference pages.
+
+       - ``[](`~pkg.Name`)``  — shortened display in user-guide prose
+       - ``[](`pkg.Name`)``   — full qualified display in user-guide prose
+       - ``[custom text](`pkg.Name`)`` — custom display text in user-guide prose
+       - ``Name``, ``Name()`` — autolinked inline code in user-guide prose
+
+       The post-render resolver should convert all of these into proper
+       hyperlinks pointing back to the reference pages, with correct
+       relative paths (e.g. ``../reference/Foo.html``).
+"""
+
+SPEC = {
+    "name": "gdtest_interlinks_userguide",
+    "description": (
+        "Interlinks syntax in user-guide pages. "
+        "Tests that [](`~Name`) references and inline-code autolinking "
+        "work on non-reference pages via the all-pages GDLS pass."
+    ),
+    "dimensions": ["A1", "D1", "F1", "L26"],
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-interlinks-userguide",
+            "version": "0.1.0",
+            "description": "Test interlinks in user guide pages",
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    },
+    "files": {
+        "gdtest_interlinks_userguide/__init__.py": '''\
+            """Package demonstrating interlinks in user-guide pages."""
+
+            __version__ = "0.1.0"
+            __all__ = ["Engine", "Connection", "execute"]
+
+
+            class Engine:
+                """Database engine that manages connections.
+
+                Use [](`~gdtest_interlinks_userguide.Connection`) to interact
+                with the database.
+
+                Parameters
+                ----------
+                url
+                    Database connection URL.
+                """
+
+                def __init__(self, url: str) -> None:
+                    self.url = url
+
+
+            class Connection:
+                """Active database connection.
+
+                Created by [](`~gdtest_interlinks_userguide.Engine`).
+
+                Parameters
+                ----------
+                engine
+                    The engine that spawned this connection.
+                """
+
+                def __init__(self, engine: Engine) -> None:
+                    self.engine = engine
+
+
+            def execute(conn: Connection, query: str) -> list:
+                """Execute a SQL query on a connection.
+
+                Parameters
+                ----------
+                conn
+                    An active [](`~gdtest_interlinks_userguide.Connection`).
+                query
+                    The SQL query string.
+
+                Returns
+                -------
+                list
+                    Query results.
+                """
+                return []
+        ''',
+        # ── User guide pages with interlinks ────────────────────────────
+        "user_guide/01-getting-started.qmd": """\
+            ---
+            title: Getting Started
+            ---
+
+            ## Creating an Engine
+
+            To connect to a database, first create an
+            [](`~gdtest_interlinks_userguide.Engine`) instance:
+
+            ```python
+            from gdtest_interlinks_userguide import Engine
+            engine = Engine("sqlite:///mydb.db")
+            ```
+
+            ## Opening a Connection
+
+            Use the engine to open a
+            [](`~gdtest_interlinks_userguide.Connection`):
+
+            ```python
+            conn = Connection(engine)
+            ```
+
+            ## Running Queries
+
+            Call [](`~gdtest_interlinks_userguide.execute`) to run SQL:
+
+            ```python
+            results = execute(conn, "SELECT * FROM users")
+            ```
+
+            See the [API Reference](../reference/index.qmd) for full details.
+        """,
+        "user_guide/02-advanced.qmd": """\
+            ---
+            title: Advanced Usage
+            ---
+
+            ## Full Qualified References
+
+            You can reference the full path:
+            [](`gdtest_interlinks_userguide.Engine`).
+
+            ## Custom Link Text
+
+            Or use [custom link text](`gdtest_interlinks_userguide.Connection`)
+            for any reference.
+
+            ## Custom Text with Tilde
+
+            And also [custom text with tilde](`~gdtest_interlinks_userguide.execute`)
+            to override display.
+
+            ## Autolinked Code
+
+            Inline code like `Engine` and `Connection` and `execute()`
+            should be automatically linked to reference pages.
+        """,
+        "README.md": """\
+            # gdtest-interlinks-userguide
+
+            A synthetic test package testing interlinks in user-guide pages.
+        """,
+    },
+    "expected": {
+        "detected_name": "gdtest-interlinks-userguide",
+        "detected_module": "gdtest_interlinks_userguide",
+        "detected_parser": "numpy",
+        "export_names": ["Connection", "Engine", "execute"],
+        "num_exports": 3,
+        "section_titles": ["Classes", "Functions"],
+        "has_user_guide": True,
+        "user_guide_files": ["01-getting-started.qmd", "02-advanced.qmd"],
+        # Interlinks that should be resolved in user-guide pages
+        # Each key is a user-guide page filename, value is a list of
+        # (display_text, target_page) tuples that should appear as links
+        "interlinks_in_userguide": {
+            "01-getting-started": {
+                "shortened_links": ["Engine", "Connection", "execute()"],
+            },
+            "02-advanced": {
+                "full_qualified_links": ["gdtest_interlinks_userguide.Engine"],
+                "custom_text_links": [
+                    "custom link text",
+                    "custom text with tilde",
+                ],
+                "autolinked_code": ["Engine", "Connection", "execute()"],
+            },
+        },
+    },
+}

--- a/tests/test_gdg_rendered.py
+++ b/tests/test_gdg_rendered.py
@@ -8179,3 +8179,135 @@ def test_SCALE_MIN_SCALE_float_page_selectors():
     selectors = meta.get("data-selectors", "")
     for sel in ("#stf_wide", "#stf_styled", "#summary_card"):
         assert sel in selectors, f"Missing {sel} in float-override page selectors"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# DED: GDLS on non-reference pages (gdtest_interlinks_userguide)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _ilu_skip():
+    pkg = "gdtest_interlinks_userguide"
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+
+
+def _ilu_site():
+    return _site_dir("gdtest_interlinks_userguide")
+
+
+@requires_bs4
+def test_DED_interlinks_userguide_ref_pages_exist():
+    """gdtest_interlinks_userguide: all exports have reference pages."""
+    _ilu_skip()
+    ref = _ref_dir("gdtest_interlinks_userguide")
+    for name in ("Engine", "Connection", "execute"):
+        assert (ref / f"{name}.html").exists(), f"Ref page {name}.html missing"
+
+
+@requires_bs4
+def test_DED_interlinks_userguide_ug_pages_exist():
+    """gdtest_interlinks_userguide: user-guide pages exist."""
+    _ilu_skip()
+    ug = _ilu_site() / "user-guide"
+    assert (ug / "getting-started.html").exists(), "Getting Started page missing"
+    assert (ug / "advanced.html").exists(), "Advanced page missing"
+
+
+@requires_bs4
+def test_DED_interlinks_userguide_shortened_links():
+    """gdtest_interlinks_userguide: [](`~pkg.Name`) in user-guide resolves to links."""
+    _ilu_skip()
+    ug = _ilu_site() / "user-guide"
+    page = ug / "getting-started.html"
+    if not page.exists():
+        pytest.skip("getting-started.html not found")
+
+    soup = _load_html(page)
+    gdls_links = soup.find_all("a", class_="gdls-link")
+    link_texts = [a.get_text(strip=True) for a in gdls_links]
+
+    # Shortened references should produce short display names
+    for expected in ("Engine", "Connection", "execute()"):
+        assert expected in link_texts, (
+            f"Getting Started: shortened interlink {expected!r} not found. Found: {link_texts}"
+        )
+
+
+@requires_bs4
+def test_DED_interlinks_userguide_hrefs_relative():
+    """gdtest_interlinks_userguide: user-guide interlink hrefs use ../reference/ paths."""
+    _ilu_skip()
+    ug = _ilu_site() / "user-guide"
+    page = ug / "getting-started.html"
+    if not page.exists():
+        pytest.skip("getting-started.html not found")
+
+    soup = _load_html(page)
+    gdls_links = soup.find_all("a", class_="gdls-link")
+    for link in gdls_links:
+        href = link.get("href", "")
+        # From user-guide/*.html, href should start with ../reference/
+        assert href.startswith("../reference/"), (
+            f"User-guide interlink href {href!r} should be relative to ../reference/"
+        )
+
+
+@requires_bs4
+def test_DED_interlinks_userguide_full_qualified():
+    """gdtest_interlinks_userguide: [](`pkg.Name`) renders full qualified name."""
+    _ilu_skip()
+    ug = _ilu_site() / "user-guide"
+    page = ug / "advanced.html"
+    if not page.exists():
+        pytest.skip("advanced.html not found")
+
+    soup = _load_html(page)
+    gdls_links = soup.find_all("a", class_="gdls-link")
+    link_texts = [a.get_text(strip=True) for a in gdls_links]
+
+    assert "gdtest_interlinks_userguide.Engine" in link_texts, (
+        f"Advanced: full qualified 'gdtest_interlinks_userguide.Engine' not found. "
+        f"Found: {link_texts}"
+    )
+
+
+@requires_bs4
+def test_DED_interlinks_userguide_custom_text():
+    """gdtest_interlinks_userguide: [custom text](`pkg.Name`) preserves display text."""
+    _ilu_skip()
+    ug = _ilu_site() / "user-guide"
+    page = ug / "advanced.html"
+    if not page.exists():
+        pytest.skip("advanced.html not found")
+
+    soup = _load_html(page)
+    gdls_links = soup.find_all("a", class_="gdls-link")
+    link_texts = [a.get_text(strip=True) for a in gdls_links]
+
+    assert "custom link text" in link_texts, (
+        f"Advanced: custom text 'custom link text' not found. Found: {link_texts}"
+    )
+    assert "custom text with tilde" in link_texts, (
+        f"Advanced: custom text 'custom text with tilde' not found. Found: {link_texts}"
+    )
+
+
+@requires_bs4
+def test_DED_interlinks_userguide_autolinked_code():
+    """gdtest_interlinks_userguide: `Engine`, `execute()` autolinked in user-guide."""
+    _ilu_skip()
+    ug = _ilu_site() / "user-guide"
+    page = ug / "advanced.html"
+    if not page.exists():
+        pytest.skip("advanced.html not found")
+
+    soup = _load_html(page)
+    # Look for gdls-link gdls-code links (autolinked code produces this class combo)
+    code_links = soup.find_all("a", class_="gdls-code")
+    link_texts = [a.get_text(strip=True) for a in code_links]
+
+    for expected in ("Engine", "Connection", "execute()"):
+        assert expected in link_texts, (
+            f"Advanced: autolinked code {expected!r} not found. Found: {link_texts}"
+        )

--- a/tests/test_post_render.py
+++ b/tests/test_post_render.py
@@ -202,6 +202,7 @@ def _get_seealso_functions():
         "__builtins__": __builtins__,
         # Provide empty inventory for resolve_interlinks
         "_interlinks_inventory": {},
+        "_CALLABLE_ROLES": {"function", "method"},
         "_t": _t,
     }
 
@@ -209,6 +210,7 @@ def _get_seealso_functions():
         "extract_seealso_from_html",
         "extract_seealso_from_doc_section",
         "generate_seealso_html",
+        "_make_relative_uri",
         "_resolve_interlink_name",
         "resolve_interlinks",
         "autolink_code_references",
@@ -755,8 +757,9 @@ def _make_autolink(inventory):
         "re": _re,
         "__builtins__": __builtins__,
         "_interlinks_inventory": inventory,
+        "_CALLABLE_ROLES": {"function", "method"},
     }
-    for func_name in ("_resolve_interlink_name", "autolink_code_references"):
+    for func_name in ("_make_relative_uri", "_resolve_interlink_name", "autolink_code_references"):
         start = source.find(f"def {func_name}(")
         rest = source[start:]
         lines = rest.split("\n")
@@ -881,6 +884,325 @@ class TestAutolinkCodeReferences:
         fn = _make_autolink({})
         html = "<p><code>MyClass</code></p>"
         assert fn(html) == html
+
+
+# ── Helpers for page_path–aware GDLS tests ──────────────────────────────────
+
+
+def _extract_make_relative_uri():
+    """Extract _make_relative_uri as a standalone callable."""
+    source = _SCRIPT.read_text()
+    ns = {"__builtins__": __builtins__}
+    start = source.find("def _make_relative_uri(")
+    rest = source[start:]
+    lines = rest.split("\n")
+    func_lines = [lines[0]]
+    for line in lines[1:]:
+        if (
+            line
+            and not line[0].isspace()
+            and (line.startswith("def ") or line.startswith("class "))
+        ):
+            break
+        func_lines.append(line)
+    exec("\n".join(func_lines), ns)
+    return ns["_make_relative_uri"]
+
+
+class TestMakeRelativeUri:
+    """Direct unit tests for _make_relative_uri."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.fn = _extract_make_relative_uri()
+
+    def test_none_strips_reference_prefix(self):
+        """page_path=None strips reference/ prefix (legacy behaviour)."""
+        assert self.fn("reference/Foo.html#anchor", None) == "Foo.html#anchor"
+
+    def test_none_non_reference_uri_unchanged(self):
+        """page_path=None with non-reference/ URI returns it as-is."""
+        assert self.fn("other/page.html", None) == "other/page.html"
+
+    def test_same_directory(self):
+        """URI and page in same directory -> sibling-relative."""
+        result = self.fn("reference/Foo.html", "reference/Bar.html")
+        assert result == "Foo.html"
+
+    def test_parent_directory(self):
+        """URI in reference/, page one level up -> reference/ prefix."""
+        result = self.fn("reference/Foo.html", "index.html")
+        assert result == "reference/Foo.html"
+
+    def test_sibling_directory(self):
+        """URI in reference/, page in user-guide/ -> ../reference/."""
+        result = self.fn("reference/Foo.html", "user-guide/intro.html")
+        assert result == "../reference/Foo.html"
+
+    def test_deeply_nested_page(self):
+        """Page 3 levels deep -> three ../ segments."""
+        result = self.fn("reference/Foo.html", "blog/2025/01/post.html")
+        assert result == "../../../reference/Foo.html"
+
+    def test_preserves_fragment(self):
+        """Fragment (#anchor) is preserved through relpath calculation."""
+        result = self.fn("reference/Foo.html#pkg.Foo", "user-guide/intro.html")
+        assert result == "../reference/Foo.html#pkg.Foo"
+
+    def test_non_reference_uri_from_subdir(self):
+        """Non-reference/ URI also gets correct relative path."""
+        result = self.fn("changelog.html", "user-guide/intro.html")
+        assert result == "../changelog.html"
+
+    def test_same_file(self):
+        """URI pointing to the same file -> just the filename."""
+        result = self.fn("user-guide/intro.html", "user-guide/intro.html")
+        assert result == "intro.html"
+
+
+def _make_resolve_interlinks(inventory):
+    """Create a resolve_interlinks function bound to a given inventory."""
+    import re as _re
+
+    source = _SCRIPT.read_text()
+    ns = {
+        "re": _re,
+        "__builtins__": __builtins__,
+        "_interlinks_inventory": inventory,
+        "_CALLABLE_ROLES": {"function", "method"},
+    }
+    for func_name in ("_make_relative_uri", "_resolve_interlink_name", "resolve_interlinks"):
+        start = source.find(f"def {func_name}(")
+        rest = source[start:]
+        lines = rest.split("\n")
+        func_lines = [lines[0]]
+        for line in lines[1:]:
+            if (
+                line
+                and not line[0].isspace()
+                and (line.startswith("def ") or line.startswith("class "))
+            ):
+                break
+            func_lines.append(line)
+        exec("\n".join(func_lines), ns)
+    return ns["resolve_interlinks"]
+
+
+def _make_autolink_with_path(inventory):
+    """Create an autolink function bound to a given inventory (page_path-aware)."""
+    import re as _re
+
+    source = _SCRIPT.read_text()
+    ns = {
+        "re": _re,
+        "__builtins__": __builtins__,
+        "_interlinks_inventory": inventory,
+        "_CALLABLE_ROLES": {"function", "method"},
+    }
+    for func_name in (
+        "_make_relative_uri",
+        "_resolve_interlink_name",
+        "autolink_code_references",
+    ):
+        start = source.find(f"def {func_name}(")
+        rest = source[start:]
+        lines = rest.split("\n")
+        func_lines = [lines[0]]
+        for line in lines[1:]:
+            if (
+                line
+                and not line[0].isspace()
+                and (line.startswith("def ") or line.startswith("class "))
+            ):
+                break
+            func_lines.append(line)
+        exec("\n".join(func_lines), ns)
+    return ns["autolink_code_references"]
+
+
+class TestResolveInterlinksPagePath:
+    """Tests for resolve_interlinks with page_path for non-reference pages."""
+
+    INVENTORY = {
+        "pkg.Engine": {
+            "uri": "reference/Engine.html#pkg.Engine",
+            "dispname": "-",
+            "role": "class",
+        },
+        "pkg.execute": {
+            "uri": "reference/execute.html#pkg.execute",
+            "dispname": "-",
+            "role": "function",
+        },
+    }
+
+    def _resolve(self, html, page_path=None):
+        fn = _make_resolve_interlinks(self.INVENTORY)
+        return fn(html, page_path=page_path)
+
+    def test_reference_page_strips_prefix(self):
+        """On a reference page (page_path=None), strips reference/ prefix."""
+        html = '<a href="`~pkg.Engine`"></a>'
+        result = self._resolve(html, page_path=None)
+        assert 'href="Engine.html#pkg.Engine"' in result
+
+    def test_reference_page_explicit_path(self):
+        """On a reference page with explicit path, keeps sibling-relative."""
+        html = '<a href="`~pkg.Engine`"></a>'
+        result = self._resolve(html, page_path="reference/Connection.html")
+        assert 'href="Engine.html#pkg.Engine"' in result
+
+    def test_user_guide_page_relative_path(self):
+        """On a user-guide page, produces ../reference/ relative path."""
+        html = '<a href="`~pkg.Engine`"></a>'
+        result = self._resolve(html, page_path="user-guide/intro.html")
+        assert 'href="../reference/Engine.html#pkg.Engine"' in result
+
+    def test_user_guide_subdir_relative_path(self):
+        """On a deeper user-guide page, produces ../../reference/ path."""
+        html = '<a href="`~pkg.Engine`"></a>'
+        result = self._resolve(html, page_path="user-guide/advanced/tips.html")
+        assert 'href="../../reference/Engine.html#pkg.Engine"' in result
+
+    def test_root_page_relative_path(self):
+        """On the site root (e.g. index.html), reference/ is direct child."""
+        html = '<a href="`~pkg.Engine`"></a>'
+        result = self._resolve(html, page_path="index.html")
+        assert 'href="reference/Engine.html#pkg.Engine"' in result
+
+    def test_callable_gets_parens(self):
+        """Functions get () appended when using tilde shortening."""
+        html = '<a href="`~pkg.execute`"></a>'
+        result = self._resolve(html, page_path="user-guide/intro.html")
+        assert "execute()" in result
+        assert 'href="../reference/execute.html#pkg.execute"' in result
+
+    def test_full_qualified_display(self):
+        """Without tilde, full qualified name is shown."""
+        html = '<a href="`pkg.Engine`"></a>'
+        result = self._resolve(html, page_path="user-guide/intro.html")
+        assert "pkg.Engine" in result
+        assert 'href="../reference/Engine.html#pkg.Engine"' in result
+
+    def test_custom_text_preserved(self):
+        """Custom link text is preserved regardless of page_path."""
+        html = '<a href="`~pkg.Engine`">my custom text</a>'
+        result = self._resolve(html, page_path="user-guide/intro.html")
+        assert "my custom text" in result
+        assert 'href="../reference/Engine.html#pkg.Engine"' in result
+
+    def test_unresolved_left_unchanged(self):
+        """Unresolved interlink on non-reference page is left as-is."""
+        html = '<a href="`~pkg.Unknown`"></a>'
+        result = self._resolve(html, page_path="user-guide/intro.html")
+        assert result == html
+
+    def test_multiple_interlinks_in_one_page(self):
+        """Multiple interlinks in a single page all resolve independently."""
+        html = '<p><a href="`~pkg.Engine`"></a> and <a href="`~pkg.execute`"></a></p>'
+        result = self._resolve(html, page_path="user-guide/intro.html")
+        assert 'href="../reference/Engine.html#pkg.Engine"' in result
+        assert 'href="../reference/execute.html#pkg.execute"' in result
+        assert "Engine" in result
+        assert "execute()" in result
+
+    def test_empty_inventory_returns_unchanged(self):
+        """With empty inventory, content is returned unchanged."""
+        fn = _make_resolve_interlinks({})
+        html = '<a href="`~pkg.Engine`"></a>'
+        assert fn(html, page_path="user-guide/intro.html") == html
+
+
+class TestAutolinkCodeReferencesPagePath:
+    """Tests for autolink_code_references with page_path for non-reference pages."""
+
+    INVENTORY = {
+        "pkg.Engine": {
+            "uri": "reference/Engine.html#pkg.Engine",
+            "dispname": "-",
+        },
+        "pkg.execute": {
+            "uri": "reference/execute.html#pkg.execute",
+            "dispname": "-",
+        },
+    }
+
+    def _autolink(self, html, page_path=None):
+        fn = _make_autolink_with_path(self.INVENTORY)
+        return fn(html, page_path=page_path)
+
+    def test_reference_page_strips_prefix(self):
+        """On a reference page (page_path=None), strips reference/ prefix."""
+        result = self._autolink("<p><code>Engine</code></p>", page_path=None)
+        assert 'href="Engine.html#pkg.Engine"' in result
+
+    def test_user_guide_relative_path(self):
+        """On a user-guide page, produces ../reference/ path."""
+        result = self._autolink("<p><code>Engine</code></p>", page_path="user-guide/intro.html")
+        assert 'href="../reference/Engine.html#pkg.Engine"' in result
+
+    def test_root_page_relative_path(self):
+        """On the site root, reference/ is direct child."""
+        result = self._autolink("<p><code>Engine</code></p>", page_path="index.html")
+        assert 'href="reference/Engine.html#pkg.Engine"' in result
+
+    def test_deep_subdir_relative_path(self):
+        """On a deeply nested page, correct number of ../ segments."""
+        result = self._autolink("<p><code>Engine</code></p>", page_path="blog/2025/01/post.html")
+        assert 'href="../../../reference/Engine.html#pkg.Engine"' in result
+
+    def test_tilde_shortening_with_path(self):
+        """~~ shortening works with page_path."""
+        result = self._autolink(
+            "<p><code>~~pkg.Engine</code></p>", page_path="user-guide/intro.html"
+        )
+        assert 'href="../reference/Engine.html#pkg.Engine"' in result
+        assert ">Engine</a>" in result
+
+    def test_parens_preserved_with_path(self):
+        """Name() display is preserved with correct page_path."""
+        result = self._autolink("<p><code>execute()</code></p>", page_path="user-guide/intro.html")
+        assert 'href="../reference/execute.html#pkg.execute"' in result
+        assert "execute()" in result
+
+    def test_pre_block_protected_with_path(self):
+        """Code inside <pre> is NOT autolinked even with page_path."""
+        result = self._autolink("<pre><code>Engine</code></pre>", page_path="user-guide/intro.html")
+        assert "<a" not in result
+
+    def test_gd_no_link_with_path(self):
+        """gd-no-link class still suppresses autolinking with page_path."""
+        result = self._autolink(
+            '<p><code class="gd-no-link">Engine</code></p>',
+            page_path="user-guide/intro.html",
+        )
+        assert "<a" not in result
+
+    def test_already_inside_link_with_path(self):
+        """Code already inside an <a> tag is not double-wrapped."""
+        result = self._autolink(
+            '<a href="foo.html"><code>Engine</code></a>',
+            page_path="user-guide/intro.html",
+        )
+        assert result.count("<a ") == 1
+
+    def test_unresolved_code_unchanged_with_path(self):
+        """Unresolved code on non-reference page stays as plain <code>."""
+        result = self._autolink(
+            "<p><code>UnknownThing</code></p>",
+            page_path="user-guide/intro.html",
+        )
+        assert "<a" not in result
+        assert "<code>UnknownThing</code>" in result
+
+    def test_multiple_codes_in_one_page(self):
+        """Multiple code references in one page all resolve."""
+        result = self._autolink(
+            "<p><code>Engine</code> and <code>execute()</code></p>",
+            page_path="user-guide/intro.html",
+        )
+        assert 'href="../reference/Engine.html#pkg.Engine"' in result
+        assert 'href="../reference/execute.html#pkg.execute"' in result
 
 
 class TestFixPlainDoctestGdCodeNav:


### PR DESCRIPTION
This PR enhances the Great Docs Linking System (GDLS) to resolve interlinks and autolinking in all site pages, not just reference pages. It introduces logic to compute correct relative paths for interlinks from non-reference pages (like user guides), ensuring that links point to the correct reference pages regardless of directory structure. The update also adds many tests (with a new synthetic test package and dedicated tests for that).