### PR TITLE
enh: improve layout of section index page

### DIFF
--- a/great_docs/assets/great-docs.scss
+++ b/great_docs/assets/great-docs.scss
@@ -3396,9 +3396,23 @@ textarea,
 
 .section-cards {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     gap: 1rem;
     margin-top: 0.5rem;
+}
+
+/* 2-column image card grid (default) */
+.section-cards-2col {
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+}
+
+/* 1-column image card grid */
+.section-cards-1col {
+    grid-template-columns: 1fr;
+}
+
+/* Single-column plain link list */
+.section-cards-list {
+    grid-template-columns: 1fr;
 }
 
 .section-card {

--- a/great_docs/config.py
+++ b/great_docs/config.py
@@ -70,7 +70,8 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "max_releases": 50,
     },
     # Custom sections (generic page groups: examples, tutorials, blog, etc.)
-    # Each entry: {"title": str, "dir": str, "index": bool, "navbar_after": str | None}
+    # Each entry: {"title": str, "dir": str, "index": bool, "index_columns": int,
+    #              "navbar_after": str | None}
     "sections": [],
     # Custom static HTML pages.
     # None: auto-discover from project_root/custom/
@@ -1497,6 +1498,7 @@ def create_default_config() -> str:
 #   - title: Examples            # Navbar link text
 #     dir: examples              # Source directory (relative to project root)
 #     index: true                # Generate card-based index page (default: false)
+#     index_columns: 2           # Columns for image cards: 1 or 2 (default: 2)
 #     navbar_after: User Guide   # Place after this navbar item (optional)
 #   - title: Tutorials
 #     dir: tutorials             # No index — navbar links to first page

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -2470,7 +2470,10 @@ class GreatDocs:
                     index_href = f"{slug}/index.qmd"
                 elif generate_index:
                     # Auto-generate a card-based index page (opt-in)
-                    self._generate_section_index(title, copied, slug, dest_dir)
+                    index_columns = section_cfg.get("index_columns", 2)
+                    self._generate_section_index(
+                        title, copied, slug, dest_dir, columns=index_columns
+                    )
                     index_href = f"{slug}/index.qmd"
                 else:
                     # No index page — navbar links to the first content page
@@ -2727,12 +2730,15 @@ class GreatDocs:
         pages: list[dict],
         slug: str,
         dest_dir: Path,
