### PR TITLE
feat: strip dir prefixes

### DIFF
--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -2484,7 +2484,15 @@ class GreatDocs:
                         index_href = f"{slug}/index.qmd"  # pragma: no cover
 
                 # Add sidebar (skipped for single-page sections)
-                self._add_section_sidebar(title, slug, copied, has_user_index, generate_index)
+                dir_titles = section_cfg.get("dir_titles", {})
+                self._add_section_sidebar(
+                    title,
+                    slug,
+                    copied,
+                    has_user_index,
+                    generate_index,
+                    dir_titles=dir_titles,
+                )
 
                 # For single-page sections (no sidebar), inject a body class so
                 # CSS can expand the content area into the sidebar space.
@@ -2884,6 +2892,7 @@ class GreatDocs:
         pages: list[dict],
         has_user_index: bool,
         has_generated_index: bool = False,
+        dir_titles: dict[str, str] | None = None,
     ) -> None:
         """
         Add a sidebar for the custom section to ``_quarto.yml``.
@@ -2900,6 +2909,9 @@ class GreatDocs:
             Whether the user provided their own index.qmd.
         has_generated_index
             Whether an auto-generated index page was created.
+        dir_titles
+            Optional mapping of subdirectory names (after prefix stripping) to
+            custom sidebar section titles.
         """
         quarto_yml = self.project_path / "_quarto.yml"
         config = self._read_quarto_config(quarto_yml)
@@ -2941,8 +2953,14 @@ class GreatDocs:
             )
 
         # Add subdirectory groups as section headers
+        if dir_titles is None:
+            dir_titles = {}
         for subdir in sorted(subdir_groups.keys()):
