### PR TITLE
feat: swatch extension

### DIFF
--- a/assets/color-data/demo-brand.yml
+++ b/assets/color-data/demo-brand.yml
@@ -1,0 +1,10 @@
+- name: Primary
+  hex: "#2563eb"
+- name: Secondary
+  hex: "#6b7280"
+- name: Accent
+  hex: "#f97316"
+- name: Success
+  hex: "#22c55e"
+- name: Error
+  hex: "#ef4444"

--- a/assets/color-data/demo-contrast.yml
+++ b/assets/color-data/demo-contrast.yml
@@ -1,0 +1,4 @@
+- name: Dark Slate
+  hex: "#1e293b"
+- name: Light Gray
+  hex: "#f1f5f9"

--- a/assets/color-data/demo-extend-accent.yml
+++ b/assets/color-data/demo-extend-accent.yml
@@ -1,0 +1,2 @@
+- name: Brand Accent
+  hex: "#ff6b6b"

--- a/assets/color-data/demo-minimal.yml
+++ b/assets/color-data/demo-minimal.yml
@@ -1,0 +1,6 @@
+- name: Rose
+  hex: "#fb7185"
+- name: Violet
+  hex: "#a78bfa"
+- name: Teal
+  hex: "#2dd4bf"

--- a/assets/color-data/demo-quick-start.yml
+++ b/assets/color-data/demo-quick-start.yml
@@ -1,0 +1,6 @@
+- name: Sky Blue
+  hex: "#38bdf8"
+- name: Deep Navy
+  hex: "#1e3a5f"
+- name: Coral
+  hex: "#f97316"

--- a/assets/color-data/demo-rectangles.yml
+++ b/assets/color-data/demo-rectangles.yml
@@ -1,0 +1,6 @@
+- name: Primary
+  hex: "#2563eb"
+- name: Secondary
+  hex: "#6b7280"
+- name: Accent
+  hex: "#f97316"

--- a/assets/color-data/demo-single.yml
+++ b/assets/color-data/demo-single.yml
@@ -1,0 +1,2 @@
+- name: Large
+  hex: "#8b5cf6"

--- a/assets/color-data/demo-title.yml
+++ b/assets/color-data/demo-title.yml
@@ -1,0 +1,4 @@
+- name: Blue
+  hex: "#2563eb"
+- name: Orange
+  hex: "#f97316"

--- a/great-docs.yml
+++ b/great-docs.yml
@@ -249,6 +249,7 @@ nav_icons:
     Docs Linting: list-checks
     API Evolution: git-compare-arrows
     Versioned Docs: git-branch
+    Color Swatches: pipette
 
 # Author Information
 # ------------------

