### PR TITLE
feat: add ability to specify sidebar groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,30 +272,52 @@ Beyond `init`, `build`, and `preview`, Great Docs includes a full suite of quali
 
 The documentation includes 22 step-by-step recipes:
 
+### Content & API
+
+| Recipe                                                                                                       | Topic                                      |
+| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
+| [Hide Internal Symbols](https://posit-dev.github.io/great-docs/recipes/hide-internal-symbols.html)           | Control what appears in your API reference |
+| [Customize API Organization](https://posit-dev.github.io/great-docs/recipes/customize-api-organization.html) | Structure reference sections your way      |
+| [Document a CLI](https://posit-dev.github.io/great-docs/recipes/document-a-cli.html)                         | Auto-generate CLI reference from Click     |
+| [Cross-Reference Items](https://posit-dev.github.io/great-docs/recipes/cross-reference-items.html)           | Link between documented objects            |
+| [Write Effective Docstrings](https://posit-dev.github.io/great-docs/recipes/write-effective-docstrings.html) | Get the most out of auto-generated docs    |
+| [Add Images & Diagrams](https://posit-dev.github.io/great-docs/recipes/add-images-diagrams.html)             | Include visuals in your documentation      |
+| [Embed Videos](https://posit-dev.github.io/great-docs/recipes/embed-videos.html)                             | Add YouTube, Vimeo, and local videos       |
+
+### Theming & Appearance
+
 | Recipe                                                                                                             | Topic                                      |
 | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
-| [Hide Internal Symbols](https://posit-dev.github.io/great-docs/recipes/hide-internal-symbols.html)                 | Control what appears in your API reference |
-| [Customize API Organization](https://posit-dev.github.io/great-docs/recipes/customize-api-organization.html)       | Structure reference sections your way      |
-| [Document a CLI](https://posit-dev.github.io/great-docs/recipes/document-a-cli.html)                               | Auto-generate CLI reference from Click     |
-| [Cross-Reference Items](https://posit-dev.github.io/great-docs/recipes/cross-reference-items.html)                 | Link between documented objects            |
 | [Add Custom CSS](https://posit-dev.github.io/great-docs/recipes/add-custom-css.html)                               | Override styles with your own SCSS         |
 | [Choose Gradient Theme](https://posit-dev.github.io/great-docs/recipes/choose-gradient-theme.html)                 | Pick and customize navbar gradients        |
 | [Add Logo & Favicon](https://posit-dev.github.io/great-docs/recipes/add-logo-favicon.html)                         | Brand your site with custom icons          |
 | [Customize Announcement Banner](https://posit-dev.github.io/great-docs/recipes/customize-announcement-banner.html) | Add dismissible site-wide notices          |
-| [Write Effective Docstrings](https://posit-dev.github.io/great-docs/recipes/write-effective-docstrings.html)       | Get the most out of auto-generated docs    |
-| [Add Images & Diagrams](https://posit-dev.github.io/great-docs/recipes/add-images-diagrams.html)                   | Include visuals in your documentation      |
+
+### Publishing & Versioning
+
+| Recipe                                                                                                             | Topic                                      |
+| ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
 | [Create Changelog](https://posit-dev.github.io/great-docs/recipes/create-changelog.html)                           | Pull changelog from GitHub Releases        |
 | [GitHub Pages & CI](https://posit-dev.github.io/great-docs/recipes/github-pages-ci.html)                           | Automate deployment with Actions           |
 | [Add Custom Domain](https://posit-dev.github.io/great-docs/recipes/add-custom-domain.html)                         | Serve docs from your own domain            |
-| [Install Great Docs Skill](https://posit-dev.github.io/great-docs/recipes/install-great-docs-skill.html)           | Generate an Agent Skill for your package   |
-| [Build Site with LLM](https://posit-dev.github.io/great-docs/recipes/build-site-with-llm.html)                     | Use an AI assistant to set up your site    |
-| [Customize Site with LLM](https://posit-dev.github.io/great-docs/recipes/customize-site-with-llm.html)             | Use an AI assistant to tweak your site     |
-| [Understand llms.txt](https://posit-dev.github.io/great-docs/recipes/understand-llms-txt.html)                     | Make your docs AI-accessible               |
-| [Fix Common Build Errors](https://posit-dev.github.io/great-docs/recipes/fix-common-build-errors.html)             | Troubleshoot build issues quickly          |
-| [Proofread Documentation](https://posit-dev.github.io/great-docs/recipes/proofread-documentation.html)             | Catch spelling and grammar issues          |
-| [Embed Videos](https://posit-dev.github.io/great-docs/recipes/embed-videos.html)                                   | Add YouTube, Vimeo, and local videos       |
 | [Enable Multi-Version Docs](https://posit-dev.github.io/great-docs/recipes/enable-multi-version-docs.html)         | Add a version selector to your site        |
 | [Use Version Fences and Badges](https://posit-dev.github.io/great-docs/recipes/use-version-fences-and-badges.html) | Annotate version-specific content          |
+
+### AI-Assisted Workflows
+
+| Recipe                                                                                                   | Topic                                      |
+| -------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| [Install Great Docs Skill](https://posit-dev.github.io/great-docs/recipes/install-great-docs-skill.html) | Generate an Agent Skill for your package   |
+| [Build Site with LLM](https://posit-dev.github.io/great-docs/recipes/build-site-with-llm.html)           | Use an AI assistant to set up your site    |
+| [Customize Site with LLM](https://posit-dev.github.io/great-docs/recipes/customize-site-with-llm.html)   | Use an AI assistant to tweak your site     |
+| [Understand llms.txt](https://posit-dev.github.io/great-docs/recipes/understand-llms-txt.html)           | Make your docs AI-accessible               |
+
+### Build & Quality
+
+| Recipe                                                                                                 | Topic                                      |
+| ------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
+| [Fix Common Build Errors](https://posit-dev.github.io/great-docs/recipes/fix-common-build-errors.html) | Troubleshoot build issues quickly          |
+| [Proofread Documentation](https://posit-dev.github.io/great-docs/recipes/proofread-documentation.html) | Catch spelling and grammar issues          |
 
 ## Documentation
 

--- a/great-docs.yml
+++ b/great-docs.yml
@@ -111,6 +111,39 @@ sections:
   - title: Recipes
     dir: recipes
     navbar_after: User Guide
+    sidebar_groups:
+      - section: Content & API
+        contents:
+          - hide-internal-symbols.qmd
+          - customize-api-organization.qmd
+          - document-a-cli.qmd
+          - cross-reference-items.qmd
+          - write-effective-docstrings.qmd
+          - add-images-diagrams.qmd
+          - embed-videos.qmd
+      - section: Theming & Appearance
+        contents:
+          - add-custom-css.qmd
+          - choose-gradient-theme.qmd
+          - add-logo-favicon.qmd
+          - customize-announcement-banner.qmd
+      - section: Publishing & Versioning
+        contents:
+          - create-changelog.qmd
+          - github-pages-ci.qmd
+          - add-custom-domain.qmd
+          - enable-multi-version-docs.qmd
+          - use-version-fences-and-badges.qmd
+      - section: AI-Assisted Workflows
+        contents:
+          - install-great-docs-skill.qmd
+          - build-site-with-llm.qmd
+          - customize-site-with-llm.qmd
+          - understand-llms-txt.qmd
+      - section: Build & Quality
+        contents:
+          - fix-common-build-errors.qmd
+          - proofread-documentation.qmd
 
 # Sidebar Filter
 # --------------

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -2455,10 +2455,9 @@ class GreatDocs:
         """
         Process custom sections: discover files, copy, generate index, wire nav.
 
-        Each configured section gets its own navbar link, sidebar, and
-        (optionally) an auto-generated index page. Blog-type sections
-        use Quarto's native `listing:` directive instead of cards and
-        skip the sidebar.
+        Each configured section gets its own navbar link, sidebar, and (optionally) an
+        auto-generated index page. Blog-type sections use Quarto's native `listing:` directive
+        instead of cards and skip the sidebar.
 
         Returns
         -------
@@ -2571,6 +2570,7 @@ class GreatDocs:
 
                 # Add sidebar (skipped for single-page sections)
                 dir_titles = section_cfg.get("dir_titles", {})
+                sidebar_groups = section_cfg.get("sidebar_groups")
                 self._add_section_sidebar(
                     title,
                     slug,
@@ -2578,6 +2578,7 @@ class GreatDocs:
                     has_user_index,
                     generate_index,
                     dir_titles=dir_titles,
+                    sidebar_groups=sidebar_groups,
                 )
 
                 # For single-page sections (no sidebar), inject a body class so
@@ -2979,6 +2980,7 @@ class GreatDocs:
         has_user_index: bool,
         has_generated_index: bool = False,
         dir_titles: dict[str, str] | None = None,
+        sidebar_groups: list[dict] | None = None,
     ) -> None:
         """
         Add a sidebar for the custom section to `_quarto.yml`.
@@ -2998,6 +3000,9 @@ class GreatDocs:
         dir_titles
             Optional mapping of subdirectory names (after prefix stripping) to
             custom sidebar section titles.
+        sidebar_groups
+            Optional list of group dicts for organizing flat pages into sidebar sections. Each dict
+            has `section` (title) and `contents` (list of page filenames without numeric prefix).
         """
         quarto_yml = self.project_path / "_quarto.yml"
         config = self._read_quarto_config(quarto_yml)
@@ -3011,53 +3016,89 @@ class GreatDocs:
             # Add index as the first item when one exists
             contents.append({"text": title, "href": f"{slug}/index.qmd"})
 
-        # Add each page (except index.qmd), grouping by subdirectory
-        # into sidebar section headers when subdirectories are present.
-        from pathlib import PurePosixPath
-
-        subdir_groups: dict[str, list[dict]] = {}
-        top_level_pages: list[dict] = []
-
+        # Build a filename -> page dict lookup for grouped sidebar
+        page_by_filename: dict[str, dict] = {}
         for page in pages:
-            if page["filename"] == "index.qmd":
-                continue
-            parts = PurePosixPath(page["filename"]).parts
-            if len(parts) > 1:
-                # Page is in a subdirectory — group by parent dir
-                subdir = parts[0]  # pragma: no cover
-                subdir_groups.setdefault(subdir, []).append(page)  # pragma: no cover
-            else:
-                top_level_pages.append(page)
+            if page["filename"] != "index.qmd":
+                page_by_filename[page["filename"]] = page
 
-        # Add top-level pages first
-        for page in top_level_pages:
-            contents.append(
-                {
-                    "text": page["title"],
-                    "href": f"{slug}/{page['filename']}",
-                }
-            )
+        if sidebar_groups:
+            # Use explicit sidebar groups to organize flat pages into sections
+            grouped_filenames: set[str] = set()
+            for group in sidebar_groups:
+                section_title = group.get("section", "")
+                group_contents_cfg = group.get("contents", [])
+                section_contents = []
+                for filename in group_contents_cfg:
+                    # Match against stripped filenames in page_by_filename
+                    page = page_by_filename.get(filename)
+                    if page:
+                        section_contents.append(
+                            {
+                                "text": page["title"],
+                                "href": f"{slug}/{page['filename']}",
+                            }
+                        )
+                        grouped_filenames.add(filename)
+                if section_contents:
+                    contents.append({"section": section_title, "contents": section_contents})
 
-        # Add subdirectory groups as section headers
-        if dir_titles is None:
-            dir_titles = {}
-        for subdir in sorted(subdir_groups.keys()):
-            clean_subdir = self._strip_numeric_prefix(subdir)  # pragma: no cover
-            section_title = dir_titles.get(  # pragma: no cover
-                clean_subdir,
-                clean_subdir.replace("-", " ").replace("_", " ").title(),
-            )  # pragma: no cover
-            section_contents = []  # pragma: no cover
-            for page in subdir_groups[subdir]:  # pragma: no cover
-                section_contents.append(  # pragma: no cover
+            # Add any ungrouped pages at the end
+            for filename, page in page_by_filename.items():
+                if filename not in grouped_filenames:
+                    contents.append(
+                        {
+                            "text": page["title"],
+                            "href": f"{slug}/{page['filename']}",
+                        }
+                    )
+        else:
+            # Default: flat listing with optional subdirectory grouping
+            from pathlib import PurePosixPath
+
+            subdir_groups_dict: dict[str, list[dict]] = {}
+            top_level_pages: list[dict] = []
+
+            for page in pages:
+                if page["filename"] == "index.qmd":
+                    continue
+                parts = PurePosixPath(page["filename"]).parts
+                if len(parts) > 1:
+                    # Page is in a subdirectory — group by parent dir
+                    subdir = parts[0]  # pragma: no cover
+                    subdir_groups_dict.setdefault(subdir, []).append(page)  # pragma: no cover
+                else:
+                    top_level_pages.append(page)
+
+            # Add top-level pages first
+            for page in top_level_pages:
+                contents.append(
                     {
                         "text": page["title"],
                         "href": f"{slug}/{page['filename']}",
                     }
                 )
-            contents.append(
-                {"section": section_title, "contents": section_contents}
-            )  # pragma: no cover
+
+            # Add subdirectory groups as section headers
+            if dir_titles is None:
+                dir_titles = {}
+            for subdir in sorted(subdir_groups_dict.keys()):
+                clean_subdir = self._strip_numeric_prefix(subdir)  # pragma: no cover
+                section_title = dir_titles.get(  # pragma: no cover
+                    clean_subdir,
+                    clean_subdir.replace("-", " ").replace("_", " ").title(),
+                )  # pragma: no cover
+                section_contents = []  # pragma: no cover
+                for page in subdir_groups_dict[subdir]:  # pragma: no cover
+                    section_contents.append(  # pragma: no cover
+                        {
+                            "text": page["title"],
+                            "href": f"{slug}/{page['filename']}",
+                        }
+                    )
+                contents.append(
+                    {"section": section_title, "contents": section_contents}
+                )  # pragma: no cover
 
         # Skip sidebar when a section has only a single page — the lone item
         # provides no navigation value and wastes horizontal space.  Without a

--- a/recipes/21-enable-multi-version-docs.qmd
+++ b/recipes/21-enable-multi-version-docs.qmd
@@ -2,7 +2,8 @@
 title: "Enable Multi-Version Documentation"
 description: "Add a version selector to your documentation site so users can switch between releases."
 tags: [Configuration, Versioning, Build]
-versions: ["dev"]
+versions: ">=0.7"
+upcoming: "0.8"
 ---
 
 # Enable Multi-Version Documentation

--- a/recipes/22-use-version-fences-and-badges.qmd
+++ b/recipes/22-use-version-fences-and-badges.qmd
@@ -2,7 +2,8 @@
 title: "Use Version Fences and Badges"
 description: "Annotate content with version fences, inline badges, and callouts to show version-specific information."
 tags: [Versioning, Authoring]
-versions: ["dev"]
+versions: ">=0.7"
+upcoming: "0.8"
 ---
 
 # Use Version Fences and Badges


### PR DESCRIPTION
This PR introduces a new way to organize documentation items into themed sidebar groups, improving both navigation and discoverability. It adds support for explicit sidebar groupings in the configuration, updates the sidebar generation logic to handle these groups, and reorganizes the documentation index and configuration accordingly.