### PR TITLE
fix: update actions versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,13 +55,13 @@ jobs:
           path: great-docs/_site
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: great-docs/_site
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   preview-docs:
     name: "Preview Docs"

--- a/great_docs/assets/github-workflow-template.yml
+++ b/great_docs/assets/github-workflow-template.yml
@@ -53,13 +53,13 @@ jobs:
           path: great-docs/_site
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: great-docs/_site
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   preview-docs:
     name: "Preview Docs"

--- a/user_guide/12-deployment.qmd
+++ b/user_guide/12-deployment.qmd
@@ -129,7 +129,7 @@ jobs:
         run: great-docs build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: great-docs/_site
 
@@ -146,7 +146,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 ```
 
 ## Manual Deployment


### PR DESCRIPTION
This PR updates GitHub Actions workflow files to use the latest major versions of the `upload-pages-artifact` and `deploy-pages` actions.