--- a/great_docs/assets/_extensions/color-swatch/_color_swatch_shortcode.py
+++ b/great_docs/assets/_extensions/color-swatch/_color_swatch_shortcode.py
@@ -1,0 +1,680 @@
+"""Color swatch shortcode helper.
+
+Called by `color-swatch.lua` via `io.popen`.  Reads an optional YAML body
+from *stdin* (when the shortcode has inner content) or loads a built-in GD
+palette preset, computes APCA contrast values, and emits self-contained HTML
+for the requested display mode.
+"""
+
+from __future__ import annotations
+
+import argparse
+import colorsys
+import html as html_mod
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Module bootstrap — load contrast helpers from great_docs.contrast
+# ---------------------------------------------------------------------------
+
+_parse_color = None
+_ideal_text_color = None
+_apca_contrast = None
+_relative_luminance_apca = None
+
+
+def _load_contrast_module() -> None:
+    global _parse_color, _ideal_text_color, _apca_contrast, _relative_luminance_apca
+
+    # Fast path: great_docs is installed
+    try:
+        from great_docs.contrast import (
+            _apca_contrast as _ac,
+        )
+        from great_docs.contrast import (
+            _relative_luminance_apca as _rl,
+        )
+        from great_docs.contrast import (
+            ideal_text_color as _itc,
+        )
+        from great_docs.contrast import (
+            parse_color as _pc,
+        )
+
+        _parse_color = _pc
+        _ideal_text_color = _itc
+        _apca_contrast = _ac
+        _relative_luminance_apca = _rl
+        return
+    except Exception:
+        pass
+
+    # Walk ancestors to find contrast.py
+    cur = Path(__file__).resolve().parent
+    for ancestor in cur.parents:
+        contrast_path = ancestor / "great_docs" / "contrast.py"
+        if contrast_path.exists():
+            spec = importlib.util.spec_from_file_location("contrast", contrast_path)
+            mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+            spec.loader.exec_module(mod)  # type: ignore[union-attr]
+            _parse_color = mod.parse_color
+            _ideal_text_color = mod.ideal_text_color
+            _apca_contrast = mod._apca_contrast
+            _relative_luminance_apca = mod._relative_luminance_apca
+            return
+
+    raise ImportError("Cannot locate great_docs/contrast.py")
+
+
+_load_contrast_module()
+
+# ---------------------------------------------------------------------------
+# Built-in GD palette presets
+# ---------------------------------------------------------------------------
+
+GD_PALETTES: dict[str, dict[str, Any]] = {
+    "sky": {
+        "description": "Soft sky blues",
+        "light": [
+            {"name": "Sky 100", "hex": "#e0f4ff"},
+            {"name": "Sky 200", "hex": "#d0ecf9"},
+            {"name": "Sky 300", "hex": "#c5e8f7"},
+            {"name": "Sky 400", "hex": "#b8e0f5"},
+        ],
+        "dark": [
+            {"name": "Sky 100", "hex": "#0096c7"},
+            {"name": "Sky 200", "hex": "#0077b6"},
+            {"name": "Sky 300", "hex": "#005f73"},
+            {"name": "Sky 400", "hex": "#023e8a"},
+        ],
+        "gradient": {
+            "angle": -45,
+            "duration": "15s",
+            "timing": "ease",
+            "iteration": "infinite",
+            "background_size": "400% 400%",
+        },
+    },
+    "peach": {
+        "description": "Peach and blush",
+        "light": [
+            {"name": "Peach 100", "hex": "#ffe4cc"},
+            {"name": "Peach 200", "hex": "#ffddc1"},
+            {"name": "Peach 300", "hex": "#fdd0d8"},
+            {"name": "Peach 400", "hex": "#fbc4d4"},
+        ],
+        "dark": [
+            {"name": "Peach 100", "hex": "#c7760f"},
+            {"name": "Peach 200", "hex": "#cc4a1a"},
+            {"name": "Peach 300", "hex": "#b84a5f"},
+            {"name": "Peach 400", "hex": "#a33560"},
+        ],
+        "gradient": {
+            "angle": -45,
+            "duration": "15s",
+            "timing": "ease",
+            "iteration": "infinite",
+            "background_size": "400% 400%",
+        },
+    },
+    "prism": {
+        "description": "Mint, sky, and lavender",
+        "light": [
+            {"name": "Prism 100", "hex": "#d0e8f5"},
+            {"name": "Prism 200", "hex": "#c4f0e0"},
+            {"name": "Prism 300", "hex": "#e4d4f4"},
+            {"name": "Prism 400", "hex": "#d8cef0"},
+        ],
+        "dark": [
+            {"name": "Prism 100", "hex": "#0c6a8a"},
+            {"name": "Prism 200", "hex": "#048a65"},
+            {"name": "Prism 300", "hex": "#52077d"},
+            {"name": "Prism 400", "hex": "#2a0978"},
+        ],
+        "gradient": {
+            "angle": -45,
+            "duration": "15s",
+            "timing": "ease",
+            "iteration": "infinite",
+            "background_size": "400% 400%",
+        },
+    },
+    "lilac": {
+        "description": "Lilac and pink",
+        "light": [
+            {"name": "Lilac 100", "hex": "#f5d0e0"},
+            {"name": "Lilac 200", "hex": "#e8d0f0"},
+            {"name": "Lilac 300", "hex": "#f0d4f8"},
+            {"name": "Lilac 400", "hex": "#eac8ee"},
+        ],
+        "dark": [
+            {"name": "Lilac 100", "hex": "#8b1140"},
+            {"name": "Lilac 200", "hex": "#561e64"},
+            {"name": "Lilac 300", "hex": "#a02db3"},
+            {"name": "Lilac 400", "hex": "#6e1a7d"},
+        ],
+        "gradient": {
+            "angle": -45,
+            "duration": "15s",
+            "timing": "ease",
+            "iteration": "infinite",
+            "background_size": "400% 400%",
+        },
+    },
+    "slate": {
+        "description": "Cool grays",
+        "light": [
+            {"name": "Slate 100", "hex": "#eceff1"},
+            {"name": "Slate 200", "hex": "#e0e4e8"},
+            {"name": "Slate 300", "hex": "#dde2e6"},
+            {"name": "Slate 400", "hex": "#d5dadf"},
+        ],
+        "dark": [
+            {"name": "Slate 100", "hex": "#455a64"},
+            {"name": "Slate 200", "hex": "#37474f"},
+            {"name": "Slate 300", "hex": "#3e525e"},
+            {"name": "Slate 400", "hex": "#263238"},
+        ],
+        "gradient": {
+            "angle": -45,
+            "duration": "15s",
+            "timing": "ease",
+            "iteration": "infinite",
+            "background_size": "400% 400%",
+        },
+    },
+    "honey": {
+        "description": "Warm cream and apricot",
+        "light": [
+            {"name": "Honey 100", "hex": "#ffedcc"},
+            {"name": "Honey 200", "hex": "#ffe0c2"},
+            {"name": "Honey 300", "hex": "#ffe5b4"},
+            {"name": "Honey 400", "hex": "#ffd6a8"},
+        ],
+        "dark": [
+            {"name": "Honey 100", "hex": "#e65100"},
+            {"name": "Honey 200", "hex": "#bf360c"},
+            {"name": "Honey 300", "hex": "#ef6c00"},
+            {"name": "Honey 400", "hex": "#b71c1c"},
+        ],
+        "gradient": {
+            "angle": -45,
+            "duration": "15s",
+            "timing": "ease",
+            "iteration": "infinite",
+            "background_size": "400% 400%",
+        },
+    },
+    "dusk": {
+        "description": "Soft lavender-blue",
+        "light": [
+            {"name": "Dusk 100", "hex": "#dddff5"},
+            {"name": "Dusk 200", "hex": "#d8daf0"},
+            {"name": "Dusk 300", "hex": "#d4d0ee"},
+            {"name": "Dusk 400", "hex": "#dad4f2"},
+        ],
+        "dark": [
+            {"name": "Dusk 100", "hex": "#141b55"},
+            {"name": "Dusk 200", "hex": "#0d1244"},
+            {"name": "Dusk 300", "hex": "#1a0f52"},
+            {"name": "Dusk 400", "hex": "#261560"},
+        ],
+        "gradient": {
+            "angle": -45,
+            "duration": "15s",
+            "timing": "ease",
+            "iteration": "infinite",
+            "background_size": "400% 400%",
+        },
+    },
+    "mint": {
+        "description": "Pale aqua",
+        "light": [
+            {"name": "Mint 100", "hex": "#d5f0ec"},
+            {"name": "Mint 200", "hex": "#ccece8"},
+            {"name": "Mint 300", "hex": "#c4e8e4"},
+            {"name": "Mint 400", "hex": "#d0f2ee"},
+        ],
+        "dark": [
+            {"name": "Mint 100", "hex": "#00796b"},
+            {"name": "Mint 200", "hex": "#00695c"},
+            {"name": "Mint 300", "hex": "#004d40"},
+            {"name": "Mint 400", "hex": "#00897b"},
+        ],
+        "gradient": {
+            "angle": -45,
+            "duration": "15s",
+            "timing": "ease",
+            "iteration": "infinite",
+            "background_size": "400% 400%",
+        },
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Color utility helpers
+# ---------------------------------------------------------------------------
+
+
+def hex_to_rgb(hex_str: str) -> tuple[int, int, int]:
+    """Convert a hex color string to (R, G, B) using `contrast.parse_color`."""
+    return _parse_color(hex_str)  # type: ignore[return-value]
+
+
+def rgb_to_hsl(r: int, g: int, b: int) -> tuple[int, int, int]:
+    """Convert RGB (0-255) to HSL (degrees, percent, percent), rounded to ints."""
+    h, l, s = colorsys.rgb_to_hls(r / 255.0, g / 255.0, b / 255.0)
+    return (round(h * 360) % 360, round(s * 100), round(l * 100))
+
+
+def needs_border_ring(hex_str: str) -> tuple[bool, str]:
+    """Determine if a swatch needs a border ring and return the ring color.
+
+    Very light colors (luminance > 0.93) get a slightly darker ring.
+    Very dark colors (luminance < 0.07) get a slightly lighter ring.
+    Returns `(needs_ring, ring_color_hex)`.
+    """
+    r, g, b = hex_to_rgb(hex_str)
+    lum = _relative_luminance_apca(r, g, b)  # type: ignore[misc]
+
+    if lum > 0.93:
+        # Darken by 10%
+        dr = max(0, int(r * 0.9))
+        dg = max(0, int(g * 0.9))
+        db = max(0, int(b * 0.9))
+        return True, f"#{dr:02x}{dg:02x}{db:02x}"
+    if lum < 0.07:
+        # Lighten by mixing with white
+        lr = min(255, r + 40)
+        lg = min(255, g + 40)
+        lb = min(255, b + 40)
+        return True, f"#{lr:02x}{lg:02x}{lb:02x}"
+
+    return False, ""
+
+
+def compute_contrast_info(hex_str: str) -> dict[str, Any]:
+    """Compute APCA contrast values for a color against white and black."""
+    r, g, b = hex_to_rgb(hex_str)
+    lum = _relative_luminance_apca(r, g, b)  # type: ignore[misc]
+    white_lum = _relative_luminance_apca(255, 255, 255)  # type: ignore[misc]
+    black_lum = _relative_luminance_apca(0, 0, 0)  # type: ignore[misc]
+
+    lc_vs_white = abs(_apca_contrast(white_lum, lum))  # type: ignore[misc]
+    lc_vs_black = abs(_apca_contrast(black_lum, lum))  # type: ignore[misc]
+
+    ideal = _ideal_text_color(hex_str)  # type: ignore[misc]
+
+    # WCAG AA via APCA: normal text >= 60 Lc, large >= 45, non-text >= 30
+    best_lc = max(lc_vs_white, lc_vs_black)
+    aa_normal = best_lc >= 60
+    aa_large = best_lc >= 45
+
+    return {
+        "lc_vs_white": round(lc_vs_white, 1),
+        "lc_vs_black": round(lc_vs_black, 1),
+        "ideal_text": ideal,
+        "aa_normal": aa_normal,
+        "aa_large": aa_large,
+    }
+
+
+# ---------------------------------------------------------------------------
+# YAML parsing
+# ---------------------------------------------------------------------------
+
+try:
+    import yaml as _yaml
+
+    def _parse_yaml(text: str) -> list[dict[str, Any]]:
+        data = _yaml.safe_load(text)
+        if isinstance(data, list):
+            return data
+        return []
+
+except ImportError:
+    # Minimal YAML-subset parser for simple list-of-dicts (no external dep)
+
+    def _parse_yaml(text: str) -> list[dict[str, Any]]:  # type: ignore[misc]
+        """Parse a trivial YAML list of dicts (single-level, string values)."""
+        items: list[dict[str, Any]] = []
+        current: dict[str, Any] | None = None
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if stripped.startswith("- "):
+                # New item — may have key on same line
+                if current is not None:
+                    items.append(current)
+                current = {}
+                rest = stripped[2:].strip()
+                if ":" in rest:
+                    k, v = rest.split(":", 1)
+                    current[k.strip()] = v.strip().strip("\"'")
+            elif ":" in stripped and current is not None:
+                k, v = stripped.split(":", 1)
+                current[k.strip()] = v.strip().strip("\"'")
+        if current is not None:
+            items.append(current)
+        return items
+
+
+def parse_colors(body: str, palette: str) -> list[dict[str, Any]]:
+    """Resolve the color list from body YAML and/or a palette preset."""
+    colors: list[dict[str, Any]] = []
+
+    if palette:
+        if palette == "all":
+            for name, preset in GD_PALETTES.items():
+                for c in preset["light"]:
+                    colors.append({**c, "group": name.capitalize()})
+        elif palette in GD_PALETTES:
+            colors.extend(GD_PALETTES[palette]["light"])
+        else:
+            raise ValueError(f"Unknown palette: {palette!r}")
+
+    if body.strip():
+        parsed = _parse_yaml(body)
+        for entry in parsed:
+            if "hex" not in entry or "name" not in entry:
+                continue
+            colors.append(entry)
+
+    return colors
+
+
+# ---------------------------------------------------------------------------
+# Tooltip HTML
+# ---------------------------------------------------------------------------
+
+
+def _esc(text: str) -> str:
+    return html_mod.escape(text, quote=True)
+
+
+def build_tooltip_html(color: dict[str, Any], show_contrast: str) -> str:
+    """Build the rich tooltip HTML for a single swatch."""
+    hex_val = color["hex"]
+    name = color.get("name", hex_val)
+    r, g, b = hex_to_rgb(hex_val)
+    h, s, l = rgb_to_hsl(r, g, b)
+
+    parts = [
+        '<div class="gd-cs-tooltip">',
+        f'<div class="gd-cs-tooltip-swatch" style="background:{_esc(hex_val)}"></div>',
+        '<div class="gd-cs-tooltip-body">',
+        f'<div class="gd-cs-tooltip-name">{_esc(name)}</div>',
+        '<table class="gd-cs-tooltip-table">',
+        f"<tr><td>HEX</td><td><code>{_esc(hex_val)}</code>"
+        f' <button class="gd-cs-tooltip-copy" data-hex="{_esc(hex_val)}" '
+        f'aria-label="Copy hex value" title="Copy">&#128203;</button></td></tr>',
+        f"<tr><td>RGB</td><td>{r}, {g}, {b}</td></tr>",
+        f"<tr><td>HSL</td><td>{h}&deg;, {s}%, {l}%</td></tr>",
+    ]
+
+    if show_contrast != "false":
+        info = compute_contrast_info(hex_val)
+        parts.append('<tr><td colspan="2" class="gd-cs-tooltip-sep"></td></tr>')
+        parts.append(f"<tr><td>vs White</td><td>{info['lc_vs_white']} Lc</td></tr>")
+        parts.append(f"<tr><td>vs Black</td><td>{info['lc_vs_black']} Lc</td></tr>")
+        verdict = "&#10003; AA" if info["aa_normal"] else "&#10007; AA"
+        css_cls = "gd-cs-pass" if info["aa_normal"] else "gd-cs-fail"
+        parts.append(f'<tr><td>WCAG</td><td class="{css_cls}">{verdict} (normal)</td></tr>')
+
+    parts.append("</table></div></div>")
+    return "".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# HTML renderers
+# ---------------------------------------------------------------------------
+
+_ID_COUNTER = 0
+
+
+def _next_id() -> str:
+    global _ID_COUNTER
+    _ID_COUNTER += 1
+    return f"gd-cs-{_ID_COUNTER}"
+
+
+def render_circles(
+    colors: list[dict[str, Any]],
+    *,
+    size: str = "56px",
+    show_contrast: str = "true",
+    show_names: str = "true",
+    show_hex: str = "true",
+    copy_format: str = "hex",
+    title: str = "",
+    description: str = "",
+    elem_id: str = "",
+    extra_class: str = "",
+    border: str = "true",
+) -> str:
+    """Render colors as circle swatches."""
+    cid = elem_id or _next_id()
+    cls = "gd-color-swatch gd-color-swatch--circles"
+    if border == "true":
+        cls += " gd-color-swatch--bordered"
+    if extra_class:
+        cls += " " + extra_class
+
+    parts = [
+        f'<div class="{cls}" id="{_esc(cid)}" data-copy-format="{_esc(copy_format)}" data-mode="circles" style="--gd-cs-size:{_esc(size)}">'
+    ]
+
+    if title:
+        parts.append(f'<div class="gd-cs-title">{_esc(title)}</div>')
+    if description:
+        parts.append(f'<div class="gd-cs-description">{_esc(description)}</div>')
+
+    parts.append('<div class="gd-cs-swatches">')
+
+    for color in colors:
+        hex_val = color["hex"]
+        name = color.get("name", hex_val)
+        ring, ring_color = needs_border_ring(hex_val)
+        tooltip = build_tooltip_html(color, show_contrast)
+
+        # Inline contrast info
+        contrast_inline = ""
+        if show_contrast == "inline":
+            info = compute_contrast_info(hex_val)
+            contrast_inline = f'<span class="gd-swatch-contrast">{info["lc_vs_white"]}/{info["lc_vs_black"]} Lc</span>'
+
+        ring_attr = ""
+        ring_style = ""
+        if ring:
+            ring_attr = ' data-needs-ring="true"'
+            ring_style = f";--gd-ring-color:{ring_color}"
+
+        # Escape tooltip HTML for data attribute (double-encode quotes)
+        tooltip_escaped = _esc(tooltip)
+
+        parts.append(
+            f'<div class="gd-swatch" role="button" tabindex="0" '
+            f'aria-label="{_esc(name)}, hex {_esc(hex_val)}, click to copy">'
+            f'<div class="gd-swatch-color" style="background:{_esc(hex_val)}{ring_style}"'
+            f'{ring_attr} data-hex="{_esc(hex_val)}" '
+            f'data-tooltip-html="{tooltip_escaped}"></div>'
+        )
+        if show_names == "true":
+            parts.append(f'<span class="gd-swatch-name">{_esc(name)}</span>')
+        if show_hex == "true":
+            parts.append(f'<span class="gd-swatch-hex">{_esc(hex_val)}</span>')
+        if contrast_inline:
+            parts.append(contrast_inline)
+        parts.append("</div>")
+
+    parts.append("</div></div>")
+    return "\n".join(parts)
+
+
+def render_rectangles(
+    colors: list[dict[str, Any]],
+    *,
+    show_contrast: str = "true",
+    show_names: str = "true",
+    show_hex: str = "true",
+    copy_format: str = "hex",
+    title: str = "",
+    description: str = "",
+    elem_id: str = "",
+    extra_class: str = "",
+    border: str = "true",
+) -> str:
+    """Render colors as horizontal rectangle strips."""
+    cid = elem_id or _next_id()
+    cls = "gd-color-swatch gd-color-swatch--rectangles"
+    if border == "true":
+        cls += " gd-color-swatch--bordered"
+    if extra_class:
+        cls += " " + extra_class
+
+    parts = [
+        f'<div class="{cls}" id="{_esc(cid)}" data-copy-format="{_esc(copy_format)}" data-mode="rectangles">'
+    ]
+
+    if title:
+        parts.append(f'<div class="gd-cs-title">{_esc(title)}</div>')
+    if description:
+        parts.append(f'<div class="gd-cs-description">{_esc(description)}</div>')
+
+    for color in colors:
+        hex_val = color["hex"]
+        name = color.get("name", hex_val)
+        info = compute_contrast_info(hex_val)
+        text_color = info["ideal_text"]
+        tooltip = build_tooltip_html(color, show_contrast)
+        tooltip_escaped = _esc(tooltip)
+
+        parts.append(
+            f'<div class="gd-swatch-rect" role="button" tabindex="0" '
+            f'style="background:{_esc(hex_val)};color:{_esc(text_color)}" '
+            f'data-hex="{_esc(hex_val)}" '
+            f'data-tooltip-html="{tooltip_escaped}" '
+            f'aria-label="{_esc(name)}, hex {_esc(hex_val)}, click to copy">'
+        )
+
+        if show_names == "true":
+            parts.append(f'<span class="gd-swatch-rect-name">{_esc(name)}</span>')
+        if show_hex == "true":
+            parts.append(f'<span class="gd-swatch-rect-hex">{_esc(hex_val)}</span>')
+
+        if show_contrast != "false":
+            white_cls = "gd-cs-pass" if info["lc_vs_white"] >= 60 else "gd-cs-fail"
+            black_cls = "gd-cs-pass" if info["lc_vs_black"] >= 60 else "gd-cs-fail"
+            parts.append(
+                '<span class="gd-swatch-contrast-samples">'
+                f'<span class="gd-swatch-aa-sample {white_cls}" style="color:#fff">Aa</span>'
+                f'<span class="gd-swatch-aa-sample {black_cls}" style="color:#000">Aa</span>'
+                "</span>"
+            )
+
+        parts.append("</div>")
+
+    parts.append("</div>")
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render color swatches as HTML.")
+    parser.add_argument("--palette", default="", help="GD palette preset name")
+    parser.add_argument("--mode", default="circles", help="Display mode")
+    parser.add_argument("--cols", default="4", help="Grid columns")
+    parser.add_argument("--size", default="56px", help="Swatch size")
+    parser.add_argument("--show-contrast", default="true", dest="show_contrast")
+    parser.add_argument("--show-names", default="true", dest="show_names")
+    parser.add_argument("--show-hex", default="true", dest="show_hex")
+    parser.add_argument("--copy-format", default="hex", dest="copy_format")
+    parser.add_argument("--title", default="")
+    parser.add_argument("--description", default="")
+    parser.add_argument("--file", default="", dest="file_path")
+    parser.add_argument("--height", default="200px")
+    parser.add_argument("--show-css", default="true", dest="show_css")
+    parser.add_argument("--show-details", default="true", dest="show_details")
+    parser.add_argument("--show-controls", default="true", dest="show_controls")
+    parser.add_argument("--id", default="", dest="elem_id")
+    parser.add_argument("--class", default="", dest="extra_class")
+    parser.add_argument("--border", default="true")
+
+    args = parser.parse_args()
+
+    try:
+        # Read body from stdin (may be empty)
+        body = ""
+        if not sys.stdin.isatty():
+            body = sys.stdin.read()
+
+        # Or from an external file
+        if args.file_path:
+            file_p = Path(args.file_path)
+            if not file_p.is_absolute():
+                file_p = Path(".").resolve() / file_p
+            body = file_p.read_text(encoding="utf-8")
+
+        colors = parse_colors(body, args.palette)
+
+        if not colors:
+            print(
+                "<!-- color-swatch: no colors to display -->",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        if args.mode == "circles":
+            html_out = render_circles(
+                colors,
+                size=args.size,
+                show_contrast=args.show_contrast,
+                show_names=args.show_names,
+                show_hex=args.show_hex,
+                copy_format=args.copy_format,
+                title=args.title,
+                description=args.description,
+                elem_id=args.elem_id,
+                extra_class=args.extra_class,
+                border=args.border,
+            )
+        elif args.mode == "rectangles":
+            html_out = render_rectangles(
+                colors,
+                show_contrast=args.show_contrast,
+                show_names=args.show_names,
+                show_hex=args.show_hex,
+                copy_format=args.copy_format,
+                title=args.title,
+                description=args.description,
+                elem_id=args.elem_id,
+                extra_class=args.extra_class,
+                border=args.border,
+            )
+        else:
+            print(
+                f"<!-- color-swatch: unsupported mode '{args.mode}' -->",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        print(html_out, end="")
+
+    except Exception as exc:
+        print(
+            f"<!-- color-swatch error: {exc} -->",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/great_docs/assets/_extensions/color-swatch/_extension.yml
+++ b/great_docs/assets/_extensions/color-swatch/_extension.yml
@@ -1,0 +1,7 @@
+title: Color Swatch
+author: Great Docs
+version: 1.0.0
+quarto-required: ">=1.3.0"
+contributes:
+  shortcodes:
+    - color-swatch.lua

--- a/great_docs/assets/_extensions/color-swatch/color-swatch.lua
+++ b/great_docs/assets/_extensions/color-swatch/color-swatch.lua
@@ -1,0 +1,119 @@
+-- color-swatch.lua — Quarto shortcode for color palette display
+--
+-- Usage in .qmd files:
+--
+--   {{< color-swatch >}}
+--   - name: Sky Blue
+--     hex: "#38bdf8"
+--   {{< /color-swatch >}}
+--
+--   {{< color-swatch palette="sky" >}}
+--   {{< color-swatch palette="sky" mode="rectangles" >}}
+--
+-- Calls the companion _color_swatch_shortcode.py script, which computes
+-- contrast ratios, builds tooltip data, and returns complete HTML.
+
+local function kwarg_str(kwargs, key)
+    local raw = kwargs[key]
+    if raw == nil then return "" end
+    local s = pandoc.utils.stringify(raw)
+    return s or ""
+end
+
+return {
+    ["color-swatch"] = function(args, kwargs, blocks)
+        -- Locate the helper script (lives alongside this .lua file)
+        local script_dir = debug.getinfo(1, "S").source:match("@?(.*/)") or "./"
+        local helper = script_dir .. "_color_swatch_shortcode.py"
+
+        -- Build CLI arguments
+        local cmd_args = { "python3", helper }
+
+        -- Forward all keyword arguments as CLI flags
+        local forwarded = {
+            { key = "palette",       flag = "--palette" },
+            { key = "mode",          flag = "--mode" },
+            { key = "cols",          flag = "--cols" },
+            { key = "size",          flag = "--size" },
+            { key = "show-contrast", flag = "--show-contrast" },
+            { key = "show-names",    flag = "--show-names" },
+            { key = "show-hex",      flag = "--show-hex" },
+            { key = "copy-format",   flag = "--copy-format" },
+            { key = "title",         flag = "--title" },
+            { key = "description",   flag = "--description" },
+            { key = "file",          flag = "--file" },
+            { key = "height",        flag = "--height" },
+            { key = "show-css",      flag = "--show-css" },
+            { key = "show-details",  flag = "--show-details" },
+            { key = "show-controls", flag = "--show-controls" },
+            { key = "id",            flag = "--id" },
+            { key = "class",         flag = "--class" },
+            { key = "border",        flag = "--border" },
+        }
+
+        for _, spec in ipairs(forwarded) do
+            local val = kwarg_str(kwargs, spec.key)
+            if val ~= "" then
+                table.insert(cmd_args, spec.flag)
+                table.insert(cmd_args, val)
+            end
+        end
+
+        -- Resolve --file relative to the Quarto project root
+        local file_val = kwarg_str(kwargs, "file")
+        if file_val ~= "" and file_val:sub(1, 1) ~= "/" then
+            local project_root = script_dir .. "../../"
+            -- Replace the already-inserted value
+            for i, arg in ipairs(cmd_args) do
+                if arg == "--file" and cmd_args[i + 1] == file_val then
+                    cmd_args[i + 1] = project_root .. file_val
+                    break
+                end
+            end
+        end
+
+        -- Note: Quarto shortcodes do not support paired (body) content.
+        -- The third parameter is `meta` (document metadata), not `blocks`.
+        -- Custom colors are supplied via the `file` parameter instead.
+        local body = ""
+
+        -- Build shell command: pipe body via echo into the helper
+        local parts = {}
+        for _, arg in ipairs(cmd_args) do
+            local escaped = arg:gsub("'", "'\\''")
+            table.insert(parts, "'" .. escaped .. "'")
+        end
+        local cmd_str = table.concat(parts, " ")
+
+        local cmd
+        if body ~= "" then
+            -- Pipe the YAML body via a here-document to avoid shell escaping issues
+            local body_escaped = body:gsub("'", "'\\''")
+            cmd = "printf '%s' '" .. body_escaped .. "' | " .. cmd_str .. " 2>&1"
+        else
+            cmd = cmd_str .. " 2>&1"
+        end
+
+        local handle = io.popen(cmd)
+        if not handle then
+            return pandoc.RawBlock(
+                "html",
+                "<!-- color-swatch error: failed to run helper script -->"
+            )
+        end
+
+        local result = handle:read("*a")
+        local success = handle:close()
+
+        if not success or result == "" then
+            local msg = result ~= "" and result or "unknown error"
+            msg = msg:gsub("-->", "-- >")
+            return pandoc.RawBlock(
+                "html",
+                "<!-- color-swatch error: " .. msg .. " -->"
+            )
+        end
+
+        return pandoc.RawBlock("html", result)
+    end
+}

--- a/great_docs/assets/color-swatch.js
+++ b/great_docs/assets/color-swatch.js
@@ -1,0 +1,186 @@
+/**
+ * Color Swatch Extension for Great Docs
+ *
+ * Handles Tippy.js tooltips, click-to-copy with feedback overlay,
+ * and tooltip copy buttons for the color-swatch shortcode.
+ */
+(function () {
+  "use strict";
+
+  var containers = document.querySelectorAll(".gd-color-swatch");
+  if (!containers.length) return;
+
+  // Check icon SVG for copy feedback overlay
+  var checkSvg =
+    '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" ' +
+    'fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" ' +
+    'stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>';
+
+  /**
+   * Copy text to clipboard with fallback for non-HTTPS contexts.
+   */
+  function copyToClipboard(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      return navigator.clipboard.writeText(text);
+    }
+    // Fallback: hidden textarea + execCommand
+    return new Promise(function (resolve, reject) {
+      var ta = document.createElement("textarea");
+      ta.value = text;
+      ta.style.position = "fixed";
+      ta.style.left = "-9999px";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      try {
+        document.execCommand("copy");
+        resolve();
+      } catch (err) {
+        reject(err);
+      } finally {
+        document.body.removeChild(ta);
+      }
+    });
+  }
+
+  /**
+   * Show a brief checkmark overlay on a swatch element after copying.
+   */
+  function showCopyFeedback(el) {
+    var overlay = document.createElement("div");
+    overlay.className = "gd-swatch-copy-overlay";
+    overlay.innerHTML = checkSvg;
+    el.appendChild(overlay);
+
+    // Announce for screen readers
+    var liveRegion = document.getElementById("gd-cs-live");
+    if (liveRegion) {
+      liveRegion.textContent = "Copied";
+    }
+
+    requestAnimationFrame(function () {
+      overlay.style.opacity = "1";
+      setTimeout(function () {
+        overlay.style.opacity = "0";
+        setTimeout(function () {
+          overlay.remove();
+        }, 300);
+      }, 700);
+    });
+  }
+
+  /**
+   * Get the hex value to copy from a swatch element.
+   */
+  function getHexFromEl(el) {
+    return (
+      el.getAttribute("data-hex") ||
+      el.querySelector("[data-hex]")?.getAttribute("data-hex") ||
+      ""
+    );
+  }
+
+  /**
+   * Handle click-to-copy on a swatch.
+   */
+  function handleSwatchClick(e) {
+    var el = e.currentTarget;
+    var hex = getHexFromEl(el);
+    if (!hex) return;
+
+    // Find the color fill element for the overlay
+    var colorEl = el.classList.contains("gd-swatch-color")
+      ? el
+      : el.querySelector(".gd-swatch-color") || el;
+
+    copyToClipboard(hex).then(function () {
+      showCopyFeedback(colorEl);
+    });
+  }
+
+  /**
+   * Handle keyboard activation (Enter/Space).
+   */
+  function handleSwatchKeydown(e) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleSwatchClick(e);
+    }
+  }
+
+  /**
+   * Initialize tooltips on elements with data-tooltip-html.
+   */
+  function initTooltips(container) {
+    if (typeof tippy === "undefined") return;
+
+    var els = container.querySelectorAll("[data-tooltip-html]");
+    els.forEach(function (el) {
+      var content = el.getAttribute("data-tooltip-html");
+      if (!content) return;
+
+      tippy(el, {
+        content: content,
+        allowHTML: true,
+        placement: "top",
+        delay: [150, 100],
+        interactive: true,
+        appendTo: document.body,
+        maxWidth: 320,
+        onShown: function (instance) {
+          // Attach copy handlers to tooltip copy buttons
+          var btns = instance.popper.querySelectorAll(".gd-cs-tooltip-copy");
+          btns.forEach(function (btn) {
+            btn.addEventListener("click", function (e) {
+              e.stopPropagation();
+              var hex = btn.getAttribute("data-hex");
+              if (hex) {
+                copyToClipboard(hex).then(function () {
+                  btn.textContent = "\u2713";
+                  setTimeout(function () {
+                    btn.innerHTML = "&#128203;";
+                  }, 1000);
+                });
+              }
+            });
+          });
+        },
+      });
+    });
+  }
+
+  /**
+   * Initialize a single color-swatch container.
+   */
+  function initContainer(container) {
+    // Circle swatches — click on the wrapper (.gd-swatch)
+    var swatches = container.querySelectorAll(".gd-swatch");
+    swatches.forEach(function (el) {
+      el.addEventListener("click", handleSwatchClick);
+      el.addEventListener("keydown", handleSwatchKeydown);
+    });
+
+    // Rectangle swatches — click on the strip (.gd-swatch-rect)
+    var rects = container.querySelectorAll(".gd-swatch-rect");
+    rects.forEach(function (el) {
+      el.addEventListener("click", handleSwatchClick);
+      el.addEventListener("keydown", handleSwatchKeydown);
+    });
+
+    // Tooltips (attach to color fills and rects)
+    initTooltips(container);
+  }
+
+  // Create a live region for screen reader announcements
+  if (!document.getElementById("gd-cs-live")) {
+    var live = document.createElement("div");
+    live.id = "gd-cs-live";
+    live.setAttribute("aria-live", "polite");
+    live.setAttribute("aria-atomic", "true");
+    live.className = "visually-hidden";
+    document.body.appendChild(live);
+  }
+
+  // Initialize all containers
+  containers.forEach(initContainer);
+})();

--- a/great_docs/assets/great-docs.scss
+++ b/great_docs/assets/great-docs.scss
@@ -6622,6 +6622,334 @@ h1.quarto-secondary-nav-title .gd-upcoming-icon svg {
 }
 
 
+/*-------------------------------- Color Swatch Extension --------------------------------*/
+
+/* ── Wrapper ── */
+
+.gd-color-swatch {
+    margin: 1.5rem 0;
+    border-radius: 12px;
+}
+
+.gd-color-swatch--bordered {
+    border: 1px solid var(--bs-border-color);
+}
+
+.gd-color-swatch--circles {
+    padding: 1.25rem;
+}
+
+.gd-color-swatch--rectangles {
+    overflow: hidden;
+    padding: 0;
+}
+
+/* ── Title & description ── */
+
+.gd-cs-title {
+    width: 100%;
+    font-weight: 600;
+    font-size: 1rem;
+    margin-bottom: 0.5rem;
+    color: var(--bs-body-color);
+}
+
+.gd-cs-description {
+    width: 100%;
+    font-size: 0.9375rem;
+    color: var(--bs-secondary-color);
+    margin-bottom: 1rem;
+    line-height: 1.6;
+}
+
+/* ── Circle swatches ── */
+
+.gd-cs-swatches {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(var(--gd-cs-size, 56px), 1fr));
+    gap: 1.25rem;
+}
+
+.gd-swatch {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.375rem;
+    cursor: pointer;
+    transition: transform 0.15s ease;
+
+    &:hover {
+        transform: translateY(-2px);
+    }
+
+    &:active {
+        transform: translateY(0);
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--bs-primary);
+        outline-offset: 4px;
+        border-radius: 4px;
+    }
+}
+
+.gd-swatch-color {
+    width: var(--gd-cs-size, 56px);
+    height: var(--gd-cs-size, 56px);
+    border-radius: 50%;
+    position: relative;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    transition: box-shadow 0.15s ease;
+
+    &:hover {
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+    }
+
+    &[data-needs-ring="true"] {
+        box-shadow: inset 0 0 0 1px var(--gd-ring-color), 0 2px 8px rgba(0, 0, 0, 0.1);
+    }
+}
+
+.gd-swatch-name {
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--bs-body-color);
+    text-align: center;
+    overflow-wrap: break-word;
+    word-break: break-word;
+    line-height: 1.3;
+}
+
+.gd-swatch-hex {
+    font-family: var(--bs-font-monospace);
+    font-size: 0.6875rem;
+    color: var(--bs-secondary-color);
+    text-align: center;
+}
+
+.gd-swatch-contrast {
+    font-family: var(--bs-font-monospace);
+    font-size: 0.625rem;
+    color: var(--bs-secondary-color);
+    text-align: center;
+}
+
+/* ── Rectangle swatches ── */
+
+.gd-swatch-rect {
+    display: flex;
+    align-items: center;
+    padding: 0.875rem 1.25rem;
+    cursor: pointer;
+    transition: filter 0.15s ease;
+    min-height: 56px;
+    position: relative;
+
+    &:hover {
+        filter: brightness(0.95);
+    }
+
+    &:not(:last-child) {
+        border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--bs-primary);
+        outline-offset: -2px;
+    }
+}
+
+.gd-swatch-rect-name {
+    font-weight: 600;
+    flex: 1;
+}
+
+.gd-swatch-rect-hex {
+    font-family: var(--bs-font-monospace);
+    font-size: 0.875rem;
+    margin-right: 1.5rem;
+}
+
+.gd-swatch-contrast-samples {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.gd-swatch-aa-sample {
+    font-weight: 700;
+    font-size: 0.875rem;
+    padding: 0.125rem 0.375rem;
+    border-radius: 4px;
+}
+
+/* ── Contrast pass/fail ── */
+
+.gd-cs-pass {
+    color: #16a34a;
+}
+
+.gd-cs-fail {
+    color: #dc2626;
+}
+
+/* ── Copy overlay ── */
+
+.gd-swatch-copy-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.35);
+    border-radius: inherit;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+
+    svg {
+        color: #fff;
+        width: 24px;
+        height: 24px;
+        filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.3));
+    }
+}
+
+/* ── Tooltip styles ── */
+
+.gd-cs-tooltip {
+    display: flex;
+    gap: 0.625rem;
+    padding: 0.25rem;
+    font-size: 0.8125rem;
+    min-width: 200px;
+}
+
+.gd-cs-tooltip-swatch {
+    width: 32px;
+    aspect-ratio: 1;
+    border-radius: 6px;
+    flex-shrink: 0;
+    margin-top: 2px;
+}
+
+.gd-cs-tooltip-name {
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+}
+
+.gd-cs-tooltip-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.75rem;
+
+    td {
+        padding: 1px 0;
+    }
+
+    td:first-child {
+        color: rgba(255, 255, 255, 0.55);
+        padding-right: 0.75rem;
+        white-space: nowrap;
+    }
+
+    code {
+        font-size: 0.75rem;
+        background: none;
+        padding: 0;
+    }
+}
+
+.gd-cs-tooltip-sep {
+    border-top: 1px solid var(--bs-border-color-translucent);
+    padding-top: 4px !important;
+}
+
+.gd-cs-tooltip-copy {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0 0.25rem;
+    font-size: 0.75rem;
+    opacity: 0.6;
+    transition: opacity 0.15s ease;
+
+    &:hover {
+        opacity: 1;
+    }
+}
+
+/* ── Dark mode overrides ── */
+
+html[data-bs-theme="dark"] {
+    .gd-swatch-color {
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+
+        &:hover {
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+        }
+
+        &[data-needs-ring="true"] {
+            box-shadow: inset 0 0 0 1px var(--gd-ring-color), 0 2px 8px rgba(0, 0, 0, 0.3);
+        }
+    }
+
+    .gd-swatch-rect:not(:last-child) {
+        border-bottom-color: rgba(255, 255, 255, 0.08);
+    }
+
+    .gd-swatch-rect:hover {
+        filter: brightness(1.1);
+    }
+
+    .gd-swatch-copy-overlay {
+        background: rgba(255, 255, 255, 0.25);
+    }
+
+    .gd-cs-pass {
+        color: #4ade80;
+    }
+
+    .gd-cs-fail {
+        color: #f87171;
+    }
+}
+
+/* ── Reduced motion ── */
+
+@media (prefers-reduced-motion: reduce) {
+    .gd-swatch:hover {
+        transform: none;
+    }
+
+    .gd-swatch-copy-overlay {
+        transition: none;
+    }
+}
+
+/* ── Responsive ── */
+
+@media (max-width: 575.98px) {
+    .gd-cs-swatches {
+        gap: 0.75rem;
+        grid-template-columns: repeat(auto-fill, minmax(44px, 1fr));
+    }
+
+    .gd-swatch-color {
+        width: 44px !important;
+        height: 44px !important;
+    }
+
+    .gd-swatch-rect {
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .gd-swatch-rect-hex {
+        margin-right: 0;
+    }
+}
+
+
 /*-- scss:functions --*/
 
 /*-- scss:uses --*/

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -202,6 +202,7 @@ class GreatDocs:
             "theme-init.js",
             "copy-code.js",
             "tooltips.js",
+            "color-swatch.js",
             "mermaid-renderer.js",
             "responsive-tables.js",
             "video-embed.js",
@@ -9794,6 +9795,7 @@ body-classes: "gd-homepage"
             "theme-init.js",
             "copy-code.js",
             "tooltips.js",
+            "color-swatch.js",
             "mermaid-renderer.js",
             "responsive-tables.js",
             "video-embed.js",
@@ -10417,6 +10419,33 @@ body-classes: "gd-homepage"
         )
         if not has_tooltips:
             config["format"]["html"]["include-after-body"].append(tooltips_script_entry)
