### PR TITLE
fix: ensure that namespace pkgs initialize correctly

### DIFF
--- a/great_docs/cli.py
+++ b/great_docs/cli.py
@@ -402,7 +402,14 @@ def scan(project_path: str | None, docs_dir: str | None, verbose: bool) -> None:
             click.echo("Error: Could not detect package name.", err=True)
             sys.exit(1)
 
-        importable_name = docs._normalize_package_name(package_name)
+        # Use explicit module name from great-docs.yml (or auto-detection) when
+        # available; this handles namespace packages like "firebird.base" where
+        # the importable module name differs from the PyPI project name.
+        module_name = docs._detect_module_name()
+        if module_name:
+            importable_name = module_name
+        else:
+            importable_name = docs._normalize_package_name(package_name)
 
         # Section 1: Discovery
         click.echo("─" * 50)

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -954,7 +954,28 @@ class GreatDocs:
                 )
                 if hatch_packages:
                     pkg = hatch_packages[0]
-                    return pkg.split("/")[-1]
+                    pkg_name = pkg.split("/")[-1]
+
+                    # Resolve the package path on disk to check for namespace packages
+                    pkg_path = package_root / pkg
+                    init_py = pkg_path / "__init__.py"
+
+                    # If the directory has no __init__.py, it is a namespace root
+                    # (e.g., src/firebird/ for the firebird.* namespace).
+                    # Derive the subpackage from the project name.
+                    if pkg_path.is_dir() and not init_py.exists():
+                        project_name = self._detect_package_name()
+                        if project_name:
+                            normalized_project = project_name.replace("-", "_")
+                            # "firebird-base" → "firebird_base"; namespace "firebird"
+                            # → subpackage "base"
+                            if normalized_project.startswith(pkg_name + "_"):
+                                sub_name = normalized_project[len(pkg_name) + 1 :]
+                                sub_path = pkg_path / sub_name
+                                if sub_path.is_dir() and (sub_path / "__init__.py").exists():
+                                    return f"{pkg_name}.{sub_name}"
+
+                    return pkg_name
 
             except Exception:
                 pass
@@ -964,7 +985,25 @@ class GreatDocs:
         if project_name:
             init_file = self._find_package_init(project_name)
             if init_file:
-                return init_file.parent.name
+                # Compute the dotted module name by finding the layout-root
+                # that contains this __init__.py (e.g. src/, python/, lib/
+                # or the project root itself).
+                pkg_dir = init_file.parent
+                for layout_dir in [
+                    package_root / "src",
+                    package_root / "python",
+                    package_root / "lib",
+                    package_root,
+                ]:
+                    try:
+                        rel = pkg_dir.relative_to(layout_dir)
+                    except ValueError:
+                        continue
+                    parts = rel.parts
+                    if parts:
+                        return ".".join(parts)
+                # Fallback: just use the immediate directory name
+                return pkg_dir.name
 
         return None
 
@@ -7539,6 +7578,17 @@ class GreatDocs:
         # Get normalized package name for imports
         importable_name = self._normalize_package_name(package_name)
 
+        # Try to detect the actual module name (handles namespace packages,
+        # src-layout mismatches, compiled extensions, etc.)
+        module_name = self._detect_module_name()
+        if module_name:
+            importable_name = module_name
+
+        # Only write an explicit 'module:' line when the detected module name
+        # differs from the simple hyphen→underscore normalized project name.
+        normalized_name = self._normalize_package_name(package_name)
+        explicit_module = module_name if module_name != normalized_name else None
+
         # Detect docstring style
         print("Detecting docstring style...")
         parser_style = self._detect_docstring_style(importable_name)
@@ -7553,6 +7603,7 @@ class GreatDocs:
             config_content = self._generate_minimal_config(
                 parser=parser_style,
                 dynamic=dynamic_mode,
+                module=explicit_module,
             )
             config_path.write_text(config_content, encoding="utf-8")
             print(f"Created {config_path}")
@@ -7580,6 +7631,7 @@ class GreatDocs:
             importable_name,
             parser=parser_style,
             dynamic=dynamic_mode,
+            module=explicit_module,
         )
 
         config_path.write_text(config_content, encoding="utf-8")
@@ -7590,6 +7642,7 @@ class GreatDocs:
         self,
         parser: str = "numpy",
         dynamic: bool = True,
