### PR TITLE
enh: docs linting checks for stale badges

### DIFF
--- a/great_docs/_lint.py
+++ b/great_docs/_lint.py
@@ -89,7 +89,7 @@ def run_lint(
     from .core import GreatDocs
 
     result = LintResult()
-    all_checks = {"docstrings", "cross-refs", "style", "directives"}
+    all_checks = {"docstrings", "cross-refs", "style", "directives", "stale-versions"}
 
     if checks is None:
         checks = all_checks
@@ -192,6 +192,9 @@ def run_lint(
 
     if "directives" in checks:
         _check_directive_consistency(pkg, importable_name, exports, result)
+
+    if "stale-versions" in checks:
+        _check_stale_versions(project_root, result)
 
     return result
 
@@ -497,3 +500,246 @@ def _check_directive_consistency(
                         _check_one(f"{name}.{member_name}", member_doc)
         except Exception:
             pass
+
+
+# ---------------------------------------------------------------------------
+# Stale version annotations
+# ---------------------------------------------------------------------------
+
+# Default thresholds (used when no config overrides)
+_DEFAULT_BADGE_THRESHOLD = 3  # releases behind latest
+_DEFAULT_CALLOUT_THRESHOLD = 4  # releases behind latest
+
+
+def _check_stale_versions(project_root: Path, result: LintResult) -> None:
+    """
+    Flag stale version-annotated content in .qmd files.
+
+    Checks for:
+      - `[version-badge new X]` where X is many releases behind latest
+      - `::: {.version-note version="X"}` / `::: {.version-deprecated version="X"}`
+        where X is very old
+      - `upcoming: "X"` frontmatter where X is already released
+    """
+    import yaml
+
+    # Load great-docs.yml for versions list and optional lint config
+    config_path = project_root / "great-docs.yml"
+    if not config_path.exists():
+        return
+
+    try:
+        raw_config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return
+
+    versions_raw = raw_config.get("versions", [])
+    if not versions_raw:
+        return
+
+    from ._versioning import parse_versions_config
+
+    versions = parse_versions_config(versions_raw)
+    if not versions:
+        return
+
+    # Determine the latest non-prerelease version
+    latest_entry = None
+    for v in versions:
+        if v.latest:
+            latest_entry = v
+            break
+    if latest_entry is None:
+        for v in versions:
+            if not v.prerelease:
+                latest_entry = v
+                break
+    if latest_entry is None:
+        return
+
+    # Optional config overrides
+    lint_cfg = raw_config.get("lint", {}) or {}
+    stale_cfg = lint_cfg.get("stale_versions", {}) or {}
+    badge_threshold = int(stale_cfg.get("badge_threshold", _DEFAULT_BADGE_THRESHOLD))
+    callout_threshold = int(stale_cfg.get("callout_threshold", _DEFAULT_CALLOUT_THRESHOLD))
+
+    # Parse the real badge expiry config (new_is_old)
+    from ._versioning import is_badge_expired, parse_badge_expiry
+
+    badge_expiry = parse_badge_expiry(raw_config.get("new_is_old"))
+
+    # Build set of released version identifiers for upcoming check
+    released_versions: set[str] = set()
+    for v in versions:
+        if not v.prerelease:
+            released_versions.add(v.tag)
+            if v.version:
+                released_versions.add(v.version)
+
+    # Compiled patterns (same as in _versioned_build)
+    badge_re = re.compile(
+        r"\[version-badge\s+(new|changed|deprecated)(?:\s+(\S+))?\]",
+        re.IGNORECASE,
+    )
+    note_re = re.compile(
+        r'^:::\s*\{\.version-note(?:\s+versions?="([^"]*)")?\}\s*$',
+        re.MULTILINE,
+    )
+    deprecated_re = re.compile(
+        r'^:::\s*\{\.version-deprecated(?:\s+versions?="([^"]*)")?\}\s*$',
+        re.MULTILINE,
+    )
+
+    # Collect .qmd files (skip _site, _extensions, build dirs, hidden dirs)
+    qmd_files = []
+    for qmd in project_root.rglob("*.qmd"):
+        rel = qmd.relative_to(project_root)
+        parts = rel.parts
+        if any(p.startswith("_") or p.startswith(".") for p in parts):
+            continue
+        qmd_files.append(qmd)
+
+    for qmd_file in sorted(qmd_files):
+        try:
+            content = qmd_file.read_text(encoding="utf-8")
+        except OSError:
+            continue
+
+        rel_path = str(qmd_file.relative_to(project_root))
+
+        # --- Check stale badges ---
+        for m in badge_re.finditer(content):
+            badge_type = m.group(1).lower()
+            badge_version = m.group(2)
+            if not badge_version:
+                continue
+            distance = _version_distance(badge_version, latest_entry, versions)
+            if distance is not None and distance >= badge_threshold:
+                lineno = content[: m.start()].count("\n") + 1
+
+                # For "new" badges, check whether it truly no longer displays
+                # using the project's actual new_is_old expiry setting
+                if badge_type == "new":
+                    expired = is_badge_expired(badge_version, latest_entry, versions, badge_expiry)
+                    if expired:
+                        advice = "consider removing badge since it no longer displays"
+                    else:
+                        advice = (
+                            "badge still displays but is getting old; "
+                            "consider whether it's still useful"
+                        )
+                else:
+                    # changed/deprecated badges always display regardless of
+                    # new_is_old config
+                    advice = (
+                        "badge still displays in all versions; consider whether it's still useful"
+                    )
+
+                result.issues.append(
+                    LintIssue(
+                        check="stale-badge",
+                        severity="warning",
+                        symbol=f"{rel_path}:{lineno}",
+                        message=(
+                            f"[version-badge {badge_type} {badge_version}] is "
+                            f"{distance} releases behind latest; {advice}"
+                        ),
+                    )
+                )
+
+        # --- Check stale callouts ---
+        for m in note_re.finditer(content):
+            callout_version = m.group(1)
+            if not callout_version:
+                continue
+            distance = _version_distance(callout_version, latest_entry, versions)
+            if distance is not None and distance >= callout_threshold:
+                lineno = content[: m.start()].count("\n") + 1
+                result.issues.append(
+                    LintIssue(
+                        check="stale-callout",
+                        severity="info",
+                        symbol=f"{rel_path}:{lineno}",
+                        message=(
+                            f'::: {{.version-note version="{callout_version}"}} is '
+                            f"{distance} releases old; "
+                            f"consider consolidating into main text"
+                        ),
+                    )
+                )
+
+        for m in deprecated_re.finditer(content):
+            callout_version = m.group(1)
+            if not callout_version:
+                continue
+            distance = _version_distance(callout_version, latest_entry, versions)
+            if distance is not None and distance >= callout_threshold:
+                lineno = content[: m.start()].count("\n") + 1
+                result.issues.append(
+                    LintIssue(
+                        check="stale-callout",
+                        severity="info",
+                        symbol=f"{rel_path}:{lineno}",
+                        message=(
+                            f'::: {{.version-deprecated version="{callout_version}"}} is '
+                            f"{distance} releases old; "
+                            f"consider consolidating into main text"
+                        ),
+                    )
+                )
+
+        # --- Check stale upcoming frontmatter ---
+        upcoming_val = _extract_frontmatter_upcoming(content)
+        if upcoming_val and upcoming_val in released_versions:
+            result.issues.append(
+                LintIssue(
+                    check="stale-upcoming",
+                    severity="warning",
+                    symbol=f"{rel_path}:1",
+                    message=(
+                        f'upcoming: "{upcoming_val}" references an already-released version; '
+                        f"remove the upcoming frontmatter"
+                    ),
+                )
+            )
+
+
+def _version_distance(
+    badge_version: str,
+    latest_entry,
+    versions: list,
+) -> int | None:
+    """
+    Count how many non-prerelease positions *badge_version* is behind *latest_entry*.
+
+    Returns None if the version is not found in the list.
+    """
+    from ._versioning import _find_entry
+
+    entry = _find_entry(badge_version, versions)
+    if entry is None:
+        return None
+    non_pre = [v for v in versions if not v.prerelease]
+    badge_idx = None
+    latest_idx = None
+    for i, v in enumerate(non_pre):
+        if v.tag == entry.tag:
+            badge_idx = i
+        if v.tag == latest_entry.tag:
+            latest_idx = i
+    if badge_idx is None or latest_idx is None:
+        return None
+    # non_pre is ordered newest-first, so badge_idx > latest_idx means older
+    return badge_idx - latest_idx
+
+
+def _extract_frontmatter_upcoming(content: str) -> str | None:
+    """Extract the `upcoming:` value from YAML frontmatter."""
+    fm_match = re.match(r"^---\s*\n(.*?)\n---\s*\n", content, re.DOTALL)
+    if not fm_match:
+        return None
+    fm = fm_match.group(1)
+    m = re.search(r"^upcoming\s*:\s*(.+)$", fm, re.MULTILINE)
+    if not m:
+        return None
+    return m.group(1).strip().strip('"').strip("'")

--- a/great_docs/cli.py
+++ b/great_docs/cli.py
@@ -1699,7 +1699,7 @@ cli.add_command(seo)
     "--check",
     "checks",
     multiple=True,
-    type=click.Choice(["docstrings", "cross-refs", "style", "directives"]),
+    type=click.Choice(["docstrings", "cross-refs", "style", "directives", "stale-versions"]),
     help="Run only specific checks (can be repeated). Default: all checks.",
 )
 @click.option(
@@ -1713,7 +1713,7 @@ def lint(project_path: str | None, checks: tuple[str, ...], json_output: bool) -
 
     Analyzes your package's public API for documentation issues including
     missing docstrings, broken cross-references, inconsistent formatting,
-    and malformed directives.
+    malformed directives, and stale version annotations.
 
     \b
     Checks performed:
@@ -1722,17 +1722,20 @@ def lint(project_path: str | None, checks: tuple[str, ...], json_output: bool) -
       • style-mismatch       Docstrings not matching configured style (numpy/google/sphinx)
       • unknown-directive    Unrecognized %directive names
       • empty-seealso        %seealso entries with empty references
+      • stale-badge          Version badges far behind latest release
+      • stale-callout        Version callouts that are very old
+      • stale-upcoming       upcoming: frontmatter for already-released versions
 
     \b
     Examples:
       great-docs lint                                # Run all checks
+      great-docs lint --check stale-versions         # Only check for stale annotations
       great-docs lint --check docstrings             # Only check for missing docstrings
       great-docs lint --check cross-refs --check style
       great-docs lint --json                         # JSON output for CI
       great-docs lint --json | jq '.issues[] | select(.severity == "error")'
     """
     import json
-    import shutil
     import textwrap
 
     from ._lint import run_lint
@@ -1768,31 +1771,33 @@ def lint(project_path: str | None, checks: tuple[str, ...], json_output: bool) -
                     # Count severities
                     errs = sum(1 for i in issues if i.severity == "error")
                     warns = sum(1 for i in issues if i.severity == "warning")
+                    infos = sum(1 for i in issues if i.severity == "info")
                     label_parts = []
                     if errs:
                         label_parts.append(f"{errs} error(s)")
                     if warns:
                         label_parts.append(f"{warns} warning(s)")
+                    if infos:
+                        label_parts.append(f"{infos} info")
                     label = ", ".join(label_parts)
 
                     click.echo(f"  {check_name}  [{label}]")
                     click.echo(f"{'─' * 60}")
 
                     for issue in issues:
-                        icon = "❌" if issue.severity == "error" else "⚠️ "
-                        symbol_str = f"  {issue.symbol}" if issue.symbol else ""
-                        prefix = f"  {icon}{symbol_str}: "
-                        # Wrap long messages to keep output tidy
-                        term_width = shutil.get_terminal_size((80, 24)).columns
-                        wrap_width = max(40, term_width - len(prefix))
-                        lines = textwrap.wrap(issue.message, width=wrap_width)
-                        if lines:
-                            click.echo(f"{prefix}{lines[0]}")
-                            indent = " " * len(prefix)
-                            for line in lines[1:]:
-                                click.echo(f"{indent}{line}")
+                        if issue.severity == "error":
+                            icon = "❌"
+                        elif issue.severity == "info":
+                            icon = "ℹ️ "
                         else:
-                            click.echo(prefix.rstrip())
+                            icon = "⚠️ "
+                        symbol_str = f"  {issue.symbol}" if issue.symbol else ""
+                        click.echo(f"  {icon}{symbol_str}")
+                        # Wrap long messages indented below the path
+                        msg_indent = "        "
+                        lines = textwrap.wrap(issue.message, width=56)
+                        for line in lines:
+                            click.echo(f"{msg_indent}{line}")
 
                 click.echo(f"\n{'─' * 60}")
                 n_errors = len(result.errors)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -900,3 +900,239 @@ class TestCheckDirectiveConsistencyEdgeCases:
         # Note: the actual _directives.extract_directives filters empties via `if name:`
         # so this won't produce an issue — but we still exercise the code path
         assert all(i.check != "empty-seealso" for i in result.issues)
+
+
+# ---------------------------------------------------------------------------
+# Stale version annotation checks
+# ---------------------------------------------------------------------------
+
+
+class TestCheckStaleVersions:
+    """Tests for _check_stale_versions lint check."""
+
+    def _make_project(self, tmp_path, versions_yaml, qmd_files: dict[str, str]):
+        """Create a minimal project with great-docs.yml and .qmd files."""
+        config = f"versions:\n{versions_yaml}\n"
+        (tmp_path / "great-docs.yml").write_text(config)
+        for rel_path, content in qmd_files.items():
+            p = tmp_path / rel_path
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(content)
+
+    @property
+    def _versions_yaml(self):
+        return (
+            '  - label: "0.8 (dev)"\n'
+            "    tag: dev\n"
+            '    version: "0.8"\n'
+            "    prerelease: true\n"
+            '  - label: "0.7"\n'
+            '    tag: "0.7"\n'
+            "    latest: true\n"
+            '  - label: "0.6"\n'
+            '    tag: "0.6"\n'
+            '  - label: "0.5"\n'
+            '    tag: "0.5"\n'
+            '  - label: "0.4"\n'
+            '    tag: "0.4"\n'
+            '  - label: "0.3"\n'
+            '    tag: "0.3"\n'
+            '  - label: "0.2"\n'
+            '    tag: "0.2"\n'
+            '  - label: "0.1"\n'
+            '    tag: "0.1"\n'
+        )
+
+    def test_stale_badge_detected(self, tmp_path):
+        from great_docs._lint import _check_stale_versions
+
+        self._make_project(
+            tmp_path,
+            self._versions_yaml,
+            {
+                "user_guide/page.qmd": (
+                    "---\ntitle: Test\n---\n\nSome text [version-badge new 0.3] here.\n"
+                ),
+            },
+        )
+        result = LintResult()
+        _check_stale_versions(tmp_path, result)
+        stale = [i for i in result.issues if i.check == "stale-badge"]
+        assert len(stale) == 1
+        assert "0.3" in stale[0].message
+        assert "4 releases behind" in stale[0].message
+
+    def test_fresh_badge_not_flagged(self, tmp_path):
+        from great_docs._lint import _check_stale_versions
+
+        self._make_project(
+            tmp_path,
+            self._versions_yaml,
+            {
+                "user_guide/page.qmd": (
+                    "---\ntitle: Test\n---\n\nSome text [version-badge new 0.6] here.\n"
+                ),
+            },
+        )
+        result = LintResult()
+        _check_stale_versions(tmp_path, result)
+        stale = [i for i in result.issues if i.check == "stale-badge"]
+        assert len(stale) == 0
+
+    def test_stale_callout_detected(self, tmp_path):
+        from great_docs._lint import _check_stale_versions
+
+        self._make_project(
+            tmp_path,
+            self._versions_yaml,
+            {
+                "user_guide/page.qmd": (
+                    "---\ntitle: Test\n---\n\n"
+                    '::: {.version-note version="0.2"}\n'
+                    "Added in 0.2.\n"
+                    ":::\n"
+                ),
+            },
+        )
+        result = LintResult()
+        _check_stale_versions(tmp_path, result)
+        stale = [i for i in result.issues if i.check == "stale-callout"]
+        assert len(stale) == 1
+        assert "0.2" in stale[0].message
+        assert stale[0].severity == "info"
+
+    def test_fresh_callout_not_flagged(self, tmp_path):
+        from great_docs._lint import _check_stale_versions
+
+        self._make_project(
+            tmp_path,
+            self._versions_yaml,
+            {
+                "user_guide/page.qmd": (
+                    "---\ntitle: Test\n---\n\n"
+                    '::: {.version-note version="0.5"}\n'
+                    "Added in 0.5.\n"
+                    ":::\n"
+                ),
+            },
+        )
+        result = LintResult()
+        _check_stale_versions(tmp_path, result)
+        stale = [i for i in result.issues if i.check == "stale-callout"]
+        assert len(stale) == 0
+
+    def test_stale_upcoming_detected(self, tmp_path):
+        from great_docs._lint import _check_stale_versions
+
+        self._make_project(
+            tmp_path,
+            self._versions_yaml,
+            {
+                "user_guide/page.qmd": ('---\ntitle: Test\nupcoming: "0.5"\n---\n\nContent.\n'),
+            },
+        )
+        result = LintResult()
+        _check_stale_versions(tmp_path, result)
+        stale = [i for i in result.issues if i.check == "stale-upcoming"]
+        assert len(stale) == 1
+        assert "0.5" in stale[0].message
+        assert "already-released" in stale[0].message
+
+    def test_valid_upcoming_not_flagged(self, tmp_path):
+        from great_docs._lint import _check_stale_versions
+
+        self._make_project(
+            tmp_path,
+            self._versions_yaml,
+            {
+                "user_guide/page.qmd": ('---\ntitle: Test\nupcoming: "0.8"\n---\n\nContent.\n'),
+            },
+        )
+        result = LintResult()
+        _check_stale_versions(tmp_path, result)
+        stale = [i for i in result.issues if i.check == "stale-upcoming"]
+        assert len(stale) == 0
+
+    def test_deprecated_callout_stale(self, tmp_path):
+        from great_docs._lint import _check_stale_versions
+
+        self._make_project(
+            tmp_path,
+            self._versions_yaml,
+            {
+                "user_guide/page.qmd": (
+                    "---\ntitle: Test\n---\n\n"
+                    '::: {.version-deprecated version="0.1"}\n'
+                    "Use new_func().\n"
+                    ":::\n"
+                ),
+            },
+        )
+        result = LintResult()
+        _check_stale_versions(tmp_path, result)
+        stale = [i for i in result.issues if i.check == "stale-callout"]
+        assert len(stale) == 1
+        assert "version-deprecated" in stale[0].message
+
+    def test_custom_thresholds(self, tmp_path):
+        from great_docs._lint import _check_stale_versions
+
+        # Use a very high threshold so nothing is flagged
+        config = (
+            f"versions:\n{self._versions_yaml}\n"
+            "lint:\n"
+            "  stale_versions:\n"
+            "    badge_threshold: 99\n"
+            "    callout_threshold: 99\n"
+        )
+        (tmp_path / "great-docs.yml").write_text(config)
+        qmd = tmp_path / "user_guide" / "page.qmd"
+        qmd.parent.mkdir(parents=True)
+        qmd.write_text(
+            "---\ntitle: Test\n---\n\n"
+            "[version-badge new 0.1]\n"
+            '::: {.version-note version="0.1"}\nOld.\n:::\n'
+        )
+        result = LintResult()
+        _check_stale_versions(tmp_path, result)
+        assert len(result.issues) == 0
+
+    def test_no_versions_config_skips(self, tmp_path):
+        from great_docs._lint import _check_stale_versions
+
+        (tmp_path / "great-docs.yml").write_text("theme: default\n")
+        result = LintResult()
+        _check_stale_versions(tmp_path, result)
+        assert len(result.issues) == 0
+
+    def test_skips_underscore_dirs(self, tmp_path):
+        from great_docs._lint import _check_stale_versions
+
+        self._make_project(
+            tmp_path,
+            self._versions_yaml,
+            {
+                "_site/page.qmd": ("---\ntitle: Test\n---\n\n[version-badge new 0.1]\n"),
+            },
+        )
+        result = LintResult()
+        _check_stale_versions(tmp_path, result)
+        assert len(result.issues) == 0
+
+    def test_line_numbers_correct(self, tmp_path):
+        from great_docs._lint import _check_stale_versions
+
+        self._make_project(
+            tmp_path,
+            self._versions_yaml,
+            {
+                "user_guide/page.qmd": (
+                    "---\ntitle: Test\n---\n\nLine 5\nLine 6\n[version-badge new 0.1]\n"
+                ),
+            },
+        )
+        result = LintResult()
+        _check_stale_versions(tmp_path, result)
+        stale = [i for i in result.issues if i.check == "stale-badge"]
+        assert len(stale) == 1
+        assert stale[0].symbol == "user_guide/page.qmd:7"


### PR DESCRIPTION
This PR adds a new lint check for stale version annotations in documentation files. It also enhances the CLI output to handle informational messages, and updates documentation and tests to support the new feature. The big thing improvement here is helping users identify outdated version badges, callouts, and frontmatter in their `.qmd` files.