+
+        # Add color-swatch script (always enabled — loaded after tooltips)
+        # Use inline loader to resolve path relative to site root (Quarto does not
+        # rewrite bare src= paths for scripts appended after its processing pass).
+        color_swatch_entry = {
+            "text": (
+                "<script>"
+                "(function(){var s=document.createElement('script');"
+                "s.src=(document.querySelector('link[rel=\"canonical\"]')||{href:location.href})"
+                ".href.replace(/\\/[^\\/]*$/,'').replace(/\\/[^\\/]*$/,'')+'/color-swatch.js';"
+                "var h=document.currentScript;"
+                "h.parentNode.insertBefore(s,h.nextSibling);})()"
+                "</script>"
+            )
+        }
+        # Remove any stale plain <script src="color-swatch.js"> entries so the
+        # dynamic loader below is used instead.
+        config["format"]["html"]["include-after-body"] = [
+            item
+            for item in config["format"]["html"]["include-after-body"]
+            if not (
+                isinstance(item, dict)
+                and "color-swatch.js" in item.get("text", "")
+                and "createElement" not in item.get("text", "")
+            )
+        ]
+        config["format"]["html"]["include-after-body"].append(color_swatch_entry)
 
         # Add responsive tables script (always enabled — wraps tables in scroll containers)
         responsive_tables_script_entry = {"text": '<script src="responsive-tables.js"></script>'}