+        module: str | None = None,
     ) -> str:
         """
         Generate minimal great-docs.yml without reference section.
@@ -7600,6 +7653,8 @@ class GreatDocs:
             The docstring parser style ("numpy", "google", or "sphinx").
         dynamic
             Whether to use dynamic introspection mode for API reference generation.
+        module
+            Explicit module name when it differs from the project name.
 
         Returns
         -------
@@ -7628,7 +7683,7 @@ class GreatDocs:
 # ----------------------
 # Set this if your importable module name differs from the project name.
 # Example: project 'py-yaml12' with module name 'yaml12'
-# module: yaml12
+{f"module: {module}" if module else "# module: yaml12"}
 
 # Docstring Parser
 # ----------------
@@ -7701,6 +7756,7 @@ jupyter: python3
         package_name: str,
         parser: str = "numpy",
         dynamic: bool = True,
+        module: str | None = None,
     ) -> str:
         """
         Generate great-docs.yml with a reference section from discovered exports.
@@ -7715,6 +7771,8 @@ jupyter: python3
             The docstring parser style ("numpy", "google", or "sphinx").
         dynamic
             Whether to use dynamic introspection mode for API reference generation.
+        module
+            Explicit module name when it differs from the project name.
 
         Returns
         -------
@@ -7735,7 +7793,7 @@ jupyter: python3
             "# ----------------------",
             "# Set this if your importable module name differs from the project name.",
             "# Example: project 'py-yaml12' with module name 'yaml12'",
-            "# module: yaml12",
+            f"module: {module}" if module else "# module: yaml12",
             "",
         ]
 

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -1020,6 +1020,23 @@ class GreatDocs:
         # Fallback to project_root if we can't find it
         return self.project_root
 