-            section_title = subdir.replace("-", " ").replace("_", " ").title()  # pragma: no cover
+            clean_subdir = self._strip_numeric_prefix(subdir)  # pragma: no cover
+            section_title = dir_titles.get(  # pragma: no cover
+                clean_subdir,
+                clean_subdir.replace("-", " ").replace("_", " ").title(),
+            )  # pragma: no cover
             section_contents = []  # pragma: no cover
             for page in subdir_groups[subdir]:  # pragma: no cover
                 section_contents.append(  # pragma: no cover
@@ -4366,7 +4384,8 @@ class GreatDocs:
                     dir_files = subdirs[subdir]
                     # Use the index.qmd title as the section title if present,
                     # otherwise derive from the directory name
-                    section_title = subdir.replace("-", " ").replace("_", " ").title()
+                    clean_subdir = self._strip_numeric_prefix(subdir)
+                    section_title = clean_subdir.replace("-", " ").replace("_", " ").title()
                     section_contents = []
                     for file_info in dir_files:
                         if file_info["path"].name == "index.qmd":

--- a/test-packages/synthetic/catalog.py
+++ b/test-packages/synthetic/catalog.py
@@ -350,6 +350,8 @@ ALL_PACKAGES: list[str] = [
     "gdtest_code_span_headings",  # 172
     # 173: Blog section with user-provided index.qmd
     "gdtest_sec_blog_user_index",  # 173
+    # 174: Custom section with dir_titles and numeric-prefix subdirectories
+    "gdtest_sec_dir_titles",  # 174
 ]
 
 
@@ -535,6 +537,7 @@ DIMENSIONS: dict[str, dict[str, str]] = {
     "N8": {"axis": "sections", "label": "Section index opt-in"},
     "N9": {"axis": "sections", "label": "Single-page sidebar hide"},
     "N10": {"axis": "sections", "label": "Section index hero cards"},
+    "N11": {"axis": "sections", "label": "dir_titles + numeric prefix subdirs"},
     # Reference axes
     "P1": {"axis": "reference", "label": "Explicit reference"},
     "P2": {"axis": "reference", "label": "members: false"},
@@ -1969,6 +1972,14 @@ PACKAGE_DESCRIPTIONS: dict[str, str] = {
         "Tests that Great Docs injects toc: false and body-classes: "
         "gd-blog-index into the user's index, hiding the TOC sidebar "
         "and copy-page widget."
+    ),
+    "gdtest_sec_dir_titles": (
+        "Custom section with dir_titles overrides and numeric-prefix "
+        "subdirectories (01-getting-started/, 02-results-and-reporting/, "
+        "03-advanced-topics/). Tests that numeric prefixes are stripped "
+        "from sidebar section headings and that dir_titles mapping "
+        "overrides the auto-generated title (e.g., 'Results/Reporting' "
+        "instead of 'Results And Reporting')."
     ),
 }
 

--- a/test-packages/synthetic/specs/gdtest_sec_dir_titles.py
+++ b/test-packages/synthetic/specs/gdtest_sec_dir_titles.py
@@ -1,0 +1,160 @@
+"""
+gdtest_sec_dir_titles — Custom section with dir_titles and numeric-prefix subdirectories.
+
+Dimensions: N11
+Focus: Subdirectory sidebar titles: numeric prefix stripping and custom dir_titles mapping.
+"""
+
+SPEC = {
+    "name": "gdtest_sec_dir_titles",
+    "description": "Custom section with dir_titles overrides and numeric-prefix subdirectories.",
+    "dimensions": ["N11"],
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-sec-dir-titles",
+            "version": "0.1.0",
+            "description": "Test dir_titles and numeric prefix stripping in section sidebars.",
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    },
+    "config": {
+        "sections": [
+            {
+                "title": "Demos",
+                "dir": "demos",
+                "index": True,
+                "dir_titles": {
+                    "getting-started": "Getting Started",
+                    "results-and-reporting": "Results/Reporting",
+                    "advanced-topics": "Advanced Topics",
+                },
+            },
+        ],
+    },
+    "files": {
+        "gdtest_sec_dir_titles/__init__.py": (
+            '"""Test package for dir_titles in section sidebars."""\n'
+            "\n"
+            "from .core import run_demo, show_results\n"
+            "\n"
+            '__all__ = ["run_demo", "show_results"]\n'
+        ),
+        "gdtest_sec_dir_titles/core.py": '''
+            """Core demo functions."""
+
+
+            def run_demo(name: str) -> str:
+                """Run a demo by name.
+
+                Parameters
+                ----------
+                name : str
+                    The name of the demo to run.
+
+                Returns
+                -------
+                str
+                    A summary of the demo run.
+
+                Examples
+                --------
+                >>> run_demo("starter")
+                'Running demo: starter'
+                """
+                return f"Running demo: {name}"
+
+
+            def show_results(data: list) -> str:
+                """Show results from a demo run.
+
+                Parameters
+                ----------
+                data : list
+                    A list of result values.
+
+                Returns
+                -------
+                str
+                    Formatted results string.
+
+                Examples
+                --------
+                >>> show_results([1, 2, 3])
+                'Results: [1, 2, 3]'
+                """
+                return f"Results: {data}"
+        ''',
+        # Subdirectories with numeric prefixes — tests prefix stripping
+        "demos/01-getting-started/installation.qmd": (
+            "---\n"
+            "title: Installation\n"
+            "description: How to install the package.\n"
+            "---\n"
+            "\n"
+            "# Installation\n"
+            "\n"
+            "Install with pip:\n"
+            "\n"
+            "```bash\n"
+            "pip install gdtest-sec-dir-titles\n"
+            "```\n"
+        ),
+        "demos/01-getting-started/first-steps.qmd": (
+            "---\n"
+            "title: First Steps\n"
+            "description: Your first steps with the package.\n"
+            "---\n"
+            "\n"
+            "# First Steps\n"
+            "\n"
+            "Start by importing the package and running a basic demo.\n"
+        ),
+        # dir_titles maps this to "Results/Reporting" instead of "Results And Reporting"
+        "demos/02-results-and-reporting/basic-report.qmd": (
+            "---\n"
+            "title: Basic Report\n"
+            "description: Generate a basic results report.\n"
+            "---\n"
+            "\n"
+            "# Basic Report\n"
+            "\n"
+            "Use `show_results()` to display output.\n"
+        ),
+        "demos/02-results-and-reporting/custom-output.qmd": (
+            "---\n"
+            "title: Custom Output\n"
+            "description: Customize the output format.\n"
+            "---\n"
+            "\n"
+            "# Custom Output\n"
+            "\n"
+            "Override the default formatting.\n"
+        ),
+        # dir_titles maps this to "Advanced Topics"
+        "demos/03-advanced-topics/tips-and-tricks.qmd": (
+            "---\n"
+            "title: Tips and Tricks\n"
+            "description: Advanced tips for power users.\n"
+            "---\n"
+            "\n"
+            "# Tips and Tricks\n"
+            "\n"
+            "Explore advanced patterns and optimizations.\n"
+        ),
+        "README.md": (
+            "# gdtest-sec-dir-titles\n"
+            "\n"
+            "Test dir_titles and numeric prefix stripping in section sidebars.\n"
+        ),
+    },
+    "expected": {
+        "detected_name": "gdtest-sec-dir-titles",
+        "detected_module": "gdtest_sec_dir_titles",
+        "detected_parser": "numpy",
+        "export_names": ["run_demo", "show_results"],
+        "num_exports": 2,
+    },
+}

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -6071,6 +6071,7 @@ class TestGdgSite144DocstringTables:
         assert "100" in html
         assert "42.5" in html
 