--- a/tests/test_color_swatch.py
+++ b/tests/test_color_swatch.py
@@ -1,0 +1,343 @@
+"""Tests for the {{< color-swatch >}} Quarto shortcode extension."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+def _ext_dir() -> Path:
+    return Path(__file__).parent.parent / "great_docs" / "assets" / "_extensions" / "color-swatch"
+
+
+def _helper() -> Path:
+    return _ext_dir() / "_color_swatch_shortcode.py"
+
+
+# ---------------------------------------------------------------------------
+# Extension files
+# ---------------------------------------------------------------------------
+
+
+class TestColorSwatchExtensionFiles:
+    """Verify that the color-swatch extension ships the required files."""
+
+    def test_extension_yml_exists(self):
+        assert (_ext_dir() / "_extension.yml").exists()
+
+    def test_lua_filter_exists(self):
+        assert (_ext_dir() / "color-swatch.lua").exists()
+
+    def test_python_bridge_exists(self):
+        assert _helper().exists()
+
+    def test_extension_yml_declares_shortcode(self):
+        ext_yml = _ext_dir() / "_extension.yml"
+        data = yaml.safe_load(ext_yml.read_text())
+        assert "contributes" in data
+        assert "shortcodes" in data["contributes"]
+        assert "color-swatch.lua" in data["contributes"]["shortcodes"]
+
+    def test_lua_defines_color_swatch_function(self):
+        lua_src = (_ext_dir() / "color-swatch.lua").read_text()
+        assert '["color-swatch"]' in lua_src
+        assert "function(args, kwargs, blocks)" in lua_src
+
+
+# ---------------------------------------------------------------------------
+# Python helper — importable unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestHelperImports:
+    """Verify the Python helper can be imported and its core utilities work."""
+
+    @pytest.fixture(autouse=True)
+    def _import_helper(self):
+        """Import the helper module dynamically."""
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("_color_swatch_shortcode", _helper())
+        self.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.mod)
+
+    # -- hex_to_rgb --
+
+    def test_hex_to_rgb_six_digit(self):
+        assert self.mod.hex_to_rgb("#38bdf8") == (56, 189, 248)
+
+    def test_hex_to_rgb_three_digit(self):
+        assert self.mod.hex_to_rgb("#fff") == (255, 255, 255)
+
+    def test_hex_to_rgb_named_color(self):
+        assert self.mod.hex_to_rgb("red") == (255, 0, 0)
+
+    def test_hex_to_rgb_invalid_raises(self):
+        with pytest.raises(ValueError):
+            self.mod.hex_to_rgb("not-a-color")
+
+    # -- rgb_to_hsl --
+
+    def test_rgb_to_hsl_red(self):
+        h, s, l = self.mod.rgb_to_hsl(255, 0, 0)
+        assert h == 0
+        assert s == 100
+        assert l == 50
+
+    def test_rgb_to_hsl_white(self):
+        h, s, l = self.mod.rgb_to_hsl(255, 255, 255)
+        assert s == 0
+        assert l == 100
+
+    def test_rgb_to_hsl_black(self):
+        h, s, l = self.mod.rgb_to_hsl(0, 0, 0)
+        assert s == 0
+        assert l == 0
+
+    # -- needs_border_ring --
+
+    def test_ring_very_light(self):
+        ring, color = self.mod.needs_border_ring("#fefefe")
+        assert ring is True
+        assert color.startswith("#")
+
+    def test_ring_very_dark(self):
+        ring, color = self.mod.needs_border_ring("#010101")
+        assert ring is True
+        assert color.startswith("#")
+
+    def test_ring_mid_range(self):
+        ring, _ = self.mod.needs_border_ring("#808080")
+        assert ring is False
+
+    # -- compute_contrast_info --
+
+    def test_contrast_info_keys(self):
+        info = self.mod.compute_contrast_info("#38bdf8")
+        assert "lc_vs_white" in info
+        assert "lc_vs_black" in info
+        assert "ideal_text" in info
+        assert "aa_normal" in info
+        assert "aa_large" in info
+
+    def test_contrast_white_on_white(self):
+        info = self.mod.compute_contrast_info("#ffffff")
+        assert info["lc_vs_white"] == 0.0
+
+    def test_contrast_black_has_high_lc(self):
+        info = self.mod.compute_contrast_info("#000000")
+        assert info["lc_vs_white"] > 90
+
+    # -- GD_PALETTES --
+
+    def test_all_palettes_defined(self):
+        names = {"sky", "peach", "prism", "lilac", "slate", "honey", "dusk", "mint"}
+        assert names == set(self.mod.GD_PALETTES.keys())
+
+    def test_palette_has_light_and_dark(self):
+        for name, preset in self.mod.GD_PALETTES.items():
+            assert "light" in preset, f"{name} missing 'light'"
+            assert "dark" in preset, f"{name} missing 'dark'"
+            assert len(preset["light"]) > 0
+            assert len(preset["dark"]) > 0
+
+    def test_palette_colors_have_name_and_hex(self):
+        for name, preset in self.mod.GD_PALETTES.items():
+            for c in preset["light"] + preset["dark"]:
+                assert "name" in c, f"{name}: color missing 'name'"
+                assert "hex" in c, f"{name}: color missing 'hex'"
+
+    # -- parse_colors --
+
+    def test_parse_colors_palette(self):
+        colors = self.mod.parse_colors("", "sky")
+        assert len(colors) == 4
+        assert all("hex" in c for c in colors)
+
+    def test_parse_colors_all(self):
+        colors = self.mod.parse_colors("", "all")
+        assert len(colors) == 8 * 4  # 8 presets × 4 colors each
+
+    def test_parse_colors_unknown_palette(self):
+        with pytest.raises(ValueError, match="Unknown palette"):
+            self.mod.parse_colors("", "nonexistent")
+
+    def test_parse_colors_yaml_body(self):
+        body = '- name: Test\n  hex: "#ff0000"\n'
+        colors = self.mod.parse_colors(body, "")
+        assert len(colors) == 1
+        assert colors[0]["hex"] == "#ff0000"
+
+    def test_parse_colors_palette_plus_body(self):
+        body = '- name: Extra\n  hex: "#abcdef"\n'
+        colors = self.mod.parse_colors(body, "sky")
+        assert len(colors) == 5  # 4 from sky + 1 from body
+
+    def test_parse_colors_empty(self):
+        colors = self.mod.parse_colors("", "")
+        assert colors == []
+
+    # -- render_circles --
+
+    def test_render_circles_basic(self):
+        colors = [
+            {"name": "Red", "hex": "#ff0000"},
+            {"name": "Blue", "hex": "#0000ff"},
+        ]
+        html = self.mod.render_circles(colors)
+        assert "gd-color-swatch--circles" in html
+        assert "#ff0000" in html
+        assert "#0000ff" in html
+        assert "Red" in html
+        assert "Blue" in html
+        assert 'role="button"' in html
+        assert "data-tooltip-html" in html
+
+    def test_render_circles_no_names(self):
+        colors = [{"name": "Red", "hex": "#ff0000"}]
+        html = self.mod.render_circles(colors, show_names="false")
+        assert "gd-swatch-name" not in html
+
+    def test_render_circles_no_hex(self):
+        colors = [{"name": "Red", "hex": "#ff0000"}]
+        html = self.mod.render_circles(colors, show_hex="false")
+        assert "gd-swatch-hex" not in html
+
+    def test_render_circles_inline_contrast(self):
+        colors = [{"name": "Red", "hex": "#ff0000"}]
+        html = self.mod.render_circles(colors, show_contrast="inline")
+        assert "gd-swatch-contrast" in html
+
+    def test_render_circles_custom_size(self):
+        colors = [{"name": "Red", "hex": "#ff0000"}]
+        html = self.mod.render_circles(colors, size="80px")
+        assert "--gd-cs-size:80px" in html
+
+    def test_render_circles_title(self):
+        colors = [{"name": "Red", "hex": "#ff0000"}]
+        html = self.mod.render_circles(colors, title="My Palette")
+        assert "My Palette" in html
+        assert "gd-cs-title" in html
+
+    # -- render_rectangles --
+
+    def test_render_rectangles_basic(self):
+        colors = [
+            {"name": "Green", "hex": "#22c55e"},
+            {"name": "Navy", "hex": "#1e3a5f"},
+        ]
+        html = self.mod.render_rectangles(colors)
+        assert "gd-color-swatch--rectangles" in html
+        assert "#22c55e" in html
+        assert "Green" in html
+        assert "gd-swatch-rect" in html
+        assert "gd-swatch-aa-sample" in html
+
+    def test_render_rectangles_no_contrast(self):
+        colors = [{"name": "Red", "hex": "#ff0000"}]
+        html = self.mod.render_rectangles(colors, show_contrast="false")
+        assert "gd-swatch-aa-sample" not in html
+
+    # -- build_tooltip_html --
+
+    def test_tooltip_html_basic(self):
+        color = {"name": "Sky Blue", "hex": "#38bdf8"}
+        html = self.mod.build_tooltip_html(color, "true")
+        assert "Sky Blue" in html
+        assert "#38bdf8" in html
+        assert "RGB" in html
+        assert "HSL" in html
+        assert "vs White" in html
+        assert "vs Black" in html
+        assert "WCAG" in html
+
+    def test_tooltip_html_no_contrast(self):
+        color = {"name": "Sky Blue", "hex": "#38bdf8"}
+        html = self.mod.build_tooltip_html(color, "false")
+        assert "vs White" not in html
+        assert "WCAG" not in html
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestColorSwatchCLI:
+    """Test the helper as a subprocess (simulates how Lua calls it)."""
+
+    def test_help_succeeds(self):
+        result = subprocess.run(
+            [sys.executable, str(_helper()), "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+        assert "palette" in result.stdout.lower()
+
+    def test_palette_sky_circles(self):
+        result = subprocess.run(
+            [sys.executable, str(_helper()), "--palette", "sky"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+        assert "gd-color-swatch--circles" in result.stdout
+        assert "Sky" in result.stdout
+
+    def test_palette_sky_rectangles(self):
+        result = subprocess.run(
+            [sys.executable, str(_helper()), "--palette", "sky", "--mode", "rectangles"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+        assert "gd-color-swatch--rectangles" in result.stdout
+
+    def test_stdin_yaml(self):
+        yaml_body = '- name: Test Red\n  hex: "#ff0000"\n'
+        result = subprocess.run(
+            [sys.executable, str(_helper())],
+            input=yaml_body,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+        assert "Test Red" in result.stdout
+        assert "#ff0000" in result.stdout
+
+    def test_unknown_palette_fails(self):
+        result = subprocess.run(
+            [sys.executable, str(_helper()), "--palette", "nonexistent"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode != 0
+
+    def test_no_input_fails(self):
+        result = subprocess.run(
+            [sys.executable, str(_helper())],
+            input="",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode != 0
+
+    def test_unsupported_mode_fails(self):
+        result = subprocess.run(
+            [sys.executable, str(_helper()), "--palette", "sky", "--mode", "gradient"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode != 0

--- a/user_guide/29-color-swatches.qmd
+++ b/user_guide/29-color-swatches.qmd
@@ -1,0 +1,345 @@
+---
+title: "Color Swatches"
+guide-section: "Site Content"
+tags: [Content, Theming, Extensions]
+status: experimental
+upcoming: "0.9"
+versions: ">=0.8"
+---
+
+# Color Swatches
+
+Documenting a project's colors (brand palette, theme variables, status indicators) is one of those tasks that looks simple until you actually try to do it well. Static screenshots go stale, hand-coded HTML is tedious to maintain, and plain text hex codes are meaningless without a visual reference beside them.
+
+The `{{{< color-swatch >}}}` shortcode solves this by turning a small YAML file into an interactive, accessible color palette. Each swatch displays its hex code, shows RGB/HSL breakdowns on hover, evaluates WCAG contrast ratios, and lets readers copy values with a single click. You can render individual palettes, reference the built-in Great Docs gradient presets, or combine both approaches.
+
+This guide walks through every feature (from a minimal first palette to advanced customization options) so you can present colors as clearly as you present code.
+
+## Quick Start
+
+The fastest way to get a palette on the page is to create a YAML file with your colors and reference it from a shortcode. No configuration beyond the file path is needed.
+
+Start by creating a YAML file somewhere in your project. Each entry needs a `name` and a `hex` value:
+
+```{.yaml filename="assets/colors.yml"}
+- name: Sky Blue
+  hex: "#38bdf8"
+- name: Deep Navy
+  hex: "#1e3a5f"
+- name: Coral
+  hex: "#f97316"
+```
+
+Then reference it with the shortcode in any `.qmd` page:
+
+````markdown
+{{{< color-swatch file="assets/colors.yml" >}}}
+````
+
+Here is the result (three circle swatches with names and hex labels):
+
+{{< color-swatch file="assets/color-data/demo-quick-start.yml" >}}
+
+Hover over any swatch to see its full color breakdown in a tooltip. Click a swatch to copy its hex value to the clipboard. That single shortcode line is all it takes to go from raw hex codes to a polished, interactive palette.
+
+## Display Modes
+
+The shortcode supports two display modes, controlled by the `mode` parameter. The default is `circles`, which works well for compact palettes and quick visual reference. The `rectangles` mode is better suited for detailed documentation where contrast information needs to be front and center. Additional modes (grid, gradient) are planned for future releases.
+
+### Circles (Default)
+
+Circle swatches are the default display mode. Each color appears as a filled circle with its name and hex code underneath, arranged in a responsive row that wraps as needed.
+
+To render circle swatches, simply omit the `mode` parameter (or set `mode="circles"` explicitly):
+
+````markdown
+{{{< color-swatch file="assets/brand-colors.yml" >}}}
+````
+
+Here is a five-color brand palette rendered as circles:
+
+{{< color-swatch file="assets/color-data/demo-brand.yml" >}}
+
+Circles are compact and scannable, making them ideal for showcasing a handful of brand or theme colors at a glance. Each swatch is individually interactive (hover for details, click to copy).
+
+### Rectangles
+
+Rectangle mode renders each color as a full-width horizontal strip. This is useful when you want to emphasize contrast information alongside the color itself.
+
+Set `mode="rectangles"` to switch:
+
+````markdown
+{{{< color-swatch mode="rectangles" file="assets/brand-colors.yml" >}}}
+````
+
+Here are three colors rendered as rectangular strips:
+
+{{< color-swatch mode="rectangles" file="assets/color-data/demo-rectangles.yml" >}}
+
+Each strip displays the color name on the left, the hex code on the right, and white/black "Aa" contrast samples. The "Aa" labels are marked pass or fail against WCAG AA thresholds, so you can immediately see which text colors are safe to use on each background. Rectangle mode is especially valuable for design-system documentation where accessibility compliance is a primary concern.
+
+## Built-In Palette Presets
+
+Great Docs ships with eight gradient presets that power the site's gradient theming system. Rather than listing colors manually, you can reference any preset by name and the shortcode will render its color stops as swatches.
+
+To use a preset, pass its name to the `palette` parameter instead of providing a `file`:
+
+````markdown
+{{{< color-swatch palette="sky" >}}}
+````
+
+Here is the `sky` preset:
+
+{{< color-swatch palette="sky" >}}
+
+The full set of available presets is:
+
+| Preset | Description |
+|--------|-------------|
+| `sky` | Soft sky blues |
+| `peach` | Peach and blush |
+| `prism` | Mint, sky, and lavender |
+| `lilac` | Lilac and pink |
+| `slate` | Cool grays |
+| `honey` | Warm cream and apricot |
+| `dusk` | Soft lavender-blue |
+| `mint` | Pale aqua |
+
+Each preset defines four color stops for both light and dark modes. The light-mode stops are shown by default. These are the same palettes available through the `gradient-preset` option in your site configuration, so the swatches you see here correspond exactly to the colors your site header and other gradient elements will use.
+
+### All Presets at a Glance
+
+If you want to compare every preset side by side (for example, when choosing a gradient theme for your site) use `palette="all"` to render all presets in a single view:
+
+````markdown
+{{{< color-swatch palette="all" >}}}
+````
+
+This renders every preset's light-mode color stops, grouped by preset name:
+
+{{< color-swatch palette="all" >}}
+
+The grid layout ensures each swatch is the same width, making visual comparison straightforward. This view is handy for theme selection pages or internal style guides.
+
+### Extend a Preset
+
+Sometimes a preset is close to what you need but you want to add a few extra colors. You can combine a preset with a YAML file (the file's colors are appended after the preset's stops).
+
+For example, to add a custom accent color after the `sky` preset:
+
+````markdown
+{{{< color-swatch palette="sky" file="assets/extra-colors.yml" >}}}
+````
+
+Here is the `sky` preset extended with one additional brand accent color:
+
+{{< color-swatch palette="sky" file="assets/color-data/demo-extend-accent.yml" >}}
+
+The preset colors appear first, followed by any colors from the file. This lets you document how your custom additions relate to the built-in palette without duplicating the preset definitions.
+
+## Tooltips
+
+Every swatch shows a rich tooltip on hover. Tooltips provide the detailed color information that would clutter the main display but is essential for anyone working with the values.
+
+Each tooltip contains:
+
+- A mini color preview square
+- The color name
+- Hex code with a clipboard copy button
+- RGB values
+- HSL values (rounded to integers)
+- APCA contrast ratio against white and against black (in Lc units)
+- WCAG AA pass/fail verdict for normal-size text
+
+Tooltips are powered by the Tippy.js library that is already bundled with Great Docs, so no additional dependencies are needed. The tooltips appear on hover for mouse users and on focus for keyboard users, ensuring the information is accessible to everyone.
+
+## Click to Copy
+
+One of the most common reasons to look up a color palette is to grab a specific value for use in code or design tools. The shortcode makes this effortless.
+
+Click any swatch to copy its hex value (including the `#`) to the clipboard. A brief checkmark animation confirms the copy succeeded. Inside the tooltip, each hex code also has a dedicated clipboard button for a more targeted copy action.
+
+The copied value is always the full hex code (e.g., `#38bdf8`), which is the format most commonly pasted into CSS, design tools, and configuration files.
+
+## Contrast Checks
+
+Choosing colors that look good is only half the job: they also need to be readable. The shortcode uses the APCA (Accessible Perceptual Contrast Algorithm) to evaluate every color against white (`#FFFFFF`) and black (`#000000`) text. This is the same algorithm that powers the automatic navbar text-color selection elsewhere in Great Docs.
+
+By default, contrast information appears in tooltips and in the "Aa" samples on rectangle swatches. You can control this behavior with the `show-contrast` parameter.
+
+### Display Options
+
+The `show-contrast` parameter accepts three values:
+
+| `show-contrast` value | Behavior |
+|----------------------|----------|
+| `"true"` (default) | Contrast info appears in tooltips and rectangle "Aa" samples |
+| `"inline"` | Contrast ratios also appear below the hex code on each circle swatch |
+| `"false"` | Contrast info is hidden everywhere |
+
+Setting `show-contrast="inline"` places the contrast ratios directly on the swatch, which is useful when contrast is the primary focus of the documentation:
+
+````markdown
+{{{< color-swatch show-contrast="inline" file="assets/contrast-demo.yml" >}}}
+````
+
+Here are two colors with inline contrast ratios visible beneath the hex codes:
+
+{{< color-swatch show-contrast="inline" file="assets/color-data/demo-contrast.yml" >}}
+
+The inline display shows the Lc (lightness contrast) value for both white-on-color and black-on-color combinations, along with a pass/fail indicator. Use this mode when your audience needs to evaluate contrast at a glance without hovering.
+
+## Controlling What's Shown
+
+Sometimes you want a simpler display (perhaps just the color circles with names, without hex codes cluttering the view). The shortcode provides three toggle parameters that control label visibility.
+
+| Parameter | Default | Effect |
+|-----------|---------|--------|
+| `show-names` | `"true"` | Show or hide color names below swatches |
+| `show-hex` | `"true"` | Show or hide hex codes below swatches |
+| `show-contrast` | `"true"` | Show or hide contrast info (see above) |
+
+For example, to show only the swatches and their names without hex labels:
+
+````markdown
+{{{< color-swatch show-hex="false" file="assets/colors.yml" >}}}
+````
+
+Here is a minimal palette with hex codes hidden:
+
+{{< color-swatch show-hex="false" file="assets/color-data/demo-minimal.yml" >}}
+
+The hex values are still available in the tooltip on hover (hiding them from the main display reduces visual noise when the color names alone are sufficient). You can combine these toggles freely: `show-names="false" show-hex="false"` gives you bare swatches with all information deferred to tooltips.
+
+## Customization
+
+The shortcode offers several parameters for fine-tuning the appearance of the palette container and individual swatches. These let you adapt the display to different contexts (from a prominent hero palette to a compact inline reference).
+
+### Title and Description
+
+Add a heading and optional description above the palette to give it context within your page. This is especially useful when you have multiple palettes on the same page and need to label each one.
+
+````markdown
+{{{< color-swatch title="Brand Colors" description="Our primary brand palette for 2026." file="assets/brand.yml" >}}}
+````
+
+Here is a palette with a title and description:
+
+{{< color-swatch title="Brand Colors" description="Our primary brand palette for 2026." file="assets/color-data/demo-title.yml" >}}
+
+The title renders as a heading within the palette container, and the description appears as a subtitle beneath it. Both are optional and can be used independently.
+
+### Swatch Size
+
+The default circle diameter is 56px, which works well for most layouts. For hero sections, style guides, or situations where you want the colors to be more prominent, increase the size:
+
+````markdown
+{{{< color-swatch size="80px" file="assets/colors.yml" >}}}
+````
+
+Here is a single swatch rendered at 80px:
+
+{{< color-swatch size="80px" file="assets/color-data/demo-single.yml" >}}
+
+The `size` parameter accepts any valid CSS length value. Smaller sizes (like `40px`) work well for dense reference tables, while larger sizes (like `100px`) make colors the focal point of the page.
+
+### Border
+
+By default, the palette container has a subtle border that visually groups the swatches. If you prefer a cleaner look (for example, when the palette sits inside a callout or a card that already has its own border) you can disable it:
+
+````markdown
+{{{< color-swatch border="false" palette="mint" >}}}
+````
+
+Here is the `mint` preset without a container border:
+
+{{< color-swatch border="false" palette="mint" >}}
+
+The swatches themselves are unchanged; only the outer container border is removed.
+
+### Extra CSS Classes
+
+For advanced styling, add custom CSS classes to the palette wrapper with the `class` parameter:
+
+````markdown
+{{{< color-swatch class="my-special-palette" palette="lilac" >}}}
+````
+
+You can then target `.my-special-palette` in your custom CSS to override spacing, alignment, background, or any other property. This provides an escape hatch for layouts that the built-in parameters don't cover.
+
+## Color Entry Format
+
+Every YAML color file follows a simple structure. Each entry is a list item with two required properties:
+
+| Property | Required | Description |
+|----------|----------|-------------|
+| `name` | Yes | Display name shown below the swatch |
+| `hex` | Yes | Hex color value (e.g., `"#38bdf8"`) |
+
+A minimal file looks like this:
+
+```{.yaml filename="assets/my-colors.yml"}
+- name: Primary
+  hex: "#2563eb"
+- name: Accent
+  hex: "#f97316"
+```
+
+Hex values must include the `#` prefix and can use either three-digit (`#fff`) or six-digit (`#ffffff`) notation. The shortcode normalizes all values to six digits internally for consistent display. Quoting the hex values in YAML is recommended to avoid parsing issues with the `#` character.
+
+## Accessibility
+
+The color-swatch shortcode is designed to be usable by everyone, including keyboard-only users and screen-reader users.
+
+Key accessibility features include:
+
+- **Keyboard navigation**: Every swatch is focusable via Tab and can be activated with Enter or Space to copy its hex value.
+- **ARIA labels**: Each swatch carries an `aria-label` describing the color name, hex value, and available actions.
+- **Live announcements**: Copy confirmations are announced through an `aria-live` region so screen readers report the result.
+- **Visibility safeguards**: Very light colors (nearly white) automatically receive a subtle border ring so they remain visible against the page background. Very dark colors get the same treatment in dark mode.
+- **Reduced motion**: The `prefers-reduced-motion` media query disables hover and copy animations for users who have requested reduced motion in their OS settings.
+
+These features ensure that color documentation is not just visual as the information is available through assistive technology as well.
+
+## Dark Mode
+
+Swatches adapt to the page theme automatically. When a reader toggles dark mode, the palette adjusts without any extra configuration:
+
+- Container borders and shadow intensities shift for dark backgrounds.
+- Border rings on very light and very dark colors swap direction (light rings appear around dark colors in dark mode, and dark rings appear around light colors in light mode).
+- Tooltips inherit the page's current theme context.
+
+When using a palette preset, the light-mode color stops are shown regardless of page theme. Dark-mode palette display (showing the preset's dark-mode stops when the page is in dark mode) is planned for a future release.
+
+## Responsive Behavior
+
+The swatch layout is responsive and adjusts to smaller screens automatically.
+
+On mobile viewports (below 576px):
+
+- Circle swatches shrink to 44px and grid gaps tighten to keep the layout compact.
+- Rectangle strips stack their labels vertically to avoid horizontal overflow.
+
+On wider screens, the grid expands to fill the available width with equal-size columns. No media-query configuration is needed on your part as the built-in CSS handles all breakpoints.
+
+## Parameters Reference
+
+The table below lists every parameter available on the `{{{< color-swatch >}}}` shortcode. All parameters are optional and, at minimum, you need either `file` or `palette` (or both) to provide colors.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `file` | string | — | Path to a YAML file with color definitions (relative to project root) |
+| `palette` | string | — | Preset name: `sky`, `peach`, `prism`, `lilac`, `slate`, `honey`, `dusk`, `mint`, or `all` |
+| `mode` | string | `"circles"` | Display mode: `circles` or `rectangles` |
+| `size` | string | `"56px"` | Circle swatch diameter (CSS length) |
+| `show-contrast` | string | `"true"` | `"true"`, `"false"`, or `"inline"` |
+| `show-names` | string | `"true"` | Show or hide color names |
+| `show-hex` | string | `"true"` | Show or hide hex values |
+| `copy-format` | string | `"hex"` | Clipboard format: `hex` |
+| `title` | string | — | Title above the palette |
+| `description` | string | — | Description below the title |
+| `border` | string | `"true"` | Show or hide container border |
+| `id` | string | auto | Custom HTML `id` for the wrapper |
+| `class` | string | — | Additional CSS classes |
+
+When both `file` and `palette` are provided, the preset colors appear first and the file colors are appended after them.


### PR DESCRIPTION
This PR introduces a color swatch extension that enables interactive color palette displays with tooltips, click-to-copy functionality, etc. Several demo color palette YAML files are also added for testing and documentation.