+    def _griffe_search_paths(self) -> list[str | Path]:
+        """Return search paths for griffe so it can find src/python/lib layouts.
+
+        Prepends the package root and common sub-layouts (`src/`, `python/`, `lib/`) in front of
+        `sys.path` so that griffe can locate packages in non-flat layouts while still falling back
+        to the normal import path.
+        """
+        import sys
+
+        package_root = self._find_package_root()
+        extra: list[str | Path] = [package_root]
+        for subdir in ("src", "python", "lib"):
+            candidate = package_root / subdir
+            if candidate.is_dir():
+                extra.append(candidate)
+        return extra + sys.path
+
     def _get_quarto_env(self) -> dict[str, str]:
         """
         Get environment variables for running Quarto commands.
@@ -1032,6 +1049,7 @@ class GreatDocs:
         griffe can find the package even if it's not installed.
 
         The method looks for Python in the following order:
+
         1. Virtual environment in the project root (.venv/bin/python or .venv/Scripts/python.exe)
         2. The currently running Python interpreter
 
@@ -4718,7 +4736,7 @@ class GreatDocs:
 
             # Load the package with griffe
             try:
-                pkg = griffe.load(normalized_name)
+                pkg = griffe.load(normalized_name, search_paths=self._griffe_search_paths())
             except Exception:
                 return None
 
@@ -5022,6 +5040,20 @@ class GreatDocs:
                 search_paths.append(package_root / pkg)
                 search_paths.append(package_root / "src" / pkg)
 
+        # Handle dotted module names (namespace packages like "firebird.base")
+        # by converting dots to path separators
+        dotted_path = None
+        if "." in package_name:
+            dotted_path = package_name.replace(".", os.sep)
+            search_paths.extend(
+                [
+                    package_root / dotted_path,
+                    package_root / "src" / dotted_path,
+                    package_root / "python" / dotted_path,
+                    package_root / "lib" / dotted_path,
+                ]
+            )
+
         # Then add standard locations based on package name
         search_paths.extend(
             [
@@ -5235,9 +5267,13 @@ class GreatDocs:
             # Normalize package name (replace dashes with underscores)
             normalized_name = package_name.replace("-", "_")
 
+            # Build search_paths for griffe so it can find packages in
+            # src/, python/, lib/ layouts without them being on sys.path
+            griffe_search_paths = self._griffe_search_paths()
+
             # Load the package using griffe
             try:
-                pkg = griffe.load(normalized_name)
+                pkg = griffe.load(normalized_name, search_paths=griffe_search_paths)
             except Exception as e:
                 print(f"Warning: Could not load package with griffe ({type(e).__name__})")
                 if package_name != normalized_name:
@@ -5253,6 +5289,11 @@ class GreatDocs:
             if pkg.exports:
                 public_members = [name for name in all_members if name in set(pkg.exports)]
                 print(f"Using __all__ with {len(public_members)} exports")
+                # If __all__ lists names that griffe couldn't resolve as actual
+                # members (e.g., lazy imports, re-exports), fall back to AST
+                # parsing so the names are still discovered.
+                if not public_members and pkg.exports:
+                    return None
             else:
                 # Filter out private names (starting with underscore)
                 # This also filters out dunder names like __version__, __all__, etc.
@@ -5449,7 +5490,7 @@ class GreatDocs:
 
             # Load the package using griffe
             try:
-                pkg = griffe.load(normalized_name)
+                pkg = griffe.load(normalized_name, search_paths=self._griffe_search_paths())
             except Exception as e:
                 print(
                     f"Warning: Could not load package for docstring detection ({type(e).__name__})"
@@ -5597,7 +5638,7 @@ class GreatDocs:
 
         # Get a sample of exports to test
         try:
-            pkg = griffe.load(normalized_name)
+            pkg = griffe.load(normalized_name, search_paths=self._griffe_search_paths())
             exports = [
                 name
                 for name in list(pkg.members.keys())[:10]  # Test first 10
@@ -6076,7 +6117,7 @@ class GreatDocs:
 
             # Try to load the package with griffe
             try:
-                pkg = griffe.load(normalized_name)
+                pkg = griffe.load(normalized_name, search_paths=self._griffe_search_paths())
             except Exception as e:
                 print(f"Warning: Could not load package with griffe ({type(e).__name__})")
                 # Fallback: use importlib + inspect to categorize exports
@@ -6845,7 +6886,7 @@ class GreatDocs:
             normalized_name = package_name.replace("-", "_")
 
             try:
-                pkg = griffe.load(normalized_name)
+                pkg = griffe.load(normalized_name, search_paths=self._griffe_search_paths())
             except Exception as e:
                 print(f"Warning: Could not load package with griffe ({type(e).__name__})")
                 return {}

--- a/test-packages/synthetic/catalog.py
+++ b/test-packages/synthetic/catalog.py
@@ -352,6 +352,8 @@ ALL_PACKAGES: list[str] = [
     "gdtest_sec_blog_user_index",  # 173
     # 174: Custom section with dir_titles and numeric-prefix subdirectories
     "gdtest_sec_dir_titles",  # 174
+    # 175: Namespace package with src/ layout and dotted module name
+    "gdtest_namespace_src",  # 175
 ]
 
 
@@ -1980,6 +1982,13 @@ PACKAGE_DESCRIPTIONS: dict[str, str] = {
         "from sidebar section headings and that dir_titles mapping "
         "overrides the auto-generated title (e.g., 'Results/Reporting' "
         "instead of 'Results And Reporting')."
+    ),
+    "gdtest_namespace_src": (
+        "Namespace package using src/ layout with dotted module name "
+        "(nspkg.core). Code lives at src/nspkg/core/__init__.py and the "
+        "great-docs.yml sets module: nspkg.core. Tests discovery of "
+        "namespace packages in src/ layout via griffe search_paths and "
+        "dotted path resolution in _find_package_init."
     ),
 }
 

--- a/test-packages/synthetic/specs/gdtest_namespace_src.py
+++ b/test-packages/synthetic/specs/gdtest_namespace_src.py
@@ -1,0 +1,153 @@
+"""
+gdtest_namespace_src — Namespace package with src/ layout.
+
+Dimensions: A2, A12, B1, C4, D1, E6, F6, G1, H7
+Focus: Namespace package using src/ layout — the importable module is
+       dotted (e.g., ``nspkg.core``) and lives under ``src/nspkg/core/``.
+       Tests the fix for namespace package discovery with ``module:`` config
+       in great-docs.yml (GitHub issue: firebird-base src layout).
+"""
+
+SPEC = {
+    "name": "gdtest_namespace_src",
+    "description": "Namespace package with src/ layout and dotted module name",
+    "dimensions": ["A2", "A12", "B1", "C4", "D1", "E6", "F6", "G1", "H7"],
+    # ── Project metadata ─────────────────────────────────────────────
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-namespace-src",
+            "version": "0.1.0",
+            "description": "Test namespace package in src/ layout",
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+        "tool": {
+            "setuptools": {
+                "package-dir": {"": "src"},
+            },
+        },
+    },
+    # ── Great-docs config ────────────────────────────────────────────
+    "config": {
+        "module": "nspkg.core",
+    },
+    # ── Source files ──────────────────────────────────────────────────
+    "files": {
+        # Namespace top level — implicit namespace (no __all__)
+        "src/nspkg/__init__.py": '''\
+            """Namespace top-level package."""
+        ''',
+        # The actual sub-package with the API
+        "src/nspkg/core/__init__.py": '''\
+            """Core sub-package of the nspkg namespace."""
+
+            __version__ = "0.1.0"
+            __all__ = ["Config", "connect", "disconnect"]
+
+
+            class Config:
+                """
+                Configuration holder for connections.
+
+                Parameters
+                ----------
+                host
+                    Server hostname.
+                port
+                    Port number.
+
+                Examples
+                --------
+                >>> cfg = Config("localhost", 5432)
+                >>> cfg.host
+                'localhost'
+                """
+
+                def __init__(self, host: str, port: int = 5432):
+                    self.host = host
+                    self.port = port
+
+                def as_dict(self) -> dict:
+                    """
+                    Return configuration as a dictionary.
+
+                    Returns
+                    -------
+                    dict
+                        Keys are ``host`` and ``port``.
+                    """
+                    return {"host": self.host, "port": self.port}
+
+                def validate(self) -> bool:
+                    """
+                    Validate the configuration.
+
+                    Returns
+                    -------
+                    bool
+                        True if the configuration is valid.
+
+                    Raises
+                    ------
+                    ValueError
+                        If the host is empty or port is out of range.
+                    """
+                    if not self.host:
+                        raise ValueError("Host cannot be empty")
+                    if not (1 <= self.port <= 65535):
+                        raise ValueError("Port must be between 1 and 65535")
+                    return True
+
+
+            def connect(config: Config) -> str:
+                """
+                Establish a connection using the given config.
+
+                Parameters
+                ----------
+                config
+                    The connection configuration.
+
+                Returns
+                -------
+                str
+                    Connection URI string.
+                """
+                return f"{config.host}:{config.port}"
+
+
+            def disconnect(connection: str) -> bool:
+                """
+                Close an active connection.
+
+                Parameters
+                ----------
+                connection
+                    The connection string to close.
+
+                Returns
+                -------
+                bool
+                    True if disconnection succeeded.
+                """
+                return True
+        ''',
+        "README.md": """\
+            # gdtest-namespace-src
+
+            Tests namespace package discovery with src/ layout and dotted module name.
+        """,
+    },
+    # ── Expected outcomes ────────────────────────────────────────────
+    "expected": {
+        "detected_name": "gdtest-namespace-src",
+        "detected_module": "nspkg.core",
+        "detected_parser": "numpy",
+        "export_names": ["Config", "connect", "disconnect"],
+        "num_exports": 3,
+        "section_titles": ["Classes", "Functions"],
+        "has_user_guide": False,
+    },
+}

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -22802,7 +22802,10 @@ def test_get_package_exports_no_all():
         docs = GreatDocs(project_path=tmp_dir)
         exports = docs._get_package_exports("exportpkg_noall")
 
-        assert exports is None
+        # No __all__ defined and the only public name (VERSION) is auto-excluded,
+        # so there are no documentable exports.  With griffe search-paths the
+        # package *is* discovered (returns []) rather than undiscoverable (None).
+        assert not exports
 
 
 def test_get_package_exports_hyphenated_name():
@@ -28246,6 +28249,7 @@ def test_cli_scan_success():
             mock_docs = MagicMock()
             MockGD.return_value = mock_docs
             mock_docs._detect_package_name.return_value = "my_package"
+            mock_docs._detect_module_name.return_value = None
             mock_docs._normalize_package_name.return_value = "my_package"
             mock_docs._get_package_exports.return_value = ["MyClass", "my_func"]
             mock_docs._categorize_api_objects.return_value = {
@@ -28281,6 +28285,7 @@ def test_cli_scan_verbose():
             mock_docs = MagicMock()
             MockGD.return_value = mock_docs
             mock_docs._detect_package_name.return_value = "my_pkg"
+            mock_docs._detect_module_name.return_value = None
             mock_docs._normalize_package_name.return_value = "my_pkg"
             mock_docs._get_package_exports.return_value = ["func"]
             mock_docs._categorize_api_objects.return_value = {
@@ -28324,6 +28329,7 @@ def test_cli_scan_no_exports():
             mock_docs = MagicMock()
             MockGD.return_value = mock_docs
             mock_docs._detect_package_name.return_value = "my_pkg"
+            mock_docs._detect_module_name.return_value = None
             mock_docs._normalize_package_name.return_value = "my_pkg"
             mock_docs._get_package_exports.return_value = []
 
@@ -28341,6 +28347,7 @@ def test_cli_scan_no_reference_config():
             mock_docs = MagicMock()
             MockGD.return_value = mock_docs
             mock_docs._detect_package_name.return_value = "my_pkg"
+            mock_docs._detect_module_name.return_value = None
             mock_docs._normalize_package_name.return_value = "my_pkg"
             mock_docs._get_package_exports.return_value = ["func"]
             mock_docs._categorize_api_objects.return_value = {
@@ -28363,6 +28370,7 @@ def test_cli_scan_class_without_members():
             mock_docs = MagicMock()
             MockGD.return_value = mock_docs
             mock_docs._detect_package_name.return_value = "my_pkg"
+            mock_docs._detect_module_name.return_value = None
             mock_docs._normalize_package_name.return_value = "my_pkg"
             mock_docs._get_package_exports.return_value = ["MyClass"]
             mock_docs._categorize_api_objects.return_value = {
@@ -28390,6 +28398,7 @@ def test_cli_scan_flat_categories():
             mock_docs = MagicMock()
             MockGD.return_value = mock_docs
             mock_docs._detect_package_name.return_value = "my_pkg"
+            mock_docs._detect_module_name.return_value = None
             mock_docs._normalize_package_name.return_value = "my_pkg"
             mock_docs._get_package_exports.return_value = [
                 "MyEnum",
@@ -28435,6 +28444,7 @@ def test_cli_scan_class_like_categories():
             mock_docs = MagicMock()
             MockGD.return_value = mock_docs
             mock_docs._detect_package_name.return_value = "my_pkg"
+            mock_docs._detect_module_name.return_value = None
             mock_docs._normalize_package_name.return_value = "my_pkg"
             mock_docs._get_package_exports.return_value = [
                 "MyDC",
@@ -28469,6 +28479,7 @@ def test_cli_scan_string_items_in_reference():
             mock_docs = MagicMock()
             MockGD.return_value = mock_docs
             mock_docs._detect_package_name.return_value = "my_pkg"
+            mock_docs._detect_module_name.return_value = None
             mock_docs._normalize_package_name.return_value = "my_pkg"
             mock_docs._get_package_exports.return_value = ["my_func"]
             mock_docs._categorize_api_objects.return_value = {
@@ -40911,3 +40922,152 @@ def test_collect_page_tags_from_recipes():
         tag_index = gd._collect_page_tags()
         assert "Config" in tag_index
         assert tag_index["Config"][0]["section"] == "Recipes"
+
+
+# ── Namespace package support ────────────────────────────────────────────────
+
+
+def test_find_package_init_dotted_module_src_layout():
+    """_find_package_init finds __init__.py for a dotted namespace module in src/."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # Simulate firebird.base in src/firebird/base/
+        pkg_path = Path(tmp_dir) / "src" / "firebird" / "base"
+        pkg_path.mkdir(parents=True)
+        init_file = pkg_path / "__init__.py"
+        init_file.write_text(
+            '"""Firebird base package."""\n__all__ = ["connect"]\n',
+            encoding="utf-8",
+        )
+        (Path(tmp_dir) / "pyproject.toml").write_text(
+            '[project]\nname = "firebird-base"\n', encoding="utf-8"
+        )
+
+        docs = GreatDocs(project_path=tmp_dir)
+        result = docs._find_package_init("firebird.base")
+
+        assert result is not None
+        assert result.resolve() == init_file.resolve()
+
+
+def test_find_package_init_dotted_module_flat_layout():
+    """_find_package_init finds __init__.py for a dotted namespace module in flat layout."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # Simulate mynamespace.pkg in mynamespace/pkg/
+        pkg_path = Path(tmp_dir) / "mynamespace" / "pkg"
+        pkg_path.mkdir(parents=True)
+        init_file = pkg_path / "__init__.py"
+        init_file.write_text(
+            '"""Package."""\n__version__ = "1.0"\n',
+            encoding="utf-8",
+        )
+        (Path(tmp_dir) / "pyproject.toml").write_text(
+            '[project]\nname = "mynamespace-pkg"\n', encoding="utf-8"
+        )
+
+        docs = GreatDocs(project_path=tmp_dir)
+        result = docs._find_package_init("mynamespace.pkg")
+
+        assert result is not None
+        assert result.resolve() == init_file.resolve()
+
+
+def test_discover_exports_namespace_src_layout():
+    """_parse_package_exports discovers exports for namespace pkg in src/ layout."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # Create src/mypkg/sub/__init__.py with __all__
+        src_dir = Path(tmp_dir) / "src"
+        pkg_path = src_dir / "mypkg" / "sub"
+        pkg_path.mkdir(parents=True)
+        (pkg_path / "__init__.py").write_text(
+            '"""Namespace sub-package."""\n'
+            '__all__ = ["hello", "goodbye"]\n'
+            "\n"
+            "def hello(name: str) -> str:\n"
+            '    """Say hello."""\n'
+            "    return f'Hello {name}'\n"
+            "\n"
+            "def goodbye(name: str) -> str:\n"
+            '    """Say goodbye."""\n'
+            "    return f'Goodbye {name}'\n",
+            encoding="utf-8",
+        )
+        # mypkg namespace level
+        (src_dir / "mypkg" / "__init__.py").write_text("")
+
+        (Path(tmp_dir) / "pyproject.toml").write_text(
+            '[project]\nname = "mypkg-sub"\n', encoding="utf-8"
+        )
+
+        docs = GreatDocs(project_path=tmp_dir)
+        # Use _parse_package_exports which exercises the core fix:
+        # dotted name -> path resolution in _find_package_init
+        exports = docs._parse_package_exports("mypkg.sub")
+
+        assert exports is not None
+        assert "hello" in exports
+        assert "goodbye" in exports
+
+
+def test_griffe_search_paths_includes_src():
+    """_griffe_search_paths includes src/ when it exists."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        (Path(tmp_dir) / "pyproject.toml").write_text(
+            '[project]\nname = "test"\n', encoding="utf-8"
+        )
+        (Path(tmp_dir) / "src").mkdir()
+
+        docs = GreatDocs(project_path=tmp_dir)
+        paths = docs._griffe_search_paths()
+
+        resolved = [str(Path(p).resolve()) for p in paths]
+        assert str((Path(tmp_dir) / "src").resolve()) in resolved
+        assert str(Path(tmp_dir).resolve()) in resolved
+
+
+def test_cli_scan_uses_module_name():
+    """CLI scan uses _detect_module_name when available (namespace package support)."""
+    from click.testing import CliRunner
+
+    runner = CliRunner()
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        with patch("great_docs.cli.GreatDocs") as MockGD:
+            mock_docs = MagicMock()
+            MockGD.return_value = mock_docs
+            mock_docs._detect_package_name.return_value = "firebird-base"
+            # Simulate module: firebird.base in great-docs.yml
+            mock_docs._detect_module_name.return_value = "firebird.base"
+            mock_docs._get_package_exports.return_value = ["connect", "Config"]
+            mock_docs._categorize_api_objects.return_value = {
+                "classes": ["Config"],
+                "functions": ["connect"],
+                "class_method_names": {},
+            }
+            mock_docs._config.reference = []
+
+            result = runner.invoke(scan, ["--project-path", tmp_dir])
+            assert result.exit_code == 0
+            # Should show the module name, not the PyPI name
+            assert "firebird.base" in result.output
+            # _get_package_exports should have been called with the module name
+            mock_docs._get_package_exports.assert_called_with("firebird.base")
+
+
+def test_parse_package_exports_dotted_name():
+    """_parse_package_exports parses __all__ from a namespace package init."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        pkg_path = Path(tmp_dir) / "src" / "ns" / "pkg"
+        pkg_path.mkdir(parents=True)
+        (pkg_path / "__init__.py").write_text(
+            '__all__ = ["Alpha", "Beta"]\n',
+            encoding="utf-8",
+        )
+        (Path(tmp_dir) / "pyproject.toml").write_text(
+            '[project]\nname = "ns-pkg"\n', encoding="utf-8"
+        )
+
+        docs = GreatDocs(project_path=tmp_dir)
+        exports = docs._parse_package_exports("ns.pkg")
+
+        assert exports is not None
+        assert "Alpha" in exports
+        assert "Beta" in exports


### PR DESCRIPTION
This PR improves support for namespace packages, especially those using a `src/` layout and dotted module names. It enhances module name detection, config generation, and search path handling to ensure accurate discovery and documentation of such packages. The test suite now cover these scenarios (plus adds a GDG site for more direct verification).

Fixes: https://github.com/posit-dev/great-docs/issues/112