### PR TITLE
fix: properly handle backticks in docstring headers

### DIFF
--- a/great_docs/_qrenderer/_render/doc.py
+++ b/great_docs/_qrenderer/_render/doc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from copy import copy
 from dataclasses import dataclass
 from functools import cached_property, singledispatchmethod
@@ -397,7 +398,11 @@ class __RenderDoc(RenderBase):
 
         for i, section in enumerate(sections):
             section_kind: gf.DocstringSectionKind = section.kind
-            title = (section.title or section_kind).strip().title()
+            raw_title = (section.title or section_kind).strip()
+            # Apply .title() only to text outside backtick-delimited code spans
+            # so that e.g. "What Can Be Used in `value=`?" keeps `value=` verbatim.
+            parts = raw_title.split("`")
+            title = "`".join(part if idx % 2 else part.title() for idx, part in enumerate(parts))
 
             if section_kind == "text":
                 assert i == 0, f"unexpected text section {section_kind}"
@@ -419,7 +424,11 @@ class __RenderDoc(RenderBase):
             body = self.render_docstring_section(section) or ""
             if not body:
                 continue
-            slug = title.lower().replace(" ", "-")
+            # Build a slug-safe CSS class: strip backticks and non-alphanumeric
+            # characters (except hyphens/spaces) before lowercasing and hyphenating.
+            slug_raw = title.replace("`", "")
+            slug = re.sub(r"[^a-z0-9 -]", "", slug_raw.lower())
+            slug = re.sub(r"[ -]+", "-", slug).strip("-")
             section_classes = [f"doc-{slug}"]
             if title in ("Text", "Deprecated"):
                 content = Div(body, Attr(classes=section_classes))

--- a/test-packages/synthetic/catalog.py
+++ b/test-packages/synthetic/catalog.py
@@ -345,6 +345,8 @@ ALL_PACKAGES: list[str] = [
     "gdtest_homepage_wide",  # 170
     # 171: Interlinks and autolinking in user-guide pages (non-reference GDLS)
     "gdtest_interlinks_userguide",  # 171
+    # 172: Custom docstring headings with backtick code spans
+    "gdtest_code_span_headings",  # 172
 ]
 
 
@@ -1946,6 +1948,12 @@ PACKAGE_DESCRIPTIONS: dict[str, str] = {
         "using [](`~pkg.Name`) interlinks and inline-code autolinking. "
         "Tests that the GDLS resolves links on non-reference pages with "
         "correct relative paths back to reference/."
+    ),
+    "gdtest_code_span_headings": (
+        "Two functions with custom docstring section headings containing "
+        "backtick code spans (e.g. 'What Can Be Used in `value=`?'). "
+        "Tests that title-casing preserves code verbatim and that slug "
+        "generation strips backticks and special characters."
     ),
 }
 

--- a/test-packages/synthetic/specs/gdtest_code_span_headings.py
+++ b/test-packages/synthetic/specs/gdtest_code_span_headings.py
@@ -1,0 +1,126 @@
+"""
+gdtest_code_span_headings — custom docstring headings containing code spans.
+
+Dimensions: A1, D1, L26
+Focus: Tests that custom docstring section headings containing backtick-
+       delimited code spans are handled correctly:
+
+       1. Title-casing preserves code spans verbatim (``value=`` stays
+          lowercase inside backticks).
+       2. Slug / CSS class generation strips backticks and special characters
+          (``=``, ``?``) so the resulting ``{.doc-...}`` class is valid.
+"""
+
+SPEC = {
+    "name": "gdtest_code_span_headings",
+    "description": (
+        "Custom docstring headings with backtick code spans. "
+        "Tests that title-casing preserves code verbatim and slugs are sanitized."
+    ),
+    "dimensions": ["A1", "D1", "L26"],
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-code-span-headings",
+            "version": "0.1.0",
+            "description": "Test code spans in docstring section headings",
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    },
+    "files": {
+        "gdtest_code_span_headings/__init__.py": '''\
+            """Package with custom docstring section headings containing code spans."""
+
+            __version__ = "0.1.0"
+            __all__ = ["compare_values", "filter_range"]
+
+
+            def compare_values(data, column: str, value=None):
+                """Compare column values against a threshold.
+
+                Parameters
+                ----------
+                data
+                    The input data.
+                column
+                    Column name to compare.
+                value
+                    Comparison threshold. Accepts scalars, column references,
+                    or expressions.
+
+                What Can Be Used in `value=`?
+                -----------------------------
+                The ``value=`` parameter accepts several types:
+
+                - A scalar like ``10`` or ``"hello"``.
+                - A column reference using ``col("other_col")``.
+                - An expression using ``expr()``.
+
+                Returns
+                -------
+                list
+                    Filtered results.
+                """
+                return []
+
+
+            def filter_range(data, column: str, left=None, right=None):
+                """Filter values within a range.
+
+                Parameters
+                ----------
+                data
+                    The input data.
+                column
+                    Column name to filter.
+                left
+                    Lower bound of the range.
+                right
+                    Upper bound of the range.
+
+                What Can Be Used in `left=` and `right=`?
+                ------------------------------------------
+                The ``left=`` and ``right=`` parameters accept:
+
+                - Scalars (``int``, ``float``, ``str``).
+                - Column references.
+                - Expressions.
+
+                Returns
+                -------
+                list
+                    Filtered results.
+                """
+                return []
+        ''',
+        "README.md": """\
+            # gdtest-code-span-headings
+
+            A synthetic test package for code spans in docstring section headings.
+        """,
+    },
+    "expected": {
+        "detected_name": "gdtest-code-span-headings",
+        "detected_module": "gdtest_code_span_headings",
+        "detected_parser": "numpy",
+        "export_names": ["compare_values", "filter_range"],
+        "num_exports": 2,
+        "section_titles": ["Functions"],
+        "has_user_guide": False,
+        # Headings in the rendered HTML should preserve code spans
+        "code_span_headings": {
+            "compare_values": {
+                # The heading text should contain `value=` as inline code
+                "heading_text": "What Can Be Used In `value=`?",
+                # The slug/class should be clean (no backticks, =, or ?)
+                "expected_class": "doc-what-can-be-used-in-value",
+            },
+            "filter_range": {
+                "heading_text": "What Can Be Used In `left=` And `right=`?",
+                "expected_class": "doc-what-can-be-used-in-left-and-right",
+            },
+        },
+    },
+}

