### PR TITLE
fix: move mobile sidebar toggle logic to `navbar-widgets.js`

### DIFF
--- a/great_docs/assets/navbar-style.js
+++ b/great_docs/assets/navbar-style.js
@@ -101,52 +101,5 @@
   mql.addEventListener("change", update);
 })();
 
-/* Widget collection is handled by navbar-widgets.js (always loaded). */
-
-/**
- * Mobile sidebar toggle → menu overlay redirect.
- *
- * On mobile (< 992px) the sidebar toggle button in the Title Bar
- * (.quarto-btn-toggle) opens the polished menu overlay (same as the
- * 'm'/'n' keyboard shortcut) instead of Bootstrap's collapse sidebar.
- * This gives a smooth fade-in/slide, rounded card, backdrop blur, and
- * auto-scroll to the current page — matching the desktop overlay UX.
- */
-(function () {
-  "use strict";
-
-  var mql = window.matchMedia("(max-width: 991.98px)");
-
-  function intercept(e) {
-    if (!mql.matches) return;           // desktop — let Bootstrap handle it
-    if (!window.__gdMenu) return;       // keyboard-nav.js not loaded yet
-
-    // Stop Bootstrap collapse and Quarto headroom toggle
-    e.preventDefault();
-    e.stopPropagation();
-
-    if (window.__gdMenu.isOpen()) {
-      window.__gdMenu.hide();
-    } else {
-      window.__gdMenu.show();
-    }
-  }
-
-  function attach() {
-    // The secondary-nav has two clickable elements: the <button> and
-    // the <a> that wraps the title text.  Intercept both.
-    var targets = document.querySelectorAll(
-      ".quarto-secondary-nav .quarto-btn-toggle, " +
-      ".quarto-secondary-nav a[data-bs-toggle='collapse']"
-    );
-    targets.forEach(function (el) {
-      el.addEventListener("click", intercept, /* capture */ true);
-    });
-  }
-
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", attach);
-  } else {
-    attach();
-  }
-})();
+/* Widget collection is handled by navbar-widgets.js (always loaded).
+   Mobile sidebar toggle is also in navbar-widgets.js. */

--- a/great_docs/assets/navbar-widgets.js
+++ b/great_docs/assets/navbar-widgets.js
@@ -146,3 +146,51 @@
         init();
     }
 })();
+
+/**
+ * Mobile sidebar toggle → menu overlay redirect.
+ *
+ * On mobile (< 992px) the sidebar toggle button in the Title Bar
+ * (.quarto-btn-toggle) opens the polished menu overlay (same as the
+ * 'm'/'n' keyboard shortcut) instead of Bootstrap's collapse sidebar.
+ * This gives a smooth fade-in/slide, rounded card, backdrop blur, and
+ * auto-scroll to the current page — matching the desktop overlay UX.
+ */
+(function () {
+  "use strict";
+
+  var mql = window.matchMedia("(max-width: 991.98px)");
+
+  function intercept(e) {
+    if (!mql.matches) return;           // desktop — let Bootstrap handle it
+    if (!window.__gdMenu) return;       // keyboard-nav.js not loaded yet
+
+    // Stop Bootstrap collapse and Quarto headroom toggle
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (window.__gdMenu.isOpen()) {
+      window.__gdMenu.hide();
+    } else {
+      window.__gdMenu.show();
+    }
+  }
+
+  function attach() {
+    // The secondary-nav has two clickable elements: the <button> and
+    // the <a> that wraps the title text.  Intercept both.
+    var targets = document.querySelectorAll(
+      ".quarto-secondary-nav .quarto-btn-toggle, " +
+      ".quarto-secondary-nav a[data-bs-toggle='collapse']"
+    );
+    targets.forEach(function (el) {
+      el.addEventListener("click", intercept, /* capture */ true);
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", attach);
+  } else {
+    attach();
+  }
+})();


### PR DESCRIPTION
This PR consolidates the logic for handling the mobile sidebar toggle into a single file, simplifying the codebase and improving maintainability. The main change is moving the mobile sidebar toggle functionality from `navbar-style.js` to `navbar-widgets.js`, ensuring all related widget and menu overlay code is managed together.