+        columns: int = 2,
     ) -> None:
         """
         Auto-generate an index page for a custom section.
 
         Creates a gallery-style listing from each page's frontmatter title
-        and description.
+        and description.  Entries that have an ``image`` field are rendered
+        as image cards in a grid (1- or 2-column); entries without images
+        are rendered as a simple single-column link list below the cards.
 
         Parameters
         ----------
@@ -2744,6 +2750,8 @@ class GreatDocs:
             URL slug for the section.
         dest_dir
             Build directory for the section.
+        columns
+            Number of columns for image-card grid (1 or 2, default 2).
         """
         lines = [
             "---",
@@ -2759,60 +2767,125 @@ class GreatDocs:
         if not entries:
             lines.append("*No pages found.*")
         else:
+            # Split entries into image cards and plain links
+            image_entries = [e for e in entries if e.get("image")]
+            plain_entries = [e for e in entries if not e.get("image")]
+
             # Use inline styles to ensure card layout renders correctly
             # regardless of Quarto's page-columns grid system.
             # Build as a single contiguous HTML block so Quarto's Markdown
             # parser does not inject extra <p> or duplicate <a> elements.
-            grid_style = (
-                "display: grid; "
-                "grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); "
-                "gap: 1rem; "
-                "margin-top: 0.5rem;"
-            )
-            card_style = (
-                "display: block; "
-                "padding: 1.25rem 1.5rem; "
-                "border: 1px solid #dee2e6; "
-                "border-radius: 0.5rem; "
-                "color: inherit; "
-                "text-decoration: none;"
-            )
-            title_style = (
-                "font-size: 1.1rem; font-weight: 600; margin-bottom: 0.35rem; color: #0d6efd;"
-            )
-            desc_style = "font-size: 0.9rem; color: #6c757d; line-height: 1.45;"
-
             parts: list[str] = []
-            parts.append(f'<div class="section-cards" style="{grid_style}">')
 
-            for entry in entries:
-                href = entry["filename"]
-                entry_title = entry["title"]
-                desc = entry.get("description", "")
-                image = entry.get("image", "")
+            # --- Image card grid ---
+            if image_entries:
+                columns = max(1, min(columns, 2))
+                col_cls = "section-cards-1col" if columns == 1 else "section-cards-2col"
+                if columns == 1:
+                    grid_style = (
+                        "display: grid; "
+                        "grid-template-columns: 1fr; "
+                        "gap: 1rem; "
+                        "margin-top: 0.5rem;"
+                    )
+                else:
+                    grid_style = (
+                        "display: grid; "
+                        "grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); "
+                        "gap: 1rem; "
+                        "margin-top: 0.5rem;"
+                    )
+                card_style = (
+                    "display: block; "
+                    "padding: 1.25rem 1.5rem; "
+                    "border: 1px solid #dee2e6; "
+                    "border-radius: 0.5rem; "
+                    "color: inherit; "
+                    "text-decoration: none;"
+                )
+                title_style = (
+                    "font-size: 1.1rem; font-weight: 600; "
+                    "margin-bottom: 0.35rem; color: #0d6efd;"
+                )
+                desc_style = "font-size: 0.9rem; color: #6c757d; line-height: 1.45;"
 
-                parts.append(f'<a href="{href}" class="section-card" style="{card_style}">')
+                parts.append(
+                    f'<div class="section-cards {col_cls}" style="{grid_style}">'
+                )
+                for entry in image_entries:
+                    href = entry["filename"]
+                    entry_title = entry["title"]
+                    desc = entry.get("description", "")
+                    image = entry["image"]
 
-                if image:
+                    parts.append(
+                        f'<a href="{href}" class="section-card" style="{card_style}">'
+                    )
                     parts.append(
                         f'<img src="{image}" class="section-card-img" '
                         'style="width: 100%; border-radius: 0.375rem; '
                         'margin-bottom: 0.75rem;" />'
                     )
+                    parts.append(
+                        f'<div class="section-card-title" style="{title_style}">'
+                        f"{entry_title}</div>"
+                    )
+                    if desc:
+                        parts.append(
+                            f'<div class="section-card-desc" style="{desc_style}">'
+                            f"{desc}</div>"
+                        )
+                    parts.append("</a>")
+
+                # Close grid container on the same line as the last </a>
+                parts[-1] = parts[-1] + "</div>"
+
+            # --- Separator ---
+            if image_entries and plain_entries:
+                parts.append("<hr>")
+
+            # --- Plain link list ---
+            if plain_entries:
+                card_style = (
+                    "display: block; "
+                    "padding: 1.25rem 1.5rem; "
+                    "border: 1px solid #dee2e6; "
+                    "border-radius: 0.5rem; "
+                    "color: inherit; "
+                    "text-decoration: none;"
+                )
+                title_style = (
+                    "font-size: 1.1rem; font-weight: 600; "
+                    "margin-bottom: 0.35rem; color: #0d6efd;"
+                )
+                desc_style = "font-size: 0.9rem; color: #6c757d; line-height: 1.45;"
 
                 parts.append(
-                    f'<div class="section-card-title" style="{title_style}">{entry_title}</div>'
+                    '<div class="section-cards section-cards-list" '
+                    'style="display: grid; grid-template-columns: 1fr; '
+                    'gap: 1rem; margin-top: 0.5rem;">'
                 )
-                if desc:
+                for entry in plain_entries:
+                    href = entry["filename"]
+                    entry_title = entry["title"]
+                    desc = entry.get("description", "")
+
                     parts.append(
-                        f'<div class="section-card-desc" style="{desc_style}">{desc}</div>'
+                        f'<a href="{href}" class="section-card" style="{card_style}">'
                     )
+                    parts.append(
+                        f'<div class="section-card-title" style="{title_style}">'
+                        f"{entry_title}</div>"
+                    )
+                    if desc:
+                        parts.append(
+                            f'<div class="section-card-desc" style="{desc_style}">'
+                            f"{desc}</div>"
+                        )
+                    parts.append("</a>")
 
-                parts.append("</a>")
-
-            # Close container on the same line as the last </a> to prevent
-            # Quarto's Markdown parser from injecting a phantom <p><a></a></p>.
-            parts[-1] = parts[-1] + "</div>"
+                # Close list container
+                parts[-1] = parts[-1] + "</div>"
 
             # Join without blank lines to keep it as one HTML block
             lines.append("\n".join(parts))

--- a/test-packages/synthetic/catalog.py
+++ b/test-packages/synthetic/catalog.py
@@ -209,6 +209,7 @@ ALL_PACKAGES: list[str] = [
     "gdtest_sec_with_ref",  # 74
     "gdtest_sec_deep",  # 75
     "gdtest_sec_index_opt",  # 75b
+    "gdtest_sec_index_hero",  # 75b2
     "gdtest_sec_sidebar_single",  # 75c
     "gdtest_custom_passthrough_navbar",  # 75d
     "gdtest_custom_raw_navbar_after",  # 75e
@@ -533,6 +534,7 @@ DIMENSIONS: dict[str, dict[str, str]] = {
     "N7": {"axis": "sections", "label": "navbar_after"},
     "N8": {"axis": "sections", "label": "Section index opt-in"},
     "N9": {"axis": "sections", "label": "Single-page sidebar hide"},
+    "N10": {"axis": "sections", "label": "Section index hero cards"},
     # Reference axes
     "P1": {"axis": "reference", "label": "Explicit reference"},
     "P2": {"axis": "reference", "label": "members: false"},
@@ -1523,6 +1525,11 @@ PACKAGE_DESCRIPTIONS: dict[str, str] = {
         "Section index opt-in: Examples section with index: true gets a "
         "card-based index page; Tutorials section without index (default) "
         "has navbar linking directly to the first page."
+    ),
+    "gdtest_sec_index_hero": (
+        "Section index hero cards: Demos section with 2-col image cards "
+        "(4 featured + 6 plain links), Gallery section with 1-col image "
+        "cards (index_columns: 1). Tests mixed image/plain and column options."
     ),
     "gdtest_sec_sidebar_single": (
         "Section sidebar for single-page sections. Has a 2-page Guides "

--- a/test-packages/synthetic/specs/gdtest_sec_index_hero.py
+++ b/test-packages/synthetic/specs/gdtest_sec_index_hero.py
@@ -1,0 +1,496 @@
+"""
+gdtest_sec_index_hero — Section index pages with hero images.
+
+Dimensions: N10
+Focus: Enhanced section index pages where some entries have hero images
+       (rendered as image cards in a grid) and some are plain links.
+       Tests both 2-column and 1-column image card layouts.
+"""
+
+# Inline SVG hero images (data URIs so they render without external files)
+_HERO_BLUE = (
+    "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' "
+    "width='600' height='300'%3E%3Crect fill='%234A90D9' width='600' height='300'/%3E"
+    "%3Ctext x='300' y='160' text-anchor='middle' fill='white' "
+    "font-size='28' font-family='sans-serif'%3EStarter Demo%3C/text%3E%3C/svg%3E"
+)
+_HERO_GREEN = (
+    "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' "
+    "width='600' height='300'%3E%3Crect fill='%2342B883' width='600' height='300'/%3E"
+    "%3Ctext x='300' y='160' text-anchor='middle' fill='white' "
+    "font-size='28' font-family='sans-serif'%3EAdvanced Demo%3C/text%3E%3C/svg%3E"
+)
+_HERO_ORANGE = (
+    "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' "
+    "width='600' height='300'%3E%3Crect fill='%23E8853D' width='600' height='300'/%3E"
+    "%3Ctext x='300' y='160' text-anchor='middle' fill='white' "
+    "font-size='28' font-family='sans-serif'%3EData Pipeline%3C/text%3E%3C/svg%3E"
+)
+_HERO_PURPLE = (
+    "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' "
+    "width='600' height='300'%3E%3Crect fill='%237C4DFF' width='600' height='300'/%3E"
+    "%3Ctext x='300' y='160' text-anchor='middle' fill='white' "
+    "font-size='28' font-family='sans-serif'%3EVisualization%3C/text%3E%3C/svg%3E"
+)
+_HERO_RED = (
+    "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' "
+    "width='600' height='300'%3E%3Crect fill='%23E53935' width='600' height='300'/%3E"
+    "%3Ctext x='300' y='160' text-anchor='middle' fill='white' "
+    "font-size='28' font-family='sans-serif'%3EReal-Time%3C/text%3E%3C/svg%3E"
+)
+_HERO_TEAL = (
+    "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' "
+    "width='600' height='300'%3E%3Crect fill='%23009688' width='600' height='300'/%3E"
+    "%3Ctext x='300' y='160' text-anchor='middle' fill='white' "
+    "font-size='28' font-family='sans-serif'%3EWorkflow%3C/text%3E%3C/svg%3E"
+)
+
+SPEC = {
+    "name": "gdtest_sec_index_hero",
+    "description": (
+        "Section index pages with hero images: 2-col demos (mixed image + plain) "
+        "and 1-col gallery (all images)."
+    ),
+    "dimensions": ["N10"],
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-sec-index-hero",
+            "version": "1.0.0",
+            "description": "Testing enhanced section index pages with hero images.",
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    },
+    "config": {
+        "sections": [
+            {
+                "title": "Demos",
+                "dir": "demos",
+                "index": True,
+                # default index_columns: 2 — featured items with images in 2-col grid,
+                # plain entries below as single-column list
+            },
+            {
+                "title": "Gallery",
+                "dir": "gallery",
+                "index": True,
+                "index_columns": 1,
+                "navbar_after": "Demos",
+            },
+        ],
+    },
+    "files": {
+        # ── Package source ──
+        "gdtest_sec_index_hero/__init__.py": (
+            '"""Test package for section index hero cards."""\n\n'
+            "from .core import process, summarize, validate\n\n"
+            '__all__ = ["process", "summarize", "validate"]\n'
+        ),
+        "gdtest_sec_index_hero/core.py": '''
+            """Core processing functions."""
+
+
+            def process(data: list, *, strict: bool = False) -> list:
+                """Process a list of values.
+
+                Parameters
+                ----------
+                data : list
+                    Input values to process.
+                strict : bool
+                    If True, raise on invalid values.
+
+                Returns
+                -------
+                list
+                    Processed values.
+
+                Examples
+                --------
+                >>> process([1, 2, 3])
+                [1, 2, 3]
+                """
+                return [x for x in data if x is not None] if strict else list(data)
+
+
+            def summarize(values: list) -> dict:
+                """Summarize a list of numeric values.
+
+                Parameters
+                ----------
+                values : list
+                    Numeric values to summarize.
+
+                Returns
+                -------
+                dict
+                    Summary with count, sum, and mean.
+
+                Examples
+                --------
+                >>> summarize([10, 20, 30])
+                {'count': 3, 'sum': 60, 'mean': 20.0}
+                """
+                n = len(values)
+                total = sum(values)
+                return {"count": n, "sum": total, "mean": total / n if n else 0}
+
+
+            def validate(schema: dict, record: dict) -> bool:
+                """Validate a record against a schema.
+
+                Parameters
+                ----------
+                schema : dict
+                    Expected field names mapped to types.
+                record : dict
+                    The record to validate.
+
+                Returns
+                -------
+                bool
+                    True if the record conforms to the schema.
+
+                Examples
+                --------
+                >>> validate({"name": str}, {"name": "Alice"})
+                True
+                """
+                for key, expected_type in schema.items():
+                    if key not in record or not isinstance(record[key], expected_type):
+                        return False
+                return True
+        ''',
+        # ── Demos section (2-column, mixed images + plain) ──
+        # Featured demos WITH hero images (appear as image cards)
+        "demos/01-starter-demo.qmd": (
+            "---\n"
+            "title: Starter Demo\n"
+            "description: A minimal example showing the basics of data processing.\n"
+            f'image: "{_HERO_BLUE}"\n'
+            "---\n"
+            "\n"
+            "# Starter Demo\n"
+            "\n"
+            "This demo walks through the most basic usage of the package.\n"
+            "\n"
+            "```python\n"
+            "from gdtest_sec_index_hero import process\n"
+            "\n"
+            "result = process([1, 2, None, 3], strict=True)\n"
+            "print(result)  # [1, 2, 3]\n"
+            "```\n"
+            "\n"
+            "The `strict` parameter filters out `None` values, giving you a clean list.\n"
+        ),
+        "demos/02-advanced-demo.qmd": (
+            "---\n"
+            "title: Advanced Demo\n"
+            "description: A comprehensive example with chained operations and validation.\n"
+            f'image: "{_HERO_GREEN}"\n'
+            "---\n"
+            "\n"
+            "# Advanced Demo\n"
+            "\n"
+            "This demo chains multiple operations together.\n"
+            "\n"
+            "```python\n"
+            "from gdtest_sec_index_hero import process, summarize, validate\n"
+            "\n"
+            "data = process([10, 20, None, 30, 40], strict=True)\n"
+            "stats = summarize(data)\n"
+            "print(stats)  # {'count': 4, 'sum': 100, 'mean': 25.0}\n"
+            "\n"
+            "schema = {'count': int, 'sum': int, 'mean': float}\n"
+            "assert validate(schema, stats)\n"
+            "```\n"
+        ),
+        "demos/03-data-pipeline.qmd": (
+            "---\n"
+            "title: Data Pipeline\n"
+            "description: Build a complete ETL pipeline from raw data to validated output.\n"
+            f'image: "{_HERO_ORANGE}"\n'
+            "---\n"
+            "\n"
+            "# Data Pipeline\n"
+            "\n"
+            "A step-by-step guide to building a data pipeline.\n"
+            "\n"
+            "## Step 1: Extract\n"
+            "\n"
+            "```python\n"
+            "raw = [100, None, 200, None, 300]\n"
+            "```\n"
+            "\n"
+            "## Step 2: Transform\n"
+            "\n"
+            "```python\n"
+            "from gdtest_sec_index_hero import process\n"
+            "clean = process(raw, strict=True)  # [100, 200, 300]\n"
+            "```\n"
+            "\n"
+            "## Step 3: Load\n"
+            "\n"
+            "```python\n"
+            "from gdtest_sec_index_hero import summarize\n"
+            "output = summarize(clean)\n"
+            "print(output)  # {'count': 3, 'sum': 600, 'mean': 200.0}\n"
+            "```\n"
+        ),
+        "demos/04-visualization.qmd": (
+            "---\n"
+            "title: Visualization\n"
+            "description: Create summary visualizations from processed data.\n"
+            f'image: "{_HERO_PURPLE}"\n'
+            "---\n"
+            "\n"
+            "# Visualization\n"
+            "\n"
+            "After processing and summarizing data, you can visualize the results.\n"
+            "\n"
+            "```python\n"
+            "from gdtest_sec_index_hero import process, summarize\n"
+            "\n"
+            "data = process([5, 15, 25, 35, 45])\n"
+            "stats = summarize(data)\n"
+            "print(f\"Mean: {stats['mean']}, Total: {stats['sum']}\")\n"
+            "```\n"
+            "\n"
+            "Use these summary statistics as input to your favorite plotting library.\n"
+        ),
+        # Plain demos WITHOUT images (appear as simple link list below the cards)
+        "demos/05-error-handling.qmd": (
+            "---\n"
+            "title: Error Handling\n"
+            "description: Learn how to handle edge cases and invalid inputs gracefully.\n"
+            "---\n"
+            "\n"
+            "# Error Handling\n"
+            "\n"
+            "When working with real-world data you need to handle edge cases.\n"
+            "\n"
+            "```python\n"
+            "from gdtest_sec_index_hero import process, validate\n"
+            "\n"
+            "# Empty lists are handled cleanly\n"
+            "result = process([], strict=True)\n"
+            "print(result)  # []\n"
+            "\n"
+            "# Validation catches missing fields\n"
+            "assert not validate({'name': str}, {'age': 30})\n"
+            "```\n"
+        ),
+        "demos/06-batch-processing.qmd": (
+            "---\n"
+            "title: Batch Processing\n"
+            "description: Process multiple datasets in batch mode.\n"
+            "---\n"
+            "\n"
+            "# Batch Processing\n"
+            "\n"
+            "Process several datasets at once.\n"
+            "\n"
+            "```python\n"
+            "from gdtest_sec_index_hero import process, summarize\n"
+            "\n"
+            "datasets = [\n"
+            "    [10, 20, 30],\n"
+            "    [5, None, 15],\n"
+            "    [100, 200, 300],\n"
+            "]\n"
+            "\n"
+            "for ds in datasets:\n"
+            "    clean = process(ds, strict=True)\n"
+            "    print(summarize(clean))\n"
+            "```\n"
+        ),
+        "demos/07-schema-patterns.qmd": (
+            "---\n"
+            "title: Common Schema Patterns\n"
+            "description: Reusable validation schemas for typical data structures.\n"
+            "---\n"
+            "\n"
+            "# Common Schema Patterns\n"
+            "\n"
+            "Define reusable schemas for common record types.\n"
+            "\n"
+            "```python\n"
+            "from gdtest_sec_index_hero import validate\n"
+            "\n"
+            "user_schema = {'name': str, 'age': int}\n"
+            "event_schema = {'type': str, 'timestamp': float}\n"
+            "\n"
+            "assert validate(user_schema, {'name': 'Alice', 'age': 30})\n"
+            "assert validate(event_schema, {'type': 'click', 'timestamp': 1.0})\n"
+            "```\n"
+        ),
+        "demos/08-performance-tips.qmd": (
+            "---\n"
+            "title: Performance Tips\n"
+            "description: Optimize processing speed for large datasets.\n"
+            "---\n"
+            "\n"
+            "# Performance Tips\n"
+            "\n"
+            "Tips for working efficiently with large volumes of data.\n"
+            "\n"
+            "- Use `strict=False` (the default) when you know data is clean\n"
+            "- Pre-validate schemas once, then batch-process records\n"
+            "- Use `summarize()` to get aggregate stats without storing intermediates\n"
+        ),
+        "demos/09-integration-guide.qmd": (
+            "---\n"
+            "title: Integration Guide\n"
+            "description: Integrate the package with pandas, Polars, and other frameworks.\n"
+            "---\n"
+            "\n"
+            "# Integration Guide\n"
+            "\n"
+            "How to use this package alongside popular data frameworks.\n"
+            "\n"
+            "## With plain Python\n"
+            "\n"
+            "```python\n"
+            "from gdtest_sec_index_hero import process\n"
+            "result = process([1, 2, 3])\n"
+            "```\n"
+            "\n"
+            "## Converting results\n"
+            "\n"
+            "The `summarize()` function returns a plain dict, making it easy\n"
+            "to convert to any format you need.\n"
+        ),
+        "demos/10-custom-validators.qmd": (
+            "---\n"
+            "title: Custom Validators\n"
+            "description: Build your own validation logic on top of the validate function.\n"
+            "---\n"
+            "\n"
+            "# Custom Validators\n"
+            "\n"
+            "Extend the built-in `validate()` with custom rules.\n"
+            "\n"
+            "```python\n"
+            "from gdtest_sec_index_hero import validate\n"
+            "\n"
+            "def validate_positive(record):\n"
+            "    base_ok = validate({'value': int}, record)\n"
+            "    return base_ok and record['value'] > 0\n"
+            "\n"
+            "assert validate_positive({'value': 42})\n"
+            "assert not validate_positive({'value': -1})\n"
+            "```\n"
+        ),
+        # ── Gallery section (1-column, all pages have images) ──
+        "gallery/01-real-time-dashboard.qmd": (
+            "---\n"
+            "title: Real-Time Dashboard\n"
+            "description: A live dashboard that processes streaming data and displays rolling statistics.\n"
+            f'image: "{_HERO_RED}"\n'
+            "---\n"
+            "\n"
+            "# Real-Time Dashboard\n"
+            "\n"
+            "This example shows a dashboard that consumes a data stream,\n"
+            "processes each batch, and updates summary statistics in real time.\n"
+            "\n"
+            "```python\n"
+            "from gdtest_sec_index_hero import process, summarize\n"
+            "\n"
+            "# Simulate a streaming batch\n"
+            "batch = [42, None, 87, 13, None, 65]\n"
+            "clean = process(batch, strict=True)\n"
+            "stats = summarize(clean)\n"
+            "print(stats)\n"
+            "```\n"
+        ),
+        "gallery/02-workflow-automation.qmd": (
+            "---\n"
+            "title: Workflow Automation\n"
+            "description: An automated pipeline that validates, processes, and reports on incoming records.\n"
+            f'image: "{_HERO_TEAL}"\n'
+            "---\n"
+            "\n"
+            "# Workflow Automation\n"
+            "\n"
+            "Automate your data quality workflow end to end.\n"
+            "\n"
+            "```python\n"
+            "from gdtest_sec_index_hero import validate, process, summarize\n"
+            "\n"
+            "schema = {'value': int}\n"
+            "records = [{'value': 10}, {'value': 20}, {'value': 30}]\n"
+            "\n"
+            "valid = [r for r in records if validate(schema, r)]\n"
+            "values = [r['value'] for r in valid]\n"
+            "clean = process(values, strict=True)\n"
+            "report = summarize(clean)\n"
+            "print(report)\n"
+            "```\n"
+        ),
+        "gallery/03-data-explorer.qmd": (
+            "---\n"
+            "title: Data Explorer\n"
+            "description: An interactive data exploration tool that lets you filter, summarize, and drill down.\n"
+            f'image: "{_HERO_PURPLE}"\n'
+            "---\n"
+            "\n"
+            "# Data Explorer\n"
+            "\n"
+            "Explore datasets interactively by processing subsets and reviewing statistics.\n"
+            "\n"
+            "```python\n"
+            "from gdtest_sec_index_hero import process, summarize\n"
+            "\n"
+            "dataset = [5, 10, 15, 20, 25, 30, 35, 40]\n"
+            "\n"
+            "# Filter to values above 15\n"
+            "subset = [x for x in process(dataset) if x > 15]\n"
+            "print(summarize(subset))\n"
+            "```\n"
+        ),
+        "gallery/04-quality-report.qmd": (
+            "---\n"
+            "title: Quality Report\n"
+            "description: Generate a comprehensive data quality report with validation summaries.\n"
+            f'image: "{_HERO_BLUE}"\n'
+            "---\n"
+            "\n"
+            "# Quality Report\n"
+            "\n"
+            "Produce a data quality report by validating every record.\n"
+            "\n"
+            "```python\n"
+            "from gdtest_sec_index_hero import validate\n"
+            "\n"
+            "schema = {'name': str, 'score': int}\n"
+            "records = [\n"
+            "    {'name': 'Alice', 'score': 95},\n"
+            "    {'name': 'Bob'},\n"
+            "    {'name': 'Carol', 'score': 88},\n"
+            "]\n"
+            "\n"
+            "passed = sum(1 for r in records if validate(schema, r))\n"
+            'print(f"{passed}/{len(records)} records valid")\n'
+            "```\n"
+        ),
+        # ── README ──
+        "README.md": (
+            "# gdtest-sec-index-hero\n"
+            "\n"
+            "Test package demonstrating enhanced section index pages with hero images.\n"
+            "\n"
+            "- **Demos**: 2-column layout with 4 featured image cards + 6 plain links\n"
+            "- **Gallery**: 1-column layout with 4 full-width image cards\n"
+        ),
+    },
+    "expected": {
+        "detected_name": "gdtest-sec-index-hero",
+        "detected_module": "gdtest_sec_index_hero",
+        "detected_parser": "numpy",
+        "export_names": ["process", "summarize", "validate"],
+        "num_exports": 3,
+    },
+}

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -11665,6 +11665,112 @@ def test_generate_section_index_with_image():
         assert "<img" in content
 
 
+def test_generate_section_index_mixed_image_and_plain():
+    """_generate_section_index separates image cards from plain links."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp = Path(tmp_dir)
+        dest = tmp / "sec"
+        dest.mkdir()
+
+        pages = [
+            {
+                "filename": "featured.qmd",
+                "title": "Featured",
+                "description": "Has image",
+                "image": "hero.png",
+            },
+            {"filename": "plain.qmd", "title": "Plain", "description": "No image", "image": ""},
+            {"filename": "also-plain.qmd", "title": "Also Plain", "description": "Text only"},
+        ]
+        docs = GreatDocs(project_path=tmp_dir)
+        docs._generate_section_index("Mixed", pages, "sec", dest)
+
+        content = (dest / "index.qmd").read_text()
+
+        # Image cards use 2col layout by default
+        assert "section-cards-2col" in content
+        # Plain links use list layout
+        assert "section-cards-list" in content
+        # Separator between image and plain sections
+        assert "<hr>" in content
+        # Image entries have <img> tags
+        assert "hero.png" in content
+        # Plain entries do NOT have <img> tags for their cards
+        assert content.count("<img") == 1
+        # All titles present
+        assert "Featured" in content
+        assert "Plain" in content
+        assert "Also Plain" in content
+
+
+def test_generate_section_index_single_column():
+    """_generate_section_index respects columns=1 for image cards."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp = Path(tmp_dir)
+        dest = tmp / "sec"
+        dest.mkdir()
+
+        pages = [
+            {"filename": "a.qmd", "title": "A", "description": "Desc A", "image": "a.png"},
+            {"filename": "b.qmd", "title": "B", "description": "Desc B", "image": "b.png"},
+        ]
+        docs = GreatDocs(project_path=tmp_dir)
+        docs._generate_section_index("Gallery", pages, "sec", dest, columns=1)
+
+        content = (dest / "index.qmd").read_text()
+
+        assert "section-cards-1col" in content
+        assert "section-cards-2col" not in content
+        # No plain list section (all have images)
+        assert "section-cards-list" not in content
+        assert "<hr>" not in content
+
+
+def test_generate_section_index_only_plain():
+    """_generate_section_index renders only plain links when no images."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp = Path(tmp_dir)
+        dest = tmp / "sec"
+        dest.mkdir()
+
+        pages = [
+            {"filename": "a.qmd", "title": "A", "description": "Desc A"},
+            {"filename": "b.qmd", "title": "B", "description": "Desc B"},
+        ]
+        docs = GreatDocs(project_path=tmp_dir)
+        docs._generate_section_index("Docs", pages, "sec", dest)
+
+        content = (dest / "index.qmd").read_text()
+
+        # No image grid at all
+        assert "section-cards-2col" not in content
+        assert "section-cards-1col" not in content
+        # Only plain list
+        assert "section-cards-list" in content
+        assert "<hr>" not in content
+        assert "<img" not in content
+
+
+def test_generate_section_index_only_images():
+    """_generate_section_index renders only image cards when all have images."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp = Path(tmp_dir)
+        dest = tmp / "sec"
+        dest.mkdir()
+
+        pages = [
+            {"filename": "a.qmd", "title": "A", "description": "Desc A", "image": "a.png"},
+        ]
+        docs = GreatDocs(project_path=tmp_dir)
+        docs._generate_section_index("Gallery", pages, "sec", dest)
+
+        content = (dest / "index.qmd").read_text()
+
+        assert "section-cards-2col" in content
+        assert "section-cards-list" not in content
+        assert "<hr>" not in content
+
+
 def test_copy_section_files_strips_prefix():
     """_copy_section_files strips numeric prefixes from filenames."""
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/user_guide/07-custom-sections.qmd
+++ b/user_guide/07-custom-sections.qmd
@@ -57,11 +57,12 @@ sections:
 
 ### Optional Fields
 
-| Field          | Default            | Description |
-|----------------|--------------------|-------------|
-| `index`        | `false`            | When `true`, auto-generates a card-based index page; when `false`, navbar links to the first page |
-| `navbar_after` | Before "Reference" | Name of an existing navbar item to place this section after |
-| `type`         | `default`          | `"default"` for card-grid index with sidebar; `"blog"` for Quarto listing page |
+| Field            | Default            | Description |
+|------------------|--------------------|-------------|
+| `index`          | `false`            | When `true`, auto-generates a card-based index page; when `false`, navbar links to the first page |
+| `index_columns`  | `2`                | Number of columns for image cards on the index page (1 or 2). Only applies when `index: true` |
+| `navbar_after`   | Before "Reference" | Name of an existing navbar item to place this section after |
+| `type`           | `default`          | `"default"` for card-grid index with sidebar; `"blog"` for Quarto listing page |
 
 ## Multiple Sections
 
@@ -147,6 +148,60 @@ sections:
     dir: examples
     index: true
 ```
+
+The generated index page renders entries in two zones:
+
+1. **Image cards** — pages with an `image` field in frontmatter appear first as clickable cards in a responsive grid. Each card shows the hero image, title, and description.
+2. **Plain links** — pages without an `image` field appear below as a single-column list of title + description links.
+
+When both zones are present, a horizontal rule separates them. This design mirrors the pattern used by the [pointblank demos page](https://posit-dev.github.io/pointblank/demos/), where featured items with screenshots sit above a simpler list of additional entries.
+
+#### Controlling Columns
+
+By default, image cards use a **2-column** responsive grid. Set `index_columns: 1` for a single-column layout (useful for wide screenshots or fewer items):
+
+```{.yaml filename="great-docs.yml"}
+sections:
+  - title: Gallery
+    dir: gallery
+    index: true
+    index_columns: 1
+```
+
+::: {.callout-tip}
+## Mixed layouts
+You can combine both approaches in the same site: a 2-column demos section with featured screenshots alongside a 1-column gallery with full-width images, plus plain text links for supplementary pages that don't need a visual.
+:::
+
+#### Example: Featured Demos with Plain Links
+
+Given this directory:
+
+```
+demos/
+├── 01-starter.qmd       ← Has image: "img/starter.png"
+├── 02-advanced.qmd      ← Has image: "img/advanced.png"
+├── 03-tips.qmd          ← No image
+├── 04-faq.qmd           ← No image
+└── img/
+    ├── starter.png
+    └── advanced.png
+```
+
+With this config:
+
+```{.yaml filename="great-docs.yml"}
+sections:
+  - title: Demos
+    dir: demos
+    index: true
+```
+
+The generated index page shows:
+
+- Two image cards side by side (Starter and Advanced) at the top
+- A horizontal rule
+- Two plain link entries (Tips and FAQ) in a single-column list below
 
 ### Custom Index
 


### PR DESCRIPTION
This PR enhances the section index page generation by introducing flexible layouts for image cards and plain links. Now, pages with images are displayed as a grid of hero cards (with configurable columns), while pages without images are shown as a simple link list below the cards. The configuration and documentation are also updated.