--- a/tests/test_gdg_rendered.py
+++ b/tests/test_gdg_rendered.py
@@ -8311,3 +8311,101 @@ def test_DED_interlinks_userguide_autolinked_code():
         assert expected in link_texts, (
             f"Advanced: autolinked code {expected!r} not found. Found: {link_texts}"
         )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# DED: Code spans in docstring section headings (gdtest_code_span_headings)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _csh_skip():
+    pkg = "gdtest_code_span_headings"
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+
+
+def _csh_ref():
+    return _ref_dir("gdtest_code_span_headings")
+
+
+@requires_bs4
+def test_DED_code_span_headings_pages_exist():
+    """gdtest_code_span_headings: reference pages exist for both functions."""
+    _csh_skip()
+    ref = _csh_ref()
+    for name in ("compare_values", "filter_range"):
+        assert (ref / f"{name}.html").exists(), f"Ref page {name}.html missing"
+
+
+@requires_bs4
+def test_DED_code_span_headings_slug_sanitized():
+    """gdtest_code_span_headings: heading CSS class has no backticks or special chars."""
+    _csh_skip()
+    ref = _csh_ref()
+
+    expected_classes = {
+        "compare_values": "doc-what-can-be-used-in-value",
+        "filter_range": "doc-what-can-be-used-in-left-and-right",
+    }
+
+    for page_name, expected_class in expected_classes.items():
+        soup = _load_html(ref / f"{page_name}.html")
+        tag = soup.find(class_=expected_class)
+        assert tag is not None, f"{page_name}.html: expected class {expected_class!r} not found"
+        # Verify no backticks or problematic chars in any doc- class on this page
+        for el in soup.find_all(class_=True):
+            for cls in el.get("class", []):
+                if cls.startswith("doc-"):
+                    assert "`" not in cls, f"Backtick in class: {cls}"
+                    assert "=" not in cls, f"Equals in class: {cls}"
+                    assert "?" not in cls, f"Question mark in class: {cls}"
+
+
+@requires_bs4
+def test_DED_code_span_headings_code_preserved():
+    """gdtest_code_span_headings: heading text preserves code spans as <code> elements."""
+    _csh_skip()
+    ref = _csh_ref()
+
+    # compare_values should have: What Can Be Used In <code>value=</code>?
+    soup = _load_html(ref / "compare_values.html")
+    heading = soup.find("h2", class_="doc-what-can-be-used-in-value")
+    if heading is None:
+        heading = soup.find("h3", class_="doc-what-can-be-used-in-value")
+    assert heading is not None, "Custom heading element not found"
+    code_el = heading.find("code")
+    assert code_el is not None, "No <code> element inside heading"
+    assert code_el.get_text() == "value=", (
+        f"Expected code span 'value=', got {code_el.get_text()!r}"
+    )
+
+    # filter_range should have: What Can Be Used In <code>left=</code> And <code>right=</code>?
+    soup = _load_html(ref / "filter_range.html")
+    heading = soup.find("h2", class_="doc-what-can-be-used-in-left-and-right")
+    if heading is None:
+        heading = soup.find("h3", class_="doc-what-can-be-used-in-left-and-right")
+    assert heading is not None, "Custom heading element not found"
+    codes = heading.find_all("code")
+    assert len(codes) == 2, f"Expected 2 <code> elements, found {len(codes)}"
+    assert codes[0].get_text() == "left=", f"Expected 'left=', got {codes[0].get_text()!r}"
+    assert codes[1].get_text() == "right=", f"Expected 'right=', got {codes[1].get_text()!r}"
+
+
+@requires_bs4
+def test_DED_code_span_headings_title_case_outside_code():
+    """gdtest_code_span_headings: text outside code spans is title-cased."""
+    _csh_skip()
+    ref = _csh_ref()
+
+    soup = _load_html(ref / "compare_values.html")
+    heading = soup.find("h2", class_="doc-what-can-be-used-in-value")
+    if heading is None:
+        heading = soup.find("h3", class_="doc-what-can-be-used-in-value")
+    assert heading is not None
+    # Get text-only content (strips <code> tags)
+    full_text = heading.get_text().strip()
+    # Should be title-cased: "What Can Be Used In value=?"
+    # The words outside code should start with uppercase
+    assert full_text.startswith("What Can Be Used In"), (
+        f"Heading text not title-cased: {full_text!r}"
+    )


### PR DESCRIPTION
This PR introduces support for custom docstring section headings containing backtick-delimited code spans, ensuring that code within backticks is preserved verbatim (not title-cased) and that generated CSS classes (slugs) are sanitized by stripping backticks and special characters. We also add a GDG site along with dedicated tests to validate this functionality.