### PR TITLE
fix: adjust layout of blog index

### DIFF
--- a/great_docs/assets/copy-page.js
+++ b/great_docs/assets/copy-page.js
@@ -60,6 +60,9 @@
         // Skip the Tags index page
         if (document.body.classList.contains('gd-tags-index')) return;
 
+        // Skip the Blog index page
+        if (document.body.classList.contains('gd-blog-index')) return;
+
         // Create the widget container
         var widget = document.createElement('div');
         widget.className = 'gd-copy-page';

--- a/great_docs/assets/great-docs.scss
+++ b/great_docs/assets/great-docs.scss
@@ -4107,6 +4107,12 @@ body.gd-license-page .content.column-page {
     max-width: 100%;
 }
 
+// Blog index page: use full width (no TOC sidebar)
+body.gd-blog-index .content.column-page {
+    grid-column: page-start / page-end !important;
+    max-width: 100%;
+}
+
 // Terminal-style raw skill file rendering
 .gd-skills-raw {
     background: $gray-100;

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -2648,6 +2648,8 @@ class GreatDocs:
             "  contents:",
             '    - "**.qmd"',
             "bread-crumbs: false",
+            "toc: false",
+            "body-classes: gd-blog-index",
             "---",
             "",
         ]


### PR DESCRIPTION
This PR improves to the blog index page in a docs site by ensuring it displays at full width without a table of contents (TOC) sidebar, and, is excluded from certain widget injections. The changes also add a unique body class to the blog index page for targeted styling and behavior.