+
 def _bp_make_trans(objects=None):
     """Helper: create a BlueprintTransformer backed by a dict of objects."""
     objects = objects or {}
@@ -9648,6 +9649,117 @@ def test_add_section_sidebar_replaces_existing():
 
         assert len(sidebar) == 1
         assert sidebar[0]["title"] == "Recipes"
+
+
+def test_add_section_sidebar_strips_numeric_prefix_from_subdirs():
+    """_add_section_sidebar strips numeric prefixes from subdirectory sidebar titles."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp = Path(tmp_dir)
+        docs = GreatDocs(project_path=tmp_dir)
+        quarto_yml = docs.project_path / "_quarto.yml"
+        docs.project_path.mkdir(parents=True, exist_ok=True)
+
+        config = {"website": {"sidebar": [], "navbar": {"left": []}}}
+        with open(quarto_yml, "w") as f:
+            write_yaml(config, f)
+
+        pages = [
+            {"filename": "01-getting-started/install.qmd", "title": "Install"},
+            {"filename": "01-getting-started/first-steps.qmd", "title": "First Steps"},
+            {"filename": "02-advanced/config.qmd", "title": "Config"},
+        ]
+        docs._add_section_sidebar("Tutorials", "tutorials", pages, has_user_index=True)
+
+        with open(quarto_yml) as f:
+            result = read_yaml(f)
+
+        sidebar = result["website"]["sidebar"]
+        assert len(sidebar) == 1
+
+        sections = [c for c in sidebar[0]["contents"] if isinstance(c, dict) and "section" in c]
+        section_titles = [s["section"] for s in sections]
+
+        # Numeric prefixes should be stripped
+        assert "Getting Started" in section_titles
+        assert "Advanced" in section_titles
+        # Raw prefixed names should NOT appear
+        assert "01 Getting Started" not in section_titles
+        assert "02 Advanced" not in section_titles
+
+
+def test_add_section_sidebar_dir_titles_override():
+    """_add_section_sidebar uses dir_titles mapping to override sidebar section titles."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp = Path(tmp_dir)
+        docs = GreatDocs(project_path=tmp_dir)
+        quarto_yml = docs.project_path / "_quarto.yml"
+        docs.project_path.mkdir(parents=True, exist_ok=True)
+
+        config = {"website": {"sidebar": [], "navbar": {"left": []}}}
+        with open(quarto_yml, "w") as f:
+            write_yaml(config, f)
+
+        pages = [
+            {"filename": "01-getting-started/install.qmd", "title": "Install"},
+            {"filename": "02-results-and-reporting/report.qmd", "title": "Report"},
+            {"filename": "03-advanced/config.qmd", "title": "Config"},
+        ]
+        dir_titles = {
+            "getting-started": "Getting Started",
+            "results-and-reporting": "Results/Reporting",
+            # "advanced" intentionally omitted — should fall back to auto-generated
+        }
+        docs._add_section_sidebar(
+            "Demos", "demos", pages, has_user_index=True, dir_titles=dir_titles
+        )
+
+        with open(quarto_yml) as f:
+            result = read_yaml(f)
+
+        sidebar = result["website"]["sidebar"]
+        sections = [c for c in sidebar[0]["contents"] if isinstance(c, dict) and "section" in c]
+        section_titles = [s["section"] for s in sections]
+
+        assert "Getting Started" in section_titles
+        assert "Results/Reporting" in section_titles
+        # Fallback auto-generated title for unmapped subdir
+        assert "Advanced" in section_titles
+
+
+def test_user_guide_sidebar_auto_strips_numeric_prefix_from_subdirs():
+    """_generate_user_guide_sidebar_auto strips numeric prefixes from subdir section titles."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp = Path(tmp_dir)
+        src = tmp / "user_guide"
+        src.mkdir()
+        sub1 = src / "01-basics"
+        sub1.mkdir()
+        (sub1 / "intro.qmd").write_text("Intro\n")
+        sub2 = src / "02-advanced-topics"
+        sub2.mkdir()
+        (sub2 / "deep.qmd").write_text("Deep\n")
+
+        guide_info = {
+            "files": [
+                {"path": sub1 / "intro.qmd", "title": "Intro", "section": None},
+                {"path": sub2 / "deep.qmd", "title": "Deep", "section": None},
+            ],
+            "source_dir": src,
+            "sections": {},
+        }
+
+        docs = GreatDocs(project_path=tmp_dir)
+        result = docs._generate_user_guide_sidebar_auto(guide_info)
+
+        section_items = [c for c in result["contents"] if isinstance(c, dict) and "section" in c]
+        section_titles = [s["section"] for s in section_items]
+
+        # Numeric prefixes should be stripped
+        assert "Basics" in section_titles
+        assert "Advanced Topics" in section_titles
+        # Raw prefixed names should NOT appear
+        assert "01 Basics" not in section_titles
+        assert "02 Advanced Topics" not in section_titles
 
 
 def test_inject_section_body_class_adds_class():
@@ -29311,7 +29423,6 @@ def test_mixin_rendered_member_pages_group_str():
 def test_mixin_render_body_with_doc_members():
     """render_body renders docstring + member groups for Doc members."""
 
-
     _, doc_cls = _build_class_with_members()
     render = RenderDocClass(doc_cls, level=1)
 
@@ -29326,7 +29437,6 @@ def test_mixin_render_body_with_doc_members():
 
 def test_mixin_render_body_with_member_pages():
     """render_body renders docstring + member page groups for MemberPage members."""
-
 
     _, doc_cls = _build_class_with_member_pages()
     render = RenderDocClass(doc_cls, level=1)
@@ -29905,7 +30015,6 @@ def test_mixin_render_functions_module_uses_functions_slug():
 
 def test_mixin_render_members_module_uses_functions_slug():
     """For DocModule, render_members has 'Functions' group not 'Methods'."""
-
 
     mod_obj = dc.Module(name="mymod")
     func_obj = dc.Function(name="func", lineno=1)
@@ -31596,10 +31705,8 @@ def test_rstconv_simple_table_two_sep_via_wrapper():
     assert "|" in result
 
 
-
 def test_docclass_attributes_excludes_dataclass_params():
     """DocClass.attributes filters out dataclass params when is_dataclass=True."""
-
 
     cls_obj = dc.Class(name="DC", lineno=1)
     cls_obj.labels.add("dataclass")
@@ -31642,7 +31749,6 @@ def test_docclass_attributes_excludes_dataclass_params():
 def test_docclass_parameter_attributes_with_dataclass():
     """DocClass.parameter_attributes returns params found in class attributes."""
 
-
     cls_obj = dc.Class(name="DC2", lineno=1)
     cls_obj.labels.add("dataclass")
 
@@ -31672,7 +31778,6 @@ def test_docclass_parameter_attributes_with_dataclass():
 
 def test_docclass_init_parameters_with_dataclass():
     """DocClass.init_parameters returns params NOT in class attributes."""
-
 
     cls_obj = dc.Class(name="DC3", lineno=1)
     cls_obj.labels.add("dataclass")
@@ -31712,7 +31817,6 @@ def test_docclass_init_parameters_with_dataclass():
 def test_docmodule_render_signature_no_signature_name():
     """DocModule.render_signature() returns None when signature_name is falsy."""
 
-
     mod_obj = dc.Module(name="my_module")
     doc_mod = layout.DocModule(name="my_module", obj=mod_obj)
 
@@ -31727,7 +31831,6 @@ def test_docmodule_render_signature_no_signature_name():
 
 def test_docmodule_render_signature_with_name():
     """DocModule.render_signature() returns Div when signature_name is set."""
-
 
     mod_obj = dc.Module(name="my_module")
     doc_mod = layout.DocModule(name="my_module", obj=mod_obj)
@@ -31745,7 +31848,6 @@ def test_docmodule_render_signature_with_name():
 
 def test_docmodule_post_init_narrows_types():
     """DocModule.__post_init__() narrows self.doc and self.obj types."""
-
 
     mod_obj = dc.Module(name="test_mod")
     doc_mod = layout.DocModule(name="test_mod", obj=mod_obj)
@@ -31771,7 +31873,6 @@ def test_get_render_type_raises_for_unmapped_type():
 
 def test_renderbase_title_property():
     """RenderBase.title calls render_title()."""
-
 
     mod_obj = dc.Module(name="tmod")
     doc_mod = layout.DocModule(name="tmod", obj=mod_obj)
@@ -31824,7 +31925,6 @@ def test_extract_directives_seealso_empty_entry():
 
 def test_docattribute_render_signature_type_kind():
     """DocAttribute.render_signature() clears name/annotation for TypeAlias kind."""
-
 
     attr_obj = dc.Attribute(name="MyType", lineno=1)
     attr_obj.annotation = gf.ExprName("str")
@@ -31883,7 +31983,6 @@ def test_renderbase_summary_property():
 def test_docclass_attribute_member_pages_dataclass():
     """DocClass.attribute_member_pages filters dataclass params."""
 
-
     cls_obj = dc.Class(name="DC4", lineno=1)
     cls_obj.labels.add("dataclass")
 
@@ -31921,7 +32020,6 @@ def test_docclass_attribute_member_pages_dataclass():
 def test_docclass_parameter_attributes_non_dataclass():
     """DocClass.parameter_attributes returns empty for non-dataclass."""
 
-
     cls_obj = dc.Class(name="RegularClass", lineno=1)
     doc_cls = layout.DocClass(name="RegularClass", obj=cls_obj, members=[])
 
@@ -31935,7 +32033,6 @@ def test_docclass_parameter_attributes_non_dataclass():
 
 def test_docclass_init_parameters_non_dataclass():
     """DocClass.init_parameters returns empty for non-dataclass."""
-
 
     cls_obj = dc.Class(name="RegularClass2", lineno=1)
     doc_cls = layout.DocClass(name="RegularClass2", obj=cls_obj, members=[])
@@ -32936,7 +33033,6 @@ def test_render_api_page_metadata():
     doc_obj = griffe_to_doc(func_obj)
     page = layout.Page(path="reference/my_func", contents=[doc_obj])
 
-
     ap = RenderAPIPage(layout_obj=page, level=1)
     meta = ap.render_metadata()
     meta_str = str(meta)
@@ -32950,7 +33046,6 @@ def test_render_api_page_render_body():
     func_obj = gf.Function(name="my_func", lineno=1)
     doc_obj = griffe_to_doc(func_obj)
     page = layout.Page(path="reference/my_func", contents=[doc_obj])
-
 
     ap = RenderAPIPage(layout_obj=page, level=1)
     body = ap.render_body()
@@ -32970,7 +33065,6 @@ def test_render_api_page_summary_with_summary_details():
         summary=summary,
     )
 
-
     ap = RenderAPIPage(layout_obj=page, level=1)
     result = ap.render_summary()
 
@@ -32988,7 +33082,6 @@ def test_render_api_page_summary_multi_no_flatten_raises():
         contents=[f1, f2],
         flatten=False,
     )
-
 
     ap = RenderAPIPage(layout_obj=page, level=1)
     with pytest.raises(ValueError, match="Cannot summarize page"):
@@ -33248,9 +33341,6 @@ def test_render_reference_page_render_body():
     section = layout.Section(title="Functions", contents=[doc_func])
     lyt = layout.Layout(title="API", sections=[section])
 
-
-
-
     with patch.dict(os.environ, {}, clear=False):
         os.environ.pop("GITHUB_REPO_URL", None)
         rp = RenderReferencePage(layout_obj=lyt, level=1)
@@ -33270,9 +33360,6 @@ def test_render_reference_section_body_with_contents():
     doc_func = layout.DocFunction(name="some_func", obj=func_obj, anchor="some_func")
 
     section = layout.Section(title="Functions", contents=[doc_func])
-
-
-
 
     with patch.dict(os.environ, {}, clear=False):
         os.environ.pop("GITHUB_REPO_URL", None)
@@ -33321,9 +33408,6 @@ def test_render_api_page_full_lifecycle():
 
     page = layout.Page(path="reference/my_func", contents=[doc_func])
 
-
-
-
     with patch.dict(os.environ, {}, clear=False):
         os.environ.pop("GITHUB_REPO_URL", None)
         ap = RenderAPIPage(layout_obj=page, level=1)
@@ -33364,9 +33448,6 @@ def test_render_api_page_with_summary_details():
         summary=layout.SummaryDetails(name="fn()", desc="Do something"),
     )
 
-
-
-
     with patch.dict(os.environ, {}, clear=False):
         os.environ.pop("GITHUB_REPO_URL", None)
         ap = RenderAPIPage(layout_obj=page, level=1)
@@ -33378,7 +33459,6 @@ def test_render_api_page_with_summary_details():
 
 def test_renderdoc_display_name_relative_level_gt1():
     """RenderDoc.display_name uses 'name' format when level > 1."""
-
 
     func_obj = gf.Function(name="my_func", lineno=1)
     doc_func = layout.DocFunction(name="my_func", obj=func_obj)
@@ -33394,7 +33474,6 @@ def test_renderdoc_display_name_relative_level_gt1():
 def test_renderdoc_render_annotation_non_attribute_raises():
     """RenderDoc.render_annotation() raises TypeError for non-attribute."""
 
-
     func_obj = gf.Function(name="fn", lineno=1)
     doc_func = layout.DocFunction(name="fn", obj=func_obj)
 
@@ -33407,7 +33486,6 @@ def test_renderdoc_render_annotation_non_attribute_raises():
 
 def test_renderdoc_render_annotation_attribute():
     """RenderDoc.render_annotation() for attribute."""
-
 
     attr_obj = gf.Attribute(name="x", lineno=1)
     attr_obj.annotation = gf.ExprName("int")
@@ -33424,7 +33502,6 @@ def test_renderdoc_render_annotation_attribute():
 def test_renderdoc_render_annotation_none():
     """RenderDoc.render_annotation() with None annotation."""
 
-
     attr_obj = gf.Attribute(name="y", lineno=1)
     attr_obj.annotation = None
     doc_attr = layout.DocAttribute(name="y", obj=attr_obj)
@@ -33438,7 +33515,6 @@ def test_renderdoc_render_annotation_none():
 
 def test_renderdoc_docstring_section_deprecated():
     """RenderDoc handles DocstringSectionDeprecated."""
-
 
     func_obj = gf.Function(name="old_fn", lineno=1)
     func_obj.docstring = gf.Docstring(
@@ -33459,7 +33535,6 @@ def test_renderdoc_docstring_section_deprecated():
 def test_renderdoc_docstring_section_examples():
     """RenderDoc handles DocstringSectionExamples."""
 
-
     func_obj = gf.Function(name="ex_fn", lineno=1)
     func_obj.docstring = gf.Docstring(
         "Short desc.\n\nExamples\n--------\n>>> 1 + 1\n2\n",
@@ -33479,7 +33554,6 @@ def test_renderdoc_docstring_section_examples():
 def test_renderdoc_docstring_section_text_in_div():
     """RenderDoc wraps 'Text' sections in a Div."""
 
-
     func_obj = gf.Function(name="txt_fn", lineno=1)
     func_obj.docstring = gf.Docstring(
         "Short description.\n\nParameters\n----------\nx : int\n    A number.",
@@ -33497,7 +33571,6 @@ def test_renderdoc_docstring_section_text_in_div():
 
 def test_renderdoc_source_link_with_github_url():
     """RenderDoc.source_link returns Link when GITHUB_REPO_URL is set."""
-
 
     mod = gf.Module(name="mymod", filepath=Path("/fake/pkg/mymod.py"))
     func_obj = gf.Function(name="linked_fn", lineno=5)
@@ -33523,7 +33596,6 @@ def test_renderdoc_source_link_with_github_url():
 
 def test_renderdoc_see_also_section():
     """RenderDoc handles See Also section."""
-
 
     func_obj = gf.Function(name="sa_fn", lineno=1)
     func_obj.docstring = gf.Docstring(
@@ -33965,7 +34037,6 @@ def test_build_github_source_url_with_source_path():
 def test_type_sections_empty_lists():
     """TypeSections with no items produces empty Blocks output."""
 
-
     ts = TypeSections(
         protocols_items=[],
         typevars_items=[],
@@ -33984,11 +34055,9 @@ def test_type_sections_empty_lists():
 def test_type_sections_items_combines_all():
     """TypeSections.items returns protocols + typevars + typealiases combined."""
 
-
     p_item = layout.Item(name="P", obj=MagicMock(), uri="ref/P.html#P", dispname="P")
     tv_item = layout.Item(name="TV", obj=MagicMock(), uri="ref/TV.html#TV", dispname="TV")
     ta_item = layout.Item(name="TA", obj=MagicMock(), uri="ref/TA.html#TA", dispname="TA")
-
 
     mock_render = MagicMock()
     mock_render_cls = MagicMock(return_value=mock_render)
@@ -34015,12 +34084,10 @@ def test_type_sections_items_combines_all():
 def test_type_sections_post_init_protocols_no_summary():
     """TypeSections.__post_init__ sets show_members_summary=False on protocols."""
 
-
     p_item = layout.Item(name="Proto", obj=MagicMock())
 
     mock_render = MagicMock()
     mock_render_cls = MagicMock(return_value=mock_render)
-
 
     with (
         patch("great_docs._renderer.typing_information.griffe_to_doc"),
@@ -34040,12 +34107,10 @@ def test_type_sections_post_init_protocols_no_summary():
 def test_type_sections_post_init_typevars_no_sig_name():
     """TypeSections.__post_init__ sets show_signature_name=False on typevars."""
 
-
     tv_item = layout.Item(name="T", obj=MagicMock())
 
     mock_render = MagicMock()
     mock_render_cls = MagicMock(return_value=mock_render)
-
 
     with (
         patch("great_docs._renderer.typing_information.griffe_to_doc"),
@@ -34065,12 +34130,10 @@ def test_type_sections_post_init_typevars_no_sig_name():
 def test_type_sections_post_init_typealiases_settings():
     """TypeSections.__post_init__ sets show_signature_name=False and show_signature_annotation=False on typealiases."""
 
-
     ta_item = layout.Item(name="MyAlias", obj=MagicMock())
 
     mock_render = MagicMock()
     mock_render_cls = MagicMock(return_value=mock_render)
-
 
     with (
         patch("great_docs._renderer.typing_information.griffe_to_doc"),
@@ -34091,13 +34154,11 @@ def test_type_sections_post_init_typealiases_settings():
 def test_type_sections_render_body_protocols_section():
     """TypeSections.render_body includes 'Protocols' header when protocols exist."""
 
-
     p_item = layout.Item(name="P", obj=MagicMock())
 
     mock_render = MagicMock()
     mock_render.__str__ = MagicMock(return_value="<protocol-rendered>")
     mock_render_cls = MagicMock(return_value=mock_render)
-
 
     with (
         patch("great_docs._renderer.typing_information.griffe_to_doc"),
@@ -34121,13 +34182,11 @@ def test_type_sections_render_body_protocols_section():
 def test_type_sections_render_body_typevars_section():
     """TypeSections.render_body includes 'Type Variables' header when typevars exist."""
 
-
     tv_item = layout.Item(name="T", obj=MagicMock())
 
     mock_render = MagicMock()
     mock_render.__str__ = MagicMock(return_value="<typevar-rendered>")
     mock_render_cls = MagicMock(return_value=mock_render)
-
 
     with (
         patch("great_docs._renderer.typing_information.griffe_to_doc"),
@@ -34149,13 +34208,11 @@ def test_type_sections_render_body_typevars_section():
 def test_type_sections_render_body_typealiases_section():
     """TypeSections.render_body includes 'Type Aliases' header when typealiases exist."""
 
-
     ta_item = layout.Item(name="A", obj=MagicMock())
 
     mock_render = MagicMock()
     mock_render.__str__ = MagicMock(return_value="<alias-rendered>")
     mock_render_cls = MagicMock(return_value=mock_render)
-
 
     with (
         patch("great_docs._renderer.typing_information.griffe_to_doc"),
@@ -34177,7 +34234,6 @@ def test_type_sections_render_body_typealiases_section():
 def test_type_sections_render_body_all_sections():
     """TypeSections.render_body includes all three section headers when all types present."""
 
-
     p_item = layout.Item(name="P", obj=MagicMock())
     tv_item = layout.Item(name="T", obj=MagicMock())
     ta_item = layout.Item(name="A", obj=MagicMock())
@@ -34185,7 +34241,6 @@ def test_type_sections_render_body_all_sections():
     mock_render = MagicMock()
     mock_render.__str__ = MagicMock(return_value="<rendered>")
     mock_render_cls = MagicMock(return_value=mock_render)
-
 
     with (
         patch("great_docs._renderer.typing_information.griffe_to_doc"),
@@ -34208,7 +34263,6 @@ def test_type_sections_render_body_all_sections():
 def test_type_information_post_init():
     """TypeInformation.__post_init__ sets package and dir from builder."""
 
-
     mock_builder = MagicMock()
     mock_builder.package = "mypkg"
     mock_builder.dir = "reference"
@@ -34222,7 +34276,6 @@ def test_type_information_post_init():
 def test_type_information_base_uri_strips_package():
     """TypeInformation.base_uri strips the package prefix from module_path."""
 
-
     mock_builder = MagicMock()
     mock_builder.package = "mypkg"
     mock_builder.dir = "reference"
@@ -34234,7 +34287,6 @@ def test_type_information_base_uri_strips_package():
 def test_type_information_base_uri_no_package_prefix():
     """TypeInformation.base_uri keeps full path when module doesn't start with package."""
 
