### PR TITLE
fix: inject favicons into resources and use absolute URLs

### DIFF
--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -9627,39 +9627,65 @@ body-classes: "gd-homepage"
                 if generated.get("icon"):
                     config["website"]["favicon"] = generated["icon"]
 
-            # Inject <link> tags for extra favicon assets
+            # Add generated favicon files to project.resources so Quarto copies
+            # them into _site/ (without this they may be missing from the deployed site)
             if generated:
-                favicon_links: list[str] = []
-                if generated.get("icon") and generated["icon"].endswith(".ico"):
-                    favicon_links.append(
-                        '<link rel="icon" type="image/x-icon" href="favicon.ico" sizes="48x48">'
-                    )
-                if generated.get("icon-svg"):
-                    favicon_links.append(
-                        '<link rel="icon" type="image/svg+xml" href="favicon.svg">'
-                    )
-                if generated.get("icon-32"):
-                    favicon_links.append(
-                        '<link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">'
-                    )
-                if generated.get("icon-16"):
-                    favicon_links.append(
-                        '<link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">'
-                    )
-                if generated.get("apple-touch-icon"):
-                    favicon_links.append(
-                        '<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">'
-                    )
+                favicon_files = list(dict.fromkeys(generated.values()))
+                resources_list = config["project"].setdefault("resources", [])
+                if isinstance(resources_list, str):
+                    resources_list = [resources_list]  # pragma: no cover
+                    config["project"]["resources"] = resources_list  # pragma: no cover
+                for fname in favicon_files:
+                    if fname not in resources_list:
+                        resources_list.append(fname)
 
-                if favicon_links:
-                    header_items = config["format"]["html"].get("include-in-header", [])
-                    if isinstance(header_items, str):
-                        header_items = [header_items]  # pragma: no cover
-                    for link_tag in favicon_links:
-                        entry = {"text": link_tag}
-                        if not any(link_tag in str(item) for item in header_items):
-                            header_items.append(entry)
-                    config["format"]["html"]["include-in-header"] = header_items
+            # Inject <link> tags for extra favicon assets using absolute URLs.
+            # Bare relative paths (e.g., href="favicon.ico") break on subpages because
+            # Quarto does not rewrite paths inside raw HTML injected via include-in-header.
+            # We derive the base URL from site-url or the Documentation URL in pyproject.toml.
+            if generated:
+                site_url = config.get("website", {}).get("site-url", "")
+                if not site_url:
+                    urls = metadata.get("urls", {})
+                    site_url = urls.get("Documentation", "")
+                if site_url:
+                    # Clean up: strip fragment, ensure trailing slash
+                    if "#" in site_url:
+                        site_url = site_url.split("#")[0]
+                    if not site_url.endswith("/"):
+                        site_url += "/"
+
+                    favicon_links: list[str] = []
+                    if generated.get("icon") and generated["icon"].endswith(".ico"):
+                        favicon_links.append(
+                            f'<link rel="icon" type="image/x-icon" href="{site_url}favicon.ico" sizes="48x48">'
+                        )
+                    if generated.get("icon-svg"):
+                        favicon_links.append(
+                            f'<link rel="icon" type="image/svg+xml" href="{site_url}favicon.svg">'
+                        )
+                    if generated.get("icon-32"):
+                        favicon_links.append(
+                            f'<link rel="icon" type="image/png" sizes="32x32" href="{site_url}favicon-32x32.png">'
+                        )
+                    if generated.get("icon-16"):
+                        favicon_links.append(
+                            f'<link rel="icon" type="image/png" sizes="16x16" href="{site_url}favicon-16x16.png">'
+                        )
+                    if generated.get("apple-touch-icon"):
+                        favicon_links.append(
+                            f'<link rel="apple-touch-icon" sizes="180x180" href="{site_url}apple-touch-icon.png">'
+                        )
+
+                    if favicon_links:
+                        header_items = config["format"]["html"].get("include-in-header", [])
+                        if isinstance(header_items, str):
+                            header_items = [header_items]  # pragma: no cover
+                        for link_tag in favicon_links:
+                            entry = {"text": link_tag}
+                            if not any(link_tag in str(item) for item in header_items):
+                                header_items.append(entry)
+                        config["format"]["html"]["include-in-header"] = header_items
 
         # Add GitHub widget script to page if using widget style
         if owner and repo and github_style == "widget":

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -10049,6 +10049,7 @@ class TestFaviconLinkInjection:
         (tmp / "pyproject.toml").write_text(
             '[project]\nname = "test-pkg"\nversion = "0.1.0"\n'
             '[project.urls]\nRepository = "https://github.com/test/test-pkg"\n'
+            'Documentation = "https://test.github.io/test-pkg"\n'
         )
 
         # great-docs.yml
