### PR TITLE
fix: ensure assets in blog dir copied to finalized site

### DIFF
--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -2595,6 +2595,10 @@ class GreatDocs:
         and leaves blog frontmatter intact so Quarto's `listing:` directive
         can read `title`, `author`, `date`, `categories`, etc.
 
+        Also copies co-located asset files (images, data files, etc.)
+        from any directory that contains a .qmd/.md file, so that
+        relative references like ``![](./image.png)`` resolve correctly.
+
         Parameters
         ----------
         files
@@ -2611,12 +2615,18 @@ class GreatDocs:
         """
         copied: list[dict] = []
 
+        # Track directories that contain content files so we can copy
+        # their co-located assets afterward
+        content_dirs: set[Path] = set()
+
         for src_file in files:
             rel = src_file.relative_to(source_dir)
             dest_file = dest_dir / rel
 
             # Ensure subdirectories exist
             dest_file.parent.mkdir(parents=True, exist_ok=True)
+
+            content_dirs.add(src_file.parent)
 
             content = src_file.read_text(encoding="utf-8")
 
@@ -2645,6 +2655,30 @@ class GreatDocs:
                     "description": description,
                 }
             )
+
+        # Copy co-located non-content files (images, data, etc.) from
+        # every directory that contained a .qmd/.md file
+        content_suffixes = {".qmd", ".md"}
+        for src_dir_path in content_dirs:
+            for item in src_dir_path.iterdir():
+                if item.is_file() and item.suffix.lower() not in content_suffixes:
+                    rel = item.relative_to(source_dir)
+                    dest_file = dest_dir / rel
+                    dest_file.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(item, dest_file)
+            # Also copy subdirectories that don't contain .qmd files
+            # (e.g., blog/my-post/datasets/)
+            for item in src_dir_path.iterdir():
+                if item.is_dir():
+                    has_content = any(
+                        f.suffix in content_suffixes for f in item.rglob("*")
+                    )
+                    if not has_content:
+                        rel = item.relative_to(source_dir)
+                        dest_sub = dest_dir / rel
+                        if dest_sub.exists():
+                            shutil.rmtree(dest_sub)
+                        shutil.copytree(item, dest_sub)
 
         return copied
 

--- a/test-packages/synthetic/specs/gdtest_sec_blog_user_index.py
+++ b/test-packages/synthetic/specs/gdtest_sec_blog_user_index.py
@@ -84,6 +84,7 @@ SPEC = {
                 return {"title": title, "status": "draft"}
         ''',
         # User-provided blog index with a custom listing type (table)
+        # and a co-located header image referenced via relative path
         "blog/index.qmd": (
             "---\n"
             "title: Blog\n"
@@ -95,7 +96,16 @@ SPEC = {
             '    - "**.qmd"\n'
             "---\n"
             "\n"
+            "![](./blog-header.svg)\n"
+            "\n"
             "Welcome to our blog.\n"
+        ),
+        # Co-located SVG image referenced by the blog index
+        "blog/blog-header.svg": (
+            '<svg xmlns="http://www.w3.org/2000/svg" width="400" height="80">'
+            '<rect width="400" height="80" fill="#4a90d9" rx="8"/>'
+            '<text x="200" y="48" text-anchor="middle" fill="white" '
+            'font-size="24" font-family="sans-serif">Blog</text></svg>\n'
         ),
         "blog/first-post/index.qmd": (
             "---\n"
@@ -104,13 +114,23 @@ SPEC = {
             "date: 2024-03-01\n"
             "categories: [announcements]\n"
             "description: Our very first blog post.\n"
+            "image: post-banner.svg\n"
             "---\n"
             "\n"
             "This is the first post on our blog.\n"
             "\n"
+            "![](post-banner.svg)\n"
+            "\n"
             "## Getting Started\n"
             "\n"
             "We're excited to share our work with you.\n"
+        ),
+        # Co-located image inside a blog post subdirectory
+        "blog/first-post/post-banner.svg": (
+            '<svg xmlns="http://www.w3.org/2000/svg" width="300" height="60">'
+            '<rect width="300" height="60" fill="#5cb85c" rx="6"/>'
+            '<text x="150" y="38" text-anchor="middle" fill="white" '
+            'font-size="18" font-family="sans-serif">First Post</text></svg>\n'
         ),
         "blog/second-post/index.qmd": (
             "---\n"

--- a/tests/test_gdg_rendered.py
+++ b/tests/test_gdg_rendered.py
@@ -8464,3 +8464,23 @@ def test_DED_sec_blog_user_index_preserves_user_listing():
     # Table listing uses quarto-listing-container-table
     listing = soup.find("div", class_="quarto-listing-container-table")
     assert listing is not None, "Expected table-type listing container"
+
+
+def test_DED_sec_blog_user_index_copies_root_image():
+    """gdtest_sec_blog_user_index: co-located root image is copied to site."""
+    pkg = "gdtest_sec_blog_user_index"
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+
+    img = _site_dir(pkg) / "blog" / "blog-header.svg"
+    assert img.exists(), "Root-level blog image blog-header.svg not copied"
+
+
+def test_DED_sec_blog_user_index_copies_post_image():
+    """gdtest_sec_blog_user_index: co-located post image is copied to site."""
+    pkg = "gdtest_sec_blog_user_index"
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+
+    img = _site_dir(pkg) / "blog" / "first-post" / "post-banner.svg"
+    assert img.exists(), "Post-level image first-post/post-banner.svg not copied"


### PR DESCRIPTION
This PR enhances the blog file copying logic to ensure that co-located asset files (such as images and data files) are copied alongside their associated content files. This allows relative references to assets within blog posts and indexes to resolve correctly after site generation.