### PR TITLE
fix: improve layout of blog with a user-provided index page

### DIFF
--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -2443,6 +2443,14 @@ class GreatDocs:
                 # (subdirectory index.qmd files are individual blog posts)
                 has_user_index = (source_path / "index.qmd").exists()
                 if has_user_index:
+                    # Inject blog-index layout options into the user's index
+                    blog_index = dest_dir / "index.qmd"
+                    idx_content = blog_index.read_text(encoding="utf-8")
+                    idx_content = self._add_frontmatter_option(idx_content, "toc", False)
+                    idx_content = self._add_frontmatter_option(
+                        idx_content, "body-classes", "gd-blog-index"
+                    )
+                    blog_index.write_text(idx_content, encoding="utf-8")
                     index_href = f"{slug}/index.qmd"
                 else:
                     self._generate_blog_index(title, slug, dest_dir)

--- a/test-packages/synthetic/catalog.py
+++ b/test-packages/synthetic/catalog.py
@@ -347,6 +347,8 @@ ALL_PACKAGES: list[str] = [
     "gdtest_interlinks_userguide",  # 171
     # 172: Custom docstring headings with backtick code spans
     "gdtest_code_span_headings",  # 172
+    # 173: Blog section with user-provided index.qmd
+    "gdtest_sec_blog_user_index",  # 173
 ]
 
 
@@ -1954,6 +1956,12 @@ PACKAGE_DESCRIPTIONS: dict[str, str] = {
         "backtick code spans (e.g. 'What Can Be Used in `value=`?'). "
         "Tests that title-casing preserves code verbatim and that slug "
         "generation strips backticks and special characters."
+    ),
+    "gdtest_sec_blog_user_index": (
+        "Blog section with a user-provided blog/index.qmd (table listing). "
+        "Tests that Great Docs injects toc: false and body-classes: "
+        "gd-blog-index into the user's index, hiding the TOC sidebar "
+        "and copy-page widget."
     ),
 }
 

--- a/test-packages/synthetic/specs/gdtest_sec_blog_user_index.py
+++ b/test-packages/synthetic/specs/gdtest_sec_blog_user_index.py
@@ -1,0 +1,140 @@
+"""
+gdtest_sec_blog_user_index — Blog section with a user-provided index.qmd.
+
+Dimensions: N4
+Focus: Blog section where the user provides their own blog/index.qmd
+(e.g., with a custom listing type) instead of relying on auto-generation.
+The blog index should still get toc: false and body-classes: gd-blog-index
+injected by Great Docs.
+"""
+
+SPEC = {
+    "name": "gdtest_sec_blog_user_index",
+    "description": "Blog section with user-provided index.qmd.",
+    "dimensions": ["N4"],
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-sec-blog-user-index",
+            "version": "0.1.0",
+            "description": "Test blog section with user-provided listing index.",
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    },
+    "config": {
+        "sections": [
+            {"title": "Blog", "dir": "blog", "type": "blog"},
+        ],
+    },
+    "files": {
+        "gdtest_sec_blog_user_index/__init__.py": (
+            '"""Test package for blog section with user index."""\n'
+            "\n"
+            "from .core import publish, draft\n"
+            "\n"
+            '__all__ = ["publish", "draft"]\n'
+        ),
+        "gdtest_sec_blog_user_index/core.py": '''
+            """Core blog helpers."""
+
+
+            def publish(title: str, body: str) -> dict:
+                """Publish a blog post.
+
+                Parameters
+                ----------
+                title : str
+                    The post title.
+                body : str
+                    The post body.
+
+                Returns
+                -------
+                dict
+                    The published post record.
+
+                Examples
+                --------
+                >>> publish("Hello", "World")
+                {'title': 'Hello', 'body': 'World', 'status': 'published'}
+                """
+                return {"title": title, "body": body, "status": "published"}
+
+
+            def draft(title: str) -> dict:
+                """Create a draft post.
+
+                Parameters
+                ----------
+                title : str
+                    The draft title.
+
+                Returns
+                -------
+                dict
+                    The draft post record.
+
+                Examples
+                --------
+                >>> draft("WIP")
+                {'title': 'WIP', 'status': 'draft'}
+                """
+                return {"title": title, "status": "draft"}
+        ''',
+        # User-provided blog index with a custom listing type (table)
+        "blog/index.qmd": (
+            "---\n"
+            "title: Blog\n"
+            "listing:\n"
+            "  type: table\n"
+            '  sort: "date desc"\n'
+            "  feed: true\n"
+            "  contents:\n"
+            '    - "**.qmd"\n'
+            "---\n"
+            "\n"
+            "Welcome to our blog.\n"
+        ),
+        "blog/first-post/index.qmd": (
+            "---\n"
+            "title: First Post\n"
+            "author: Alice\n"
+            "date: 2024-03-01\n"
+            "categories: [announcements]\n"
+            "description: Our very first blog post.\n"
+            "---\n"
+            "\n"
+            "This is the first post on our blog.\n"
+            "\n"
+            "## Getting Started\n"
+            "\n"
+            "We're excited to share our work with you.\n"
+        ),
+        "blog/second-post/index.qmd": (
+            "---\n"
+            "title: Second Post\n"
+            "author: Bob\n"
+            "date: 2024-04-15\n"
+            "categories: [updates]\n"
+            "description: A follow-up with new features.\n"
+            "---\n"
+            "\n"
+            "Here's what we've been working on.\n"
+            "\n"
+            "## New Features\n"
+            "\n"
+            "- Improved performance\n"
+            "- Better error messages\n"
+        ),
+    },
+    "expected": {
+        "detected_name": "gdtest_sec_blog_user_index",
+        "has_reference": True,
+        "all_names": ["publish", "draft"],
+        "ref_pages": ["publish.html", "draft.html"],
+        "has_user_guide": False,
+        "user_guide_pages": [],
+    },
+}