@@ -10073,21 +10074,22 @@ class TestFaviconLinkInjection:
             return read_yaml(f)
 
     def test_auto_detect_injects_link_tags(self):
-        """Auto-detected logo should inject favicon <link> tags."""
+        """Auto-detected logo should inject favicon <link> tags with absolute URLs."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = self._build_with_favicon(tmp_dir, create_logo=True)
 
             header = config.get("format", {}).get("html", {}).get("include-in-header", [])
             header_text = " ".join(str(item) for item in header)
 
-            assert "favicon.ico" in header_text
-            assert "favicon.svg" in header_text
-            assert "favicon-32x32.png" in header_text
-            assert "favicon-16x16.png" in header_text
-            assert "apple-touch-icon.png" in header_text
+            base = "https://test.github.io/test-pkg/"
+            assert f'href="{base}favicon.ico"' in header_text
+            assert f'href="{base}favicon.svg"' in header_text
+            assert f'href="{base}favicon-32x32.png"' in header_text
+            assert f'href="{base}favicon-16x16.png"' in header_text
+            assert f'href="{base}apple-touch-icon.png"' in header_text
 
     def test_explicit_favicon_injects_link_tags(self):
-        """Explicit favicon config should also inject <link> tags."""
+        """Explicit favicon config should also inject <link> tags with absolute URLs."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             # Create the favicon source file and a logo (favicon block requires logo)
             tmp = Path(tmp_dir)
@@ -10103,11 +10105,12 @@ class TestFaviconLinkInjection:
             header = config.get("format", {}).get("html", {}).get("include-in-header", [])
             header_text = " ".join(str(item) for item in header)
 
-            assert "favicon.ico" in header_text
-            assert "favicon.svg" in header_text
-            assert "favicon-32x32.png" in header_text
-            assert "favicon-16x16.png" in header_text
-            assert "apple-touch-icon.png" in header_text
+            base = "https://test.github.io/test-pkg/"
+            assert f'href="{base}favicon.ico"' in header_text
+            assert f'href="{base}favicon.svg"' in header_text
+            assert f'href="{base}favicon-32x32.png"' in header_text
+            assert f'href="{base}favicon-16x16.png"' in header_text
+            assert f'href="{base}apple-touch-icon.png"' in header_text
 
     def test_no_favicon_no_link_tags(self):
         """Without logo or favicon config, no <link> tags should be injected."""
@@ -28920,7 +28923,186 @@ def test_update_quarto_config_favicon_not_found():
             docs._update_quarto_config()
 
 