-
     mock_builder = MagicMock()
     mock_builder.package = "mypkg"
     mock_builder.dir = "reference"
@@ -34245,7 +34297,6 @@ def test_type_information_base_uri_no_package_prefix():
 
 def test_type_information_sections_calls_get_object():
     """TypeInformation.sections calls get_object and classifies members."""
-
 
     mock_builder = MagicMock()
     mock_builder.package = "mypkg"
@@ -34298,7 +34349,6 @@ def test_type_information_sections_calls_get_object():
 def test_type_information_sections_item_uris():
     """TypeInformation.sections creates items with correct URIs based on base_uri."""
 
-
     mock_builder = MagicMock()
     mock_builder.package = "mypkg"
     mock_builder.dir = "reference"
@@ -34333,7 +34383,6 @@ def test_type_information_sections_item_uris():
 def test_type_information_content_has_meta_and_sections():
     """TypeInformation.content returns Blocks with Meta title and TypeSections."""
 
-
     mock_builder = MagicMock()
     mock_builder.package = "mypkg"
     mock_builder.dir = "reference"
@@ -34352,7 +34401,6 @@ def test_type_information_content_has_meta_and_sections():
 def test_type_information_str_delegates_to_content():
     """TypeInformation.__str__ returns str(self.content)."""
 