--- a/tests/test_gdg_rendered.py
+++ b/tests/test_gdg_rendered.py
@@ -8409,3 +8409,58 @@ def test_DED_code_span_headings_title_case_outside_code():
     assert full_text.startswith("What Can Be Used In"), (
         f"Heading text not title-cased: {full_text!r}"
     )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# DED: Blog section with user-provided index
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@requires_bs4
+def test_DED_sec_blog_user_index_has_body_class():
+    """gdtest_sec_blog_user_index: blog index has gd-blog-index body class."""
+    pkg = "gdtest_sec_blog_user_index"
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+
+    blog_index = _site_dir(pkg) / "blog" / "index.html"
+    assert blog_index.exists(), "Blog index.html missing"
+
+    soup = _load_html(blog_index)
+    body = soup.find("body")
+    assert body is not None
+    classes = body.get("class", [])
+    assert "gd-blog-index" in classes, f"Expected gd-blog-index in body classes, got {classes}"
+
+
+@requires_bs4
+def test_DED_sec_blog_user_index_no_toc():
+    """gdtest_sec_blog_user_index: blog index has fullcontent (no TOC sidebar)."""
+    pkg = "gdtest_sec_blog_user_index"
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+
+    blog_index = _site_dir(pkg) / "blog" / "index.html"
+    assert blog_index.exists(), "Blog index.html missing"
+
+    soup = _load_html(blog_index)
+    body = soup.find("body")
+    assert body is not None
+    classes = body.get("class", [])
+    assert "fullcontent" in classes, f"Expected fullcontent in body classes, got {classes}"
+
+
+@requires_bs4
+def test_DED_sec_blog_user_index_preserves_user_listing():
+    """gdtest_sec_blog_user_index: user-provided listing type is preserved."""
+    pkg = "gdtest_sec_blog_user_index"
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+
+    blog_index = _site_dir(pkg) / "blog" / "index.html"
+    assert blog_index.exists(), "Blog index.html missing"
+
+    soup = _load_html(blog_index)
+    # Table listing uses quarto-listing-container-table
+    listing = soup.find("div", class_="quarto-listing-container-table")
+    assert listing is not None, "Expected table-type listing container"


### PR DESCRIPTION
This PR adds support for blog sections with user-provided `index.qmd` files, ensuring that necessary layout options are injected to maintain a consistent look and feel. It also introduces synthetic test data (a GDG site) to verify this behavior.