-def test_update_quarto_config_include_after_body_string():
+def test_update_quarto_config_favicon_resources_added():
+    """Test _update_quarto_config adds generated favicon files to project.resources."""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        (Path(tmp_dir) / "logo.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+
+        docs, quarto_yml = _make_uqc_docs(
+            tmp_dir,
+            gd_yml_content="logo:\n  light: logo.png\n",
+        )
+
+        generated = {
+            "icon": "favicon.ico",
+            "icon-svg": "favicon.svg",
+            "icon-32": "favicon-32x32.png",
+            "icon-16": "favicon-16x16.png",
+            "apple-touch-icon": "apple-touch-icon.png",
+        }
+
+        with (
+            patch.object(docs, "_find_package_root", return_value=Path(tmp_dir)),
+            patch.object(docs, "_generate_favicons", return_value=generated),
+        ):
+            docs._update_quarto_config()
+
+        with open(quarto_yml) as f:
+            result = read_yaml(f)
+
+        resources = result["project"]["resources"]
+        assert "favicon.ico" in resources
+        assert "favicon.svg" in resources
+        assert "favicon-32x32.png" in resources
+        assert "favicon-16x16.png" in resources
+        assert "apple-touch-icon.png" in resources
+
+
+def test_update_quarto_config_favicon_absolute_urls_with_site_url():
+    """Test favicon <link> tags use absolute URLs when site-url is available."""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        (Path(tmp_dir) / "logo.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+
+        docs, quarto_yml = _make_uqc_docs(
+            tmp_dir,
+            gd_yml_content="logo:\n  light: logo.png\n",
+            quarto_content={
+                "project": {"type": "website"},
+                "website": {
+                    "navbar": {"left": []},
+                    "sidebar": [],
+                    "site-url": "https://posit-dev.github.io/pointblank",
+                },
+                "format": {"html": {}},
+            },
+        )
+
+        generated = {
+            "icon": "favicon.ico",
+            "icon-svg": "favicon.svg",
+            "icon-32": "favicon-32x32.png",
+            "icon-16": "favicon-16x16.png",
+            "apple-touch-icon": "apple-touch-icon.png",
+        }
+
+        with (
+            patch.object(docs, "_find_package_root", return_value=Path(tmp_dir)),
+            patch.object(docs, "_generate_favicons", return_value=generated),
+        ):
+            docs._update_quarto_config()
+
+        with open(quarto_yml) as f:
+            result = read_yaml(f)
+
+        header_items = result["format"]["html"]["include-in-header"]
+        header_texts = [
+            item["text"] if isinstance(item, dict) else str(item) for item in header_items
+        ]
+        header_joined = " ".join(header_texts)
+
+        # All favicon hrefs should use absolute URLs
+        assert 'href="https://posit-dev.github.io/pointblank/favicon.ico"' in header_joined
+        assert 'href="https://posit-dev.github.io/pointblank/favicon.svg"' in header_joined
+        assert 'href="https://posit-dev.github.io/pointblank/favicon-32x32.png"' in header_joined
+        assert 'href="https://posit-dev.github.io/pointblank/favicon-16x16.png"' in header_joined
+        assert 'href="https://posit-dev.github.io/pointblank/apple-touch-icon.png"' in header_joined
+
+        # Must NOT contain bare relative paths
+        assert 'href="favicon.ico"' not in header_joined
+        assert 'href="favicon.svg"' not in header_joined
+
+
+def test_update_quarto_config_favicon_no_links_without_site_url():
+    """Test favicon <link> tags are NOT injected when no site-url is available."""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        (Path(tmp_dir) / "logo.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+
+        docs, quarto_yml = _make_uqc_docs(
+            tmp_dir,
+            gd_yml_content="logo:\n  light: logo.png\n",
+            quarto_content={
+                "project": {"type": "website"},
+                "website": {"navbar": {"left": []}, "sidebar": []},
+                "format": {"html": {}},
+            },
+        )
+
+        generated = {
+            "icon": "favicon.ico",
+            "icon-svg": "favicon.svg",
+            "icon-32": "favicon-32x32.png",
+            "icon-16": "favicon-16x16.png",
+            "apple-touch-icon": "apple-touch-icon.png",
+        }
+
+        with (
+            patch.object(docs, "_find_package_root", return_value=Path(tmp_dir)),
+            patch.object(docs, "_generate_favicons", return_value=generated),
+        ):
+            docs._update_quarto_config()
+
+        with open(quarto_yml) as f:
+            result = read_yaml(f)
+
+        # Quarto's native website.favicon should still be set (Quarto handles path adjustment)
+        assert result["website"].get("favicon") is not None
+
+        # But no manual <link> tags for favicons should be injected
+        header_items = result["format"]["html"].get("include-in-header", [])
+        header_texts = [
+            item["text"] if isinstance(item, dict) else str(item) for item in header_items
+        ]
+        header_joined = " ".join(header_texts)
+        assert 'href="favicon.ico"' not in header_joined
+        assert 'href="favicon.svg"' not in header_joined
+
+
+def test_update_quarto_config_favicon_absolute_urls_from_pyproject():
+    """Test favicon <link> tags use Documentation URL from pyproject.toml as fallback."""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        (Path(tmp_dir) / "logo.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+
+        docs, quarto_yml = _make_uqc_docs(
+            tmp_dir,
+            gd_yml_content="logo:\n  light: logo.png\n",
+            pyproject_content=(
+                '[project]\nname = "testpkg"\n'
+                "[project.urls]\n"
+                'Documentation = "https://example.com/docs"\n'
+            ),
+            quarto_content={
+                "project": {"type": "website"},
+                "website": {"navbar": {"left": []}, "sidebar": []},
+                "format": {"html": {}},
+            },
+        )
+
+        generated = {
+            "icon": "favicon.ico",
+            "icon-svg": "favicon.svg",
+        }
+
+        with (
+            patch.object(docs, "_find_package_root", return_value=Path(tmp_dir)),
+            patch.object(docs, "_generate_favicons", return_value=generated),
+        ):
+            docs._update_quarto_config()
+
+        with open(quarto_yml) as f:
+            result = read_yaml(f)
+
+        header_items = result["format"]["html"]["include-in-header"]
+        header_texts = [
+            item["text"] if isinstance(item, dict) else str(item) for item in header_items
+        ]
+        header_joined = " ".join(header_texts)
+
+        assert 'href="https://example.com/docs/favicon.ico"' in header_joined
+        assert 'href="https://example.com/docs/favicon.svg"' in header_joined
     """Test _update_quarto_config converts string include-after-body to list."""
 
     with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
This pull request improves how favicon assets are handled in Quarto documentation sites, ensuring that favicon files are correctly included in the site build and that favicon `<link>` tags use absolute URLs for better compatibility. It also adds comprehensive tests for these behaviors.