-
     mock_builder = MagicMock()
     mock_builder.package = "mypkg"
     mock_builder.dir = "reference"
@@ -34369,8 +34417,6 @@ def test_type_information_str_delegates_to_content():
 
 def test_type_information_write_creates_file():
     """TypeInformation.write() extends builder items and writes the qmd file."""
-
-
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         mock_builder = MagicMock()
@@ -34396,8 +34442,6 @@ def test_type_information_write_creates_file():
 
 def test_type_information_write_extends_builder_items():
     """TypeInformation.write() adds all section items to builder.items."""
-
-
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         ref_dir = str(Path(tmp_dir) / "reference")

--- a/user_guide/07-custom-sections.qmd
+++ b/user_guide/07-custom-sections.qmd
@@ -63,6 +63,7 @@ sections:
 | `index_columns`  | `2`                | Number of columns for image cards on the index page (1 or 2). Only applies when `index: true` |
 | `navbar_after`   | Before "Reference" | Name of an existing navbar item to place this section after |
 | `type`           | `default`          | `"default"` for card-grid index with sidebar; `"blog"` for Quarto listing page |
+| `dir_titles`     | `{}`               | Mapping of subdirectory names to custom sidebar section titles (see [Subdirectories](#subdirectories)) |
 
 ## Multiple Sections
 
@@ -219,7 +220,7 @@ examples/
 
 ## Subdirectories
 
-Sections support nested subdirectories. Files in subdirectories are copied with their relative paths preserved:
+Sections support nested subdirectories. Files in subdirectories are copied with their relative paths preserved, and each subdirectory becomes a **sidebar section** with its own heading.
 
 ```
 tutorials/
@@ -229,6 +230,46 @@ tutorials/
 └── advanced/
     └── custom-config.qmd
 ```
+
+### Numeric Prefix Stripping
+
+Just like individual files, subdirectory names have numeric prefixes stripped automatically. This lets you control the sort order of sidebar sections while keeping clean display titles:
+
+```
+examples/
+├── 01-getting-started/
+│   ├── installation.qmd
+│   └── first-steps.qmd
+├── 02-results-and-reporting/
+│   ├── basic-report.qmd
+│   └── custom-output.qmd
+└── 03-advanced-topics/
+    └── custom-config.qmd
+```
+
+The sidebar displays these as **"Getting Started"**, **"Results And Reporting"**, and **"Advanced Topics"** (not "01 Getting Started", etc.).
+
+### Custom Subdirectory Titles {#custom-subdirectory-titles}
+
+The auto-generated title converts hyphens and underscores to spaces and applies title case. If you need different capitalization or phrasing, use `dir_titles` to override specific subdirectory headings:
+
+```{.yaml filename="great-docs.yml"}
+sections:
+  - title: Demos
+    dir: examples
+    index: true
+    dir_titles:
+      getting-started: "Getting Started"
+      results-and-reporting: "Results/Reporting"
+      advanced-topics: "Advanced Topics"
+```
+
+The keys in `dir_titles` are the subdirectory names **after** numeric prefix stripping (e.g., use `getting-started`, not `01-getting-started`). Any subdirectory not listed in the mapping falls back to the auto-generated title.
+
+::: {.callout-tip}
+## When to use `dir_titles`
+This is useful when the auto-generated title doesn't match your preferred style — for example, turning "Results And Reporting" into "Results/Reporting", or "Actions And Thresholds" into "Actions & Thresholds".
+:::
 
 ## Example: Visual Gallery
 


### PR DESCRIPTION
This PR adds support for customizing sidebar section titles in documentation. It introduces a `dir_titles` mapping for sections, allowing users to override auto-generated sidebar titles for subdirectories and ensures that numeric prefixes are stripped from subdirectory names in sidebar headings. The changes are tested with new and updated test cases and synthetic test packages.