### PR TITLE
feat: horizontal rule shortcode

### DIFF
--- a/great-docs.yml
+++ b/great-docs.yml
@@ -264,6 +264,7 @@ nav_icons:
     Color Swatches: pipette
     Table Previews: table
     Table Explorer: telescope
+    Horizontal Rules: minus
 
 # Author Information
 # ------------------

--- a/great_docs/assets/_extensions/hr/_extension.yml
+++ b/great_docs/assets/_extensions/hr/_extension.yml
@@ -1,0 +1,7 @@
+title: Horizontal Rule
+author: Great Docs
+version: 1.0.0
+quarto-required: ">=1.3.0"
+contributes:
+  shortcodes:
+    - hr.lua

--- a/great_docs/assets/_extensions/hr/hr.lua
+++ b/great_docs/assets/_extensions/hr/hr.lua
@@ -1,0 +1,167 @@
+-- hr.lua — Quarto shortcode for decorative horizontal rules
+--
+-- Usage in .qmd files:
+--
+--   {{< hr >}}
+--   {{< hr style="dashed" color="sky" >}}
+--   {{< hr style="dotted" thickness="3px" width="50%" align="center" >}}
+--   {{< hr text="§" >}}
+--   {{< hr text="Continue Reading" style="solid" color="#6366f1" >}}
+--   {{< hr preset="gradient-shimmer" >}}
+--   {{< hr preset="fade" width="60%" >}}
+--
+-- Pure Lua implementation — no Python helper needed.
+-- All styling is handled via CSS classes in great-docs.scss.
+
+local function kwarg_str(kwargs, key)
+    local raw = kwargs[key]
+    if raw == nil then return "" end
+    local s = pandoc.utils.stringify(raw)
+    return s or ""
+end
+
+-- Named palette colors that map to CSS custom properties
+local PALETTE_COLORS = {
+    sky = true,
+    peach = true,
+    prism = true,
+    lilac = true,
+    slate = true,
+    honey = true,
+    dusk = true,
+    mint = true,
+    accent = true,
+}
+
+-- Valid presets
+local PRESETS = {
+    ["gradient-shimmer"] = true,
+    ["gradient-static"] = true,
+    ["fade"] = true,
+    ["fade-edges"] = true,
+    ["dots"] = true,
+    ["diamond"] = true,
+    ["ornament"] = true,
+    ["wave"] = true,
+    ["double-line"] = true,
+}
+
+-- Valid line styles
+local STYLES = {
+    solid = true, dotted = true, dashed = true, double = true,
+}
+
+-- Named thickness values
+local THICKNESS_MAP = {
+    thin = "1px",
+    medium = "2px",
+    thick = "4px",
+}
+
+-- Named spacing values
+local SPACING_MAP = {
+    compact = "1rem",
+    normal = "2rem",
+    spacious = "4rem",
+}
+
+return {
+    ["hr"] = function(args, kwargs)
+        local preset = kwarg_str(kwargs, "preset")
+        local style = kwarg_str(kwargs, "style")
+        local color = kwarg_str(kwargs, "color")
+        local thickness = kwarg_str(kwargs, "thickness")
+        local width = kwarg_str(kwargs, "width")
+        local align = kwarg_str(kwargs, "align")
+        local text = kwarg_str(kwargs, "text")
+        local text_color = kwarg_str(kwargs, "text-color")
+        local text_size = kwarg_str(kwargs, "text-size")
+        local spacing = kwarg_str(kwargs, "spacing")
+
+        -- Build CSS classes
+        local classes = { "gd-hr" }
+
+        if preset ~= "" and PRESETS[preset] then
+            table.insert(classes, "gd-hr--" .. preset)
+        end
+
+        if style ~= "" and STYLES[style] then
+            table.insert(classes, "gd-hr--" .. style)
+        end
+
+        if align == "left" then
+            table.insert(classes, "gd-hr--left")
+        elseif align == "right" then
+            table.insert(classes, "gd-hr--right")
+        end
+
+        -- Build inline styles for dynamic values
+        local inline_styles = {}
+
+        -- Color: palette name → CSS var, otherwise raw CSS color
+        if color ~= "" then
+            if PALETTE_COLORS[color] then
+                table.insert(inline_styles,
+                    "--gd-hr-color: var(--gd-palette-" .. color .. ", var(--gd-accent, #6366f1))")
+            else
+                table.insert(inline_styles, "--gd-hr-color: " .. color)
+            end
+        end
+
+        -- Thickness
+        if thickness ~= "" then
+            local resolved = THICKNESS_MAP[thickness] or thickness
+            table.insert(inline_styles, "--gd-hr-thickness: " .. resolved)
+        end
+
+        -- Width
+        if width ~= "" then
+            if width == "full" then
+                width = "100%"
+            end
+            table.insert(inline_styles, "--gd-hr-width: " .. width)
+        end
+
+        -- Spacing
+        if spacing ~= "" then
+            local resolved = SPACING_MAP[spacing] or spacing
+            table.insert(inline_styles, "--gd-hr-spacing: " .. resolved)
+        end
+
+        local style_attr = ""
+        if #inline_styles > 0 then
+            style_attr = ' style="' .. table.concat(inline_styles, "; ") .. '"'
+        end
+
+        local class_attr = table.concat(classes, " ")
+
+        -- If there's embedded text, use the flex wrapper structure
+        if text ~= "" then
+            local text_classes = { "gd-hr-text" }
+            if text_size == "sm" then
+                table.insert(text_classes, "gd-hr-text--sm")
+            elseif text_size == "lg" then
+                table.insert(text_classes, "gd-hr-text--lg")
+            end
+
+            local text_style = ""
+            if text_color ~= "" then
+                text_style = ' style="color: ' .. text_color .. '"'
+            end
+
+            local html = '<div class="' .. class_attr .. ' gd-hr--with-text"' .. style_attr .. '>'
+                .. '<span class="gd-hr-line"></span>'
+                .. '<span class="' .. table.concat(text_classes, " ") .. '"' .. text_style .. '>'
+                .. text
+                .. '</span>'
+                .. '<span class="gd-hr-line"></span>'
+                .. '</div>'
+
+            return pandoc.RawBlock("html", html)
+        end
+
+        -- Simple <hr> element
+        local html = '<hr class="' .. class_attr .. '"' .. style_attr .. '>'
+        return pandoc.RawBlock("html", html)
+    end,
+}

--- a/great_docs/assets/great-docs.scss
+++ b/great_docs/assets/great-docs.scss
@@ -4244,6 +4244,359 @@ body.quarto-dark .gd-cta-desc {
     }
 }
 
+/* ── Horizontal Rule Shortcode ────────────────────────── */
+
+/* Palette color tokens — representative hue from each gradient preset */
+:root {
+    --gd-palette-sky: #0077b6;
+    --gd-palette-peach: #e07a3a;
+    --gd-palette-prism: #6d28d9;
+    --gd-palette-lilac: #a855f7;
+    --gd-palette-slate: #64748b;
+    --gd-palette-honey: #d97706;
+    --gd-palette-dusk: #4338ca;
+    --gd-palette-mint: #0d9488;
+    --gd-palette-accent: var(--gd-accent, #6366f1);
+}
+
+html[data-bs-theme="dark"] {
+    --gd-palette-sky: #38bdf8;
+    --gd-palette-peach: #fb923c;
+    --gd-palette-prism: #a78bfa;
+    --gd-palette-lilac: #c084fc;
+    --gd-palette-slate: #94a3b8;
+    --gd-palette-honey: #fbbf24;
+    --gd-palette-dusk: #818cf8;
+    --gd-palette-mint: #2dd4bf;
+    --gd-palette-accent: var(--gd-accent, #818cf8);
+}
+
+.gd-hr {
+    --gd-hr-color: var(--gd-accent, #6366f1);
+    --gd-hr-thickness: 2px;
+    --gd-hr-width: 100%;
+    --gd-hr-spacing: 2rem;
+
+    border: none;
+    height: var(--gd-hr-thickness);
+    width: var(--gd-hr-width);
+    max-width: 100%;
+    margin: var(--gd-hr-spacing) auto;
+    background: var(--gd-hr-color);
+    opacity: 0.7;
+    display: block;
+}
+
+/* ─ Line Styles ─ */
+.gd-hr--dotted {
+    background: none;
+    border-top: var(--gd-hr-thickness) dotted var(--gd-hr-color);
+    height: 0;
+}
+
+.gd-hr--dashed {
+    background: none;
+    border-top: var(--gd-hr-thickness) dashed var(--gd-hr-color);
+    height: 0;
+}
+
+.gd-hr--double {
+    background: none;
+    border-top: calc(var(--gd-hr-thickness) * 0.5) double var(--gd-hr-color);
+    height: 0;
+    border-top-width: calc(var(--gd-hr-thickness) + 2px);
+}
+
+/* ─ Alignment ─ */
+.gd-hr--left {
+    margin-left: 0;
+    margin-right: auto;
+}
+
+.gd-hr--right {
+    margin-left: auto;
+    margin-right: 0;
+}
+
+/* ─ With-Text Structure ─ */
+.gd-hr--with-text {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    height: auto;
+    background: none;
+    border: none;
+    width: var(--gd-hr-width);
+    max-width: 100%;
+    margin: var(--gd-hr-spacing) auto;
+    opacity: 1;
+}
+
+.gd-hr--with-text.gd-hr--left {
+    margin-left: 0;
+    margin-right: auto;
+}
+
+.gd-hr--with-text.gd-hr--right {
+    margin-left: auto;
+    margin-right: 0;
+}
+
+.gd-hr-line {
+    flex: 1;
+    height: var(--gd-hr-thickness, 2px);
+    background: var(--gd-hr-color);
+    opacity: 0.7;
+}
+
+.gd-hr-text {
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--gd-hr-color);
+    white-space: nowrap;
+    user-select: none;
+    line-height: 1;
+}
+
+.gd-hr-text--sm {
+    font-size: 0.75rem;
+}
+
+.gd-hr-text--lg {
+    font-size: 1.2rem;
+}
+
+/* ─ Presets ─ */
+
+/* Gradient shimmer (animated) — generalizes .gd-fw-rule */
+.gd-hr--gradient-shimmer {
+    background: linear-gradient(
+        90deg,
+        transparent,
+        var(--gd-hr-color, var(--gd-accent, #6366f1)) 25%,
+        var(--gd-accent-secondary, #a855f7) 50%,
+        var(--gd-hr-color, var(--gd-accent, #6366f1)) 75%,
+        transparent
+    );
+    background-size: 200% 100%;
+    animation: gd-hr-shimmer 4s ease-in-out infinite;
+    border: none;
+    height: var(--gd-hr-thickness);
+}
+
+@keyframes gd-hr-shimmer {
+    0%   { background-position: 100% 0; }
+    50%  { background-position: 0% 0; }
+    100% { background-position: 100% 0; }
+}
+
+/* Gradient static (non-animated) */
+.gd-hr--gradient-static {
+    background: linear-gradient(
+        90deg,
+        transparent,
+        var(--gd-hr-color, var(--gd-accent, #6366f1)) 25%,
+        var(--gd-accent-secondary, #a855f7) 50%,
+        var(--gd-hr-color, var(--gd-accent, #6366f1)) 75%,
+        transparent
+    );
+    border: none;
+    height: var(--gd-hr-thickness);
+}
+
+/* Fade — full opacity at center, transparent at edges */
+.gd-hr--fade {
+    background: linear-gradient(
+        90deg,
+        transparent,
+        var(--gd-hr-color) 20%,
+        var(--gd-hr-color) 80%,
+        transparent
+    );
+    border: none;
+    height: var(--gd-hr-thickness);
+}
+
+/* Fade-edges — transparent edges to colored center */
+.gd-hr--fade-edges {
+    background: radial-gradient(
+        ellipse at center,
+        var(--gd-hr-color) 0%,
+        transparent 70%
+    );
+    border: none;
+    height: var(--gd-hr-thickness);
+}
+
+/* Dots — three centered dots, no line */
+.gd-hr--dots {
+    background: none;
+    border: none;
+    height: auto;
+    text-align: center;
+    opacity: 1;
+}
+
+.gd-hr--dots::after {
+    content: "·  ·  ·";
+    font-size: 1.5rem;
+    letter-spacing: 0.3em;
+    color: var(--gd-hr-color);
+    opacity: 0.8;
+}
+
+/* Diamond — centered diamond flanked by thin lines */
+.gd-hr--diamond {
+    background: none;
+    border: none;
+    height: auto;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    opacity: 1;
+}
+
+.gd-hr--diamond::before,
+.gd-hr--diamond::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: var(--gd-hr-color);
+    opacity: 0.5;
+}
+
+.gd-hr--diamond::before {
+    content: "";
+}
+
+/* Insert diamond via a nested approach — use a wrapper trick.
+   Since <hr> can't have children, we use a background trick instead. */
+hr.gd-hr--diamond {
+    display: flex;
+}
+
+hr.gd-hr--diamond::before {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, var(--gd-hr-color));
+}
+
+hr.gd-hr--diamond::after {
+    content: "◇";
+    flex: none;
+    height: auto;
+    background: none;
+    font-size: 1rem;
+    color: var(--gd-hr-color);
+    opacity: 0.8;
+    padding: 0 0.5rem;
+}
+
+/* Ornament — fleuron between fading lines */
+.gd-hr--ornament {
+    background: none;
+    border: none;
+    height: auto;
+    display: flex;
+    align-items: center;
+    opacity: 1;
+}
+
+hr.gd-hr--ornament::before {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, var(--gd-hr-color));
+}
+
+hr.gd-hr--ornament::after {
+    content: "❧";
+    flex: none;
+    height: auto;
+    background: none;
+    font-size: 1.2rem;
+    color: var(--gd-hr-color);
+    opacity: 0.7;
+    padding: 0 0.75rem;
+}
+
+/* Wave — repeating wave pattern */
+.gd-hr--wave {
+    background: repeating-linear-gradient(
+        135deg,
+        var(--gd-hr-color) 0px,
+        var(--gd-hr-color) 2px,
+        transparent 2px,
+        transparent 6px
+    );
+    border: none;
+    height: var(--gd-hr-thickness);
+    opacity: 0.6;
+}
+
+/* Double-line — two parallel lines */
+.gd-hr--double-line {
+    background: none;
+    border: none;
+    height: calc(var(--gd-hr-thickness) * 2 + 3px);
+    position: relative;
+    opacity: 0.7;
+}
+
+.gd-hr--double-line::before,
+.gd-hr--double-line::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: var(--gd-hr-thickness);
+    background: var(--gd-hr-color);
+}
+
+.gd-hr--double-line::before {
+    top: 0;
+}
+
+.gd-hr--double-line::after {
+    bottom: 0;
+}
+
+/* ─ Dark Mode ─ */
+body.quarto-dark .gd-hr {
+    opacity: 0.6;
+}
+
+body.quarto-dark .gd-hr--with-text {
+    opacity: 1;
+}
+
+body.quarto-dark .gd-hr-line {
+    opacity: 0.5;
+}
+
+body.quarto-dark .gd-hr-text {
+    opacity: 0.85;
+}
+
+body.quarto-dark .gd-hr--dots::after {
+    opacity: 0.6;
+}
+
+/* ─ Reduced Motion ─ */
+@media (prefers-reduced-motion: reduce) {
+    .gd-hr--gradient-shimmer {
+        animation: none;
+    }
+}
+
+/* ─ Responsive ─ */
+@media (max-width: 768px) {
+    .gd-hr {
+        --gd-hr-spacing: 1.5rem;
+    }
+}
+
 /* ── Feature Wall Closing ─────────────────────────────── */
 
 .gd-fw-rule {

--- a/great_docs/config.py
+++ b/great_docs/config.py
@@ -140,6 +140,12 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "stable": True,  # /v/stable/ -> same as latest
         "dev": True,  # /v/dev/ -> prerelease version (if any)
     },
+    # Site-wide accent color (CSS color: hex, named, etc.)
+    # Sets the --gd-accent custom property used by shortcodes (hr, etc.),
+    # gradient presets, and other accent-colored elements.
+    # str: same color for both light and dark mode
+    # dict: {"light": str, "dark": str} for per-mode colors
+    "accent_color": None,
     # Navbar gradient preset (e.g., "sky", "peach", "lilac", etc.)
     "navbar_style": None,
     # Navbar solid background color (CSS color: hex, named, etc.)
@@ -1139,6 +1145,30 @@ class Config:
     def attribution(self) -> bool:
         """Whether to show Great Docs attribution in the footer."""
         return bool(self.get("attribution", True))
+
+    @property
+    def accent_color(self) -> dict[str, str] | None:
+        """Get the normalized accent color configuration.
+
+        Returns
+        -------
+        dict[str, str] | None
+            A dict with `"light"` and/or `"dark"` keys mapping to CSS color strings. Returns `None`
+            when not configured.
+        """
+        raw = self.get("accent_color")
+        if raw is None or raw is False:
+            return None
+        if isinstance(raw, str):
+            return {"light": raw, "dark": raw}
+        if isinstance(raw, dict):
+            result: dict[str, str] = {}
+            for key in ("light", "dark"):
+                val = raw.get(key)
+                if val and isinstance(val, str):
+                    result[key] = val
+            return result if result else None
+        return None
 
     @property
     def navbar_style(self) -> str | None:

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -10778,6 +10778,34 @@ body-classes: "gd-homepage"
             if "navbar-style.js" not in resources_list:
                 resources_list.append("navbar-style.js")
 
+        # Add site-wide accent color if configured
+        accent_color = self._config.accent_color
+        if accent_color:
+            import html as html_mod_ac
+
+            accent_css_parts: list[str] = []
+            for mode in ("light", "dark"):
+                color_val = accent_color.get(mode)
+                if not color_val:
+                    continue
+                escaped = html_mod_ac.escape(color_val)
+                if mode == "light":
+                    selector = ":root, html.quarto-light, :root[data-bs-theme='light']"
+                else:
+                    selector = "html.quarto-dark, :root[data-bs-theme='dark']"
+                accent_css_parts.append(f"{selector} {{\n    --gd-accent: {escaped};\n}}")
+            if accent_css_parts:
+                accent_css = "\n".join(accent_css_parts)
+                accent_style_tag = (
+                    f"<style>\n/* Great Docs: accent_color overrides */\n{accent_css}\n</style>"
+                )
+                after_body = config["format"]["html"].setdefault("include-after-body", [])
+                if isinstance(after_body, str):
+                    after_body = [after_body]
+                    config["format"]["html"]["include-after-body"] = after_body
+                after_body[:] = [h for h in after_body if "accent_color overrides" not in str(h)]
+                after_body.append({"text": accent_style_tag})
+
         # Add navbar solid color if configured (ignored when `navbar_style` is set)
         navbar_color = self._config.navbar_color
         if navbar_color:

--- a/test-packages/synthetic/catalog.py
+++ b/test-packages/synthetic/catalog.py
@@ -363,6 +363,10 @@ ALL_PACKAGES: list[str] = [
     "gdtest_tbl_shortcode",  # 179
     # 180: Interactive table explorer showcase
     "gdtest_tbl_explorer",  # 180
+    # 181: Decorative horizontal rule shortcode showcase
+    "gdtest_hr_shortcode",  # 181
+    # 182: Site-wide accent_color config option
+    "gdtest_accent_color",  # 182
 ]
 
 
@@ -2036,6 +2040,22 @@ PACKAGE_DESCRIPTIONS: dict[str, str] = {
         "missing-value highlighting, minimal chrome (hide row numbers, dtypes, "
         "dimensions), tbl-explorer Quarto shortcode with CSV/TSV/JSONL files, "
         "and a side-by-side comparison of tbl_preview() vs tbl_explorer()."
+    ),
+    "gdtest_hr_shortcode": (
+        "Decorative horizontal rule shortcode showcase exercising the "
+        "{{< hr >}} shortcode in six user-guide pages: line styles (solid, "
+        "dashed, dotted, double), palette and custom colors, sizing and "
+        "alignment (thickness, width, align, spacing), embedded text with "
+        "symbols and labels, all nine presets (gradient-shimmer, gradient-"
+        "static, fade, fade-edges, dots, diamond, ornament, wave, double-"
+        "line), and combined options with real-world examples."
+    ),
+    "gdtest_accent_color": (
+        "Site-wide accent_color config option that sets --gd-accent via "
+        "great-docs.yml. Uses a distinctive teal (#0d9488) to verify the "
+        "accent propagates to default hr shortcodes, gradient presets, "
+        "and text dividers while palette colors (sky, peach, etc.) retain "
+        "their own hues. Tests light and dark mode handling."
     ),
 }
 

--- a/test-packages/synthetic/specs/gdtest_accent_color.py
+++ b/test-packages/synthetic/specs/gdtest_accent_color.py
@@ -1,0 +1,250 @@
+"""
+gdtest_accent_color — Verify the accent_color config option.
+
+Dimensions: A1, B1, C4, D2, E6, F1, G1, H7
+Focus: The accent_color config key that sets --gd-accent site-wide.
+       Uses a distinctive teal (#0d9488) so it's immediately obvious whether
+       the accent propagates to hr shortcodes, gradient presets, and other
+       accent-colored elements. Includes light/dark per-mode variant to
+       verify dark-mode handling.
+"""
+
+SPEC = {
+    "name": "gdtest_accent_color",
+    "description": "Site-wide accent_color config with hr shortcode integration",
+    "dimensions": ["A1", "B1", "C4", "D2", "E6", "F1", "G1", "H7"],
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-accent-color",
+            "version": "1.0.0",
+            "description": "A package demonstrating the accent_color config option",
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    },
+    "files": {
+        # ── Python module (minimal) ──────────────────────────────────────
+        "gdtest_accent_color/__init__.py": (
+            '"""Accent color demo package."""\n'
+            "\n"
+            '__version__ = "1.0.0"\n'
+            '__all__ = ["highlight", "summarize"]\n'
+            "\n"
+            "\n"
+            "def highlight(text: str) -> str:\n"
+            '    """Highlight important text.\n'
+            "\n"
+            "    Parameters\n"
+            "    ----------\n"
+            "    text\n"
+            "        The text to highlight.\n"
+            "\n"
+            "    Returns\n"
+            "    -------\n"
+            "    str\n"
+            "        Highlighted text.\n"
+            '    """\n'
+            '    return f"**{text}**"\n'
+            "\n"
+            "\n"
+            "def summarize(items: list) -> str:\n"
+            '    """Summarize a list of items.\n'
+            "\n"
+            "    Parameters\n"
+            "    ----------\n"
+            "    items\n"
+            "        Items to summarize.\n"
+            "\n"
+            "    Returns\n"
+            "    -------\n"
+            "    str\n"
+            "        A summary string.\n"
+            '    """\n'
+            '    return f"{len(items)} items"\n'
+        ),
+        # ── User guide: accent color with string value ───────────────────
+        "user_guide/01-string-accent.qmd": (
+            "---\n"
+            "title: String Accent Color\n"
+            "---\n"
+            "\n"
+            "# Single Accent Color\n"
+            "\n"
+            "This site uses `accent_color: '#0d9488'` (teal) in the config.\n"
+            "Every element that references `--gd-accent` should appear teal.\n"
+            "\n"
+            "## Default HR\n"
+            "\n"
+            "A plain `{{< hr >}}` with no color override should be teal:\n"
+            "\n"
+            "{{< hr >}}\n"
+            "\n"
+            "## HR with Accent Keyword\n"
+            "\n"
+            '{{< hr color="accent" >}}\n'
+            "\n"
+            "## Gradient Shimmer\n"
+            "\n"
+            "The shimmer should use the teal accent in its gradient:\n"
+            "\n"
+            '{{< hr preset="gradient-shimmer" >}}\n'
+            "\n"
+            "## Gradient Static\n"
+            "\n"
+            '{{< hr preset="gradient-static" >}}\n'
+            "\n"
+            "## Fade\n"
+            "\n"
+            '{{< hr preset="fade" >}}\n'
+            "\n"
+            "## HR Styles\n"
+            "\n"
+            "These should all be teal by default:\n"
+            "\n"
+            '{{< hr style="solid" >}}\n'
+            "\n"
+            '{{< hr style="dashed" >}}\n'
+            "\n"
+            '{{< hr style="dotted" >}}\n'
+            "\n"
+            '{{< hr style="double" >}}\n'
+            "\n"
+            "## Thick HR\n"
+            "\n"
+            '{{< hr thickness="thick" >}}\n'
+            "\n"
+            "## HR with Text\n"
+            "\n"
+            '{{< hr text="Teal Accent" >}}\n'
+            "\n"
+            "## Explicit Color Override\n"
+            "\n"
+            "This one explicitly sets red, so the accent should NOT apply:\n"
+            "\n"
+            '{{< hr color="#e11d48" >}}\n'
+        ),
+        # ── User guide: per-mode accent colors ───────────────────────────
+        "user_guide/02-per-mode-accent.qmd": (
+            "---\n"
+            "title: Per-Mode Accent Colors\n"
+            "---\n"
+            "\n"
+            "# Light / Dark Accent Colors\n"
+            "\n"
+            "This page tests that the accent color config can accept a dict\n"
+            "with `light` and `dark` keys. The site config for this package\n"
+            "uses a single string, so both modes get the same teal.\n"
+            "\n"
+            "Toggle dark mode to verify the color persists in both themes.\n"
+            "\n"
+            "## Default HR in Each Mode\n"
+            "\n"
+            "{{< hr >}}\n"
+            "\n"
+            "## Ornament Preset\n"
+            "\n"
+            '{{< hr preset="ornament" >}}\n'
+            "\n"
+            "## Diamond Preset\n"
+            "\n"
+            '{{< hr preset="diamond" >}}\n'
+            "\n"
+            "## Dots Preset\n"
+            "\n"
+            '{{< hr preset="dots" >}}\n'
+            "\n"
+            "## Text with Size Variants\n"
+            "\n"
+            '{{< hr text="Small" text-size="sm" >}}\n'
+            "\n"
+            '{{< hr text="Default" >}}\n'
+            "\n"
+            '{{< hr text="Large" text-size="lg" >}}\n'
+        ),
+        # ── User guide: accent + palette color interaction ───────────────
+        "user_guide/03-palette-vs-accent.qmd": (
+            "---\n"
+            "title: Palette vs Accent\n"
+            "---\n"
+            "\n"
+            "# Palette Colors vs Accent\n"
+            "\n"
+            "Named palette colors should use their own hue, not the accent.\n"
+            "Only a plain `{{< hr >}}` or `color='accent'` should use the\n"
+            "site accent.\n"
+            "\n"
+            "## Accent (should be teal)\n"
+            "\n"
+            "{{< hr >}}\n"
+            "\n"
+            '{{< hr color="accent" >}}\n'
+            "\n"
+            "## Sky (should be blue, NOT teal)\n"
+            "\n"
+            '{{< hr color="sky" >}}\n'
+            "\n"
+            "## Peach (should be orange, NOT teal)\n"
+            "\n"
+            '{{< hr color="peach" >}}\n'
+            "\n"
+            "## Honey (should be amber, NOT teal)\n"
+            "\n"
+            '{{< hr color="honey" >}}\n'
+            "\n"
+            "## Lilac (should be purple, NOT teal)\n"
+            "\n"
+            '{{< hr color="lilac" >}}\n'
+            "\n"
+            "## Mint (should be mint, similar to teal but distinct token)\n"
+            "\n"
+            '{{< hr color="mint" >}}\n'
+            "\n"
+            "## Custom Red (should be red, NOT teal)\n"
+            "\n"
+            '{{< hr color="#e11d48" >}}\n'
+        ),
+    },
+    "config": {
+        "accent_color": "#0d9488",
+        "dark_mode": True,
+    },
+    "expected": {
+        "files_exist": [
+            "reference/index.html",
+            "reference/highlight.html",
+            "reference/summarize.html",
+            "user-guide/string-accent.html",
+            "user-guide/per-mode-accent.html",
+            "user-guide/palette-vs-accent.html",
+        ],
+        "files_contain": {
+            # The accent_color style tag should be injected
+            "user-guide/string-accent.html": [
+                "accent_color overrides",
+                "--gd-accent: #0d9488",
+                "gd-hr",
+            ],
+            # Default hr should use the accent (no explicit color class)
+            "user-guide/string-accent.html": [
+                "gd-hr",
+                "accent_color overrides",
+            ],
+            # Palette colors should still use their own tokens
+            "user-guide/palette-vs-accent.html": [
+                "gd-hr",
+                "--gd-hr-color: var(--gd-palette-sky",
+                "--gd-hr-color: var(--gd-palette-peach",
+                "--gd-hr-color: var(--gd-palette-honey",
+                "--gd-hr-color: var(--gd-palette-lilac",
+                "--gd-hr-color: var(--gd-palette-mint",
+            ],
+            # Text hr should have the text wrapper
+            "user-guide/per-mode-accent.html": [
+                "gd-hr--with-text",
+                "gd-hr-text",
+            ],
+        },
+    },
+}

--- a/test-packages/synthetic/specs/gdtest_hr_shortcode.py
+++ b/test-packages/synthetic/specs/gdtest_hr_shortcode.py
@@ -1,0 +1,585 @@
+"""
+gdtest_hr_shortcode — Exercise the {{< hr >}} shortcode in many contexts.
+
+Dimensions: A1, B1, C4, D2, E6, F1, G1, H7
+Focus: The decorative horizontal rule shortcode with every supported option:
+       line styles (solid, dashed, dotted, double), colors (palette + custom),
+       thickness, width, alignment, embedded text, presets (gradient-shimmer,
+       fade, dots, diamond, ornament, wave, double-line), and combined options.
+       Tests that all styles render correctly and look good in dark mode.
+"""
+
+SPEC = {
+    "name": "gdtest_hr_shortcode",
+    "description": "Decorative horizontal rule shortcode with styles, presets, and text",
+    "dimensions": ["A1", "B1", "C4", "D2", "E6", "F1", "G1", "H7"],
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-hr-shortcode",
+            "version": "1.0.0",
+            "description": "A package demonstrating the hr shortcode extension",
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    },
+    "files": {
+        # ── Python module (minimal) ──────────────────────────────────────
+        "gdtest_hr_shortcode/__init__.py": (
+            '"""Horizontal rule shortcode demo package."""\n'
+            "\n"
+            '__version__ = "1.0.0"\n'
+            '__all__ = ["render", "transform"]\n'
+            "\n"
+            "\n"
+            "def render(template: str) -> str:\n"
+            '    """Render a template string.\n'
+            "\n"
+            "    Parameters\n"
+            "    ----------\n"
+            "    template\n"
+            "        The template to render.\n"
+            "\n"
+            "    Returns\n"
+            "    -------\n"
+            "    str\n"
+            "        Rendered output.\n"
+            '    """\n'
+            "    return template\n"
+            "\n"
+            "\n"
+            "def transform(data: list) -> list:\n"
+            '    """Transform a data list.\n'
+            "\n"
+            "    Parameters\n"
+            "    ----------\n"
+            "    data\n"
+            "        Input data.\n"
+            "\n"
+            "    Returns\n"
+            "    -------\n"
+            "    list\n"
+            "        Transformed data.\n"
+            '    """\n'
+            "    return data\n"
+        ),
+        # ── User guide page 1: Line styles ───────────────────────────────
+        "user_guide/01-line-styles.qmd": (
+            "---\n"
+            "title: Line Styles\n"
+            "---\n"
+            "\n"
+            "The `{{< hr >}}` shortcode supports multiple line styles.\n"
+            "Each style changes how the rule is rendered.\n"
+            "\n"
+            "## Default (Solid)\n"
+            "\n"
+            "A plain horizontal rule with default settings:\n"
+            "\n"
+            "{{< hr >}}\n"
+            "\n"
+            "The default is a 2px solid line at full width.\n"
+            "\n"
+            "## Dashed\n"
+            "\n"
+            'A dashed rule using `style="dashed"`:\n'
+            "\n"
+            '{{< hr style="dashed" >}}\n'
+            "\n"
+            "Dashes work well for separating related content.\n"
+            "\n"
+            "## Dotted\n"
+            "\n"
+            'A dotted rule using `style="dotted"`:\n'
+            "\n"
+            '{{< hr style="dotted" >}}\n'
+            "\n"
+            "Dots create a softer, less prominent separation.\n"
+            "\n"
+            "## Double\n"
+            "\n"
+            'A double-line rule using `style="double"`:\n'
+            "\n"
+            '{{< hr style="double" >}}\n'
+            "\n"
+            "Double lines signal a more definitive break.\n"
+            "\n"
+            "## Comparing All Styles\n"
+            "\n"
+            "Here they are side by side for comparison:\n"
+            "\n"
+            "**Solid:**\n"
+            "\n"
+            "{{< hr >}}\n"
+            "\n"
+            "**Dashed:**\n"
+            "\n"
+            '{{< hr style="dashed" >}}\n'
+            "\n"
+            "**Dotted:**\n"
+            "\n"
+            '{{< hr style="dotted" >}}\n'
+            "\n"
+            "**Double:**\n"
+            "\n"
+            '{{< hr style="double" >}}\n'
+        ),
+        # ── User guide page 2: Colors ────────────────────────────────────
+        "user_guide/02-colors.qmd": (
+            "---\n"
+            "title: Colors\n"
+            "---\n"
+            "\n"
+            "Horizontal rules can use named palette colors or custom hex values.\n"
+            "\n"
+            "## Palette Colors\n"
+            "\n"
+            "Great Docs ships with eight gradient palette presets.\n"
+            "Each can be used as a named color:\n"
+            "\n"
+            "**Sky:**\n"
+            "\n"
+            '{{< hr color="sky" >}}\n'
+            "\n"
+            "**Peach:**\n"
+            "\n"
+            '{{< hr color="peach" >}}\n'
+            "\n"
+            "**Prism:**\n"
+            "\n"
+            '{{< hr color="prism" >}}\n'
+            "\n"
+            "**Lilac:**\n"
+            "\n"
+            '{{< hr color="lilac" >}}\n'
+            "\n"
+            "**Slate:**\n"
+            "\n"
+            '{{< hr color="slate" >}}\n'
+            "\n"
+            "**Honey:**\n"
+            "\n"
+            '{{< hr color="honey" >}}\n'
+            "\n"
+            "**Dusk:**\n"
+            "\n"
+            '{{< hr color="dusk" >}}\n'
+            "\n"
+            "**Mint:**\n"
+            "\n"
+            '{{< hr color="mint" >}}\n'
+            "\n"
+            "## Custom Colors\n"
+            "\n"
+            "Any CSS color value works with the `color` parameter:\n"
+            "\n"
+            "**Rose red:**\n"
+            "\n"
+            '{{< hr color="#e11d48" >}}\n'
+            "\n"
+            "**Forest green:**\n"
+            "\n"
+            '{{< hr color="#16a34a" >}}\n'
+            "\n"
+            "**Royal blue:**\n"
+            "\n"
+            '{{< hr color="#2563eb" >}}\n'
+            "\n"
+            "**Amber:**\n"
+            "\n"
+            '{{< hr color="#d97706" >}}\n'
+            "\n"
+            "## Accent Color\n"
+            "\n"
+            'Use `color="accent"` to reference the site\'s theme accent:\n'
+            "\n"
+            '{{< hr color="accent" >}}\n'
+            "\n"
+            "## Colored Styles\n"
+            "\n"
+            "Colors combine with line styles naturally:\n"
+            "\n"
+            '{{< hr style="dashed" color="#e11d48" >}}\n'
+            "\n"
+            '{{< hr style="dotted" color="#2563eb" >}}\n'
+            "\n"
+            '{{< hr style="double" color="#16a34a" >}}\n'
+        ),
+        # ── User guide page 3: Sizing and alignment ──────────────────────
+        "user_guide/03-sizing-alignment.qmd": (
+            "---\n"
+            "title: Sizing & Alignment\n"
+            "---\n"
+            "\n"
+            "Control the thickness, width, alignment, and spacing of rules.\n"
+            "\n"
+            "## Thickness\n"
+            "\n"
+            "Named thickness values — `thin`, `medium` (default), and `thick`:\n"
+            "\n"
+            '{{< hr thickness="thin" >}}\n'
+            "\n"
+            "{{< hr >}}\n"
+            "\n"
+            '{{< hr thickness="thick" >}}\n'
+            "\n"
+            "Custom pixel values:\n"
+            "\n"
+            '{{< hr thickness="1px" >}}\n'
+            "\n"
+            '{{< hr thickness="3px" >}}\n'
+            "\n"
+            '{{< hr thickness="6px" >}}\n'
+            "\n"
+            "## Width\n"
+            "\n"
+            "Rules can be narrower than the full container:\n"
+            "\n"
+            '{{< hr width="100%" >}}\n'
+            "\n"
+            '{{< hr width="75%" >}}\n'
+            "\n"
+            '{{< hr width="50%" >}}\n'
+            "\n"
+            '{{< hr width="25%" >}}\n'
+            "\n"
+            "## Alignment\n"
+            "\n"
+            "When the rule is narrower than 100%, alignment matters:\n"
+            "\n"
+            "**Center (default):**\n"
+            "\n"
+            '{{< hr width="50%" align="center" >}}\n'
+            "\n"
+            "**Left:**\n"
+            "\n"
+            '{{< hr width="50%" align="left" >}}\n'
+            "\n"
+            "**Right:**\n"
+            "\n"
+            '{{< hr width="50%" align="right" >}}\n'
+            "\n"
+            "## Spacing\n"
+            "\n"
+            "Control the vertical margin around the rule:\n"
+            "\n"
+            "Content above.\n"
+            "\n"
+            '{{< hr spacing="compact" >}}\n'
+            "\n"
+            "Compact spacing (1rem).\n"
+            "\n"
+            '{{< hr spacing="normal" >}}\n'
+            "\n"
+            "Normal spacing (2rem, default).\n"
+            "\n"
+            '{{< hr spacing="spacious" >}}\n'
+            "\n"
+            "Spacious spacing (4rem).\n"
+            "\n"
+            "## Combined Sizing\n"
+            "\n"
+            "Mix thickness, width, and alignment:\n"
+            "\n"
+            '{{< hr thickness="thick" width="60%" align="left" color="#6366f1" >}}\n'
+            "\n"
+            '{{< hr thickness="thin" width="40%" align="right" style="dashed" >}}\n'
+            "\n"
+            '{{< hr thickness="3px" width="80%" color="#e11d48" >}}\n'
+        ),
+        # ── User guide page 4: Embedded text ─────────────────────────────
+        "user_guide/04-embedded-text.qmd": (
+            "---\n"
+            "title: Embedded Text\n"
+            "---\n"
+            "\n"
+            "Place text or symbols in the center of a horizontal rule.\n"
+            "\n"
+            "## Simple Symbols\n"
+            "\n"
+            "Single characters work great as decorative breaks:\n"
+            "\n"
+            '{{< hr text="§" >}}\n'
+            "\n"
+            '{{< hr text="✦" >}}\n'
+            "\n"
+            '{{< hr text="◆" >}}\n'
+            "\n"
+            '{{< hr text="❖" >}}\n'
+            "\n"
+            "## Multiple Symbols\n"
+            "\n"
+            "Repeat a symbol for a decorative pattern:\n"
+            "\n"
+            '{{< hr text="· · ·" >}}\n'
+            "\n"
+            '{{< hr text="★ ★ ★" >}}\n'
+            "\n"
+            '{{< hr text="— ✦ —" >}}\n'
+            "\n"
+            "## Text Labels\n"
+            "\n"
+            "Full words or short phrases as section dividers:\n"
+            "\n"
+            '{{< hr text="Continue Reading" >}}\n'
+            "\n"
+            '{{< hr text="Part Two" >}}\n'
+            "\n"
+            '{{< hr text="End of Section" >}}\n'
+            "\n"
+            "## Text Sizing\n"
+            "\n"
+            "Three text sizes are available — `sm`, `md` (default), and `lg`:\n"
+            "\n"
+            '{{< hr text="Small" text-size="sm" >}}\n'
+            "\n"
+            '{{< hr text="Medium" >}}\n'
+            "\n"
+            '{{< hr text="Large" text-size="lg" >}}\n'
+            "\n"
+            "## Colored Text Rules\n"
+            "\n"
+            "Combine text with colors:\n"
+            "\n"
+            '{{< hr text="Chapter One" color="#6366f1" >}}\n'
+            "\n"
+            '{{< hr text="Warning" color="#e11d48" text-color="#e11d48" >}}\n'
+            "\n"
+            '{{< hr text="Success" color="#16a34a" text-color="#16a34a" >}}\n'
+            "\n"
+            "## Text with Width and Alignment\n"
+            "\n"
+            '{{< hr text="Centered" width="70%" >}}\n'
+            "\n"
+            '{{< hr text="Left" width="60%" align="left" >}}\n'
+            "\n"
+            '{{< hr text="Right" width="60%" align="right" >}}\n'
+        ),
+        # ── User guide page 5: Presets ───────────────────────────────────
+        "user_guide/05-presets.qmd": (
+            "---\n"
+            "title: Presets\n"
+            "---\n"
+            "\n"
+            "Presets provide ready-made decorative styles.\n"
+            "Each preset has a distinct visual character.\n"
+            "\n"
+            "## Gradient Shimmer\n"
+            "\n"
+            "An animated gradient that shifts across the rule — the signature\n"
+            "Great Docs look from the homepage:\n"
+            "\n"
+            '{{< hr preset="gradient-shimmer" >}}\n'
+            "\n"
+            "## Gradient Static\n"
+            "\n"
+            "The same gradient palette without animation:\n"
+            "\n"
+            '{{< hr preset="gradient-static" >}}\n'
+            "\n"
+            "## Fade\n"
+            "\n"
+            "Full opacity at center, transparent at both edges:\n"
+            "\n"
+            '{{< hr preset="fade" >}}\n'
+            "\n"
+            "## Fade Edges\n"
+            "\n"
+            "Transparent edges that bloom into a colored center:\n"
+            "\n"
+            '{{< hr preset="fade-edges" >}}\n'
+            "\n"
+            "## Dots\n"
+            "\n"
+            "Three centered dots — a classic section break:\n"
+            "\n"
+            '{{< hr preset="dots" >}}\n'
+            "\n"
+            "## Diamond\n"
+            "\n"
+            "A diamond ornament flanked by fading lines:\n"
+            "\n"
+            '{{< hr preset="diamond" >}}\n'
+            "\n"
+            "## Ornament\n"
+            "\n"
+            "An elegant fleuron between fading lines:\n"
+            "\n"
+            '{{< hr preset="ornament" >}}\n'
+            "\n"
+            "## Wave\n"
+            "\n"
+            "A subtle repeating wave pattern:\n"
+            "\n"
+            '{{< hr preset="wave" >}}\n'
+            "\n"
+            "## Double Line\n"
+            "\n"
+            "Two parallel thin lines with a gap:\n"
+            "\n"
+            '{{< hr preset="double-line" >}}\n'
+            "\n"
+            "## Preset Gallery\n"
+            "\n"
+            "All presets in sequence for comparison:\n"
+            "\n"
+            '{{< hr preset="gradient-shimmer" >}}\n'
+            '{{< hr preset="gradient-static" >}}\n'
+            '{{< hr preset="fade" >}}\n'
+            '{{< hr preset="fade-edges" >}}\n'
+            '{{< hr preset="dots" >}}\n'
+            '{{< hr preset="diamond" >}}\n'
+            '{{< hr preset="ornament" >}}\n'
+            '{{< hr preset="wave" >}}\n'
+            '{{< hr preset="double-line" >}}\n'
+        ),
+        # ── User guide page 6: Combinations ──────────────────────────────
+        "user_guide/06-combinations.qmd": (
+            "---\n"
+            "title: Combinations\n"
+            "---\n"
+            "\n"
+            "The real power of `{{< hr >}}` comes from combining options.\n"
+            "Presets can be customized with width, alignment, spacing, and color.\n"
+            "\n"
+            "## Preset with Width\n"
+            "\n"
+            "Narrow the shimmer preset to 60%:\n"
+            "\n"
+            '{{< hr preset="gradient-shimmer" width="60%" >}}\n'
+            "\n"
+            "A fade at 50%, centered:\n"
+            "\n"
+            '{{< hr preset="fade" width="50%" >}}\n'
+            "\n"
+            "## Preset with Spacing\n"
+            "\n"
+            "Spacious shimmer for a dramatic section break:\n"
+            "\n"
+            '{{< hr preset="gradient-shimmer" width="60%" spacing="spacious" >}}\n'
+            "\n"
+            "Compact dots for a subtle pause:\n"
+            "\n"
+            '{{< hr preset="dots" spacing="compact" >}}\n'
+            "\n"
+            "## Colored Presets\n"
+            "\n"
+            "Override the default accent color on presets:\n"
+            "\n"
+            '{{< hr preset="dots" color="#e11d48" >}}\n'
+            "\n"
+            '{{< hr preset="diamond" color="#2563eb" >}}\n'
+            "\n"
+            '{{< hr preset="ornament" color="#d97706" >}}\n'
+            "\n"
+            "## Style + Color + Sizing\n"
+            "\n"
+            "A thick dashed peach line, aligned left at 75%:\n"
+            "\n"
+            '{{< hr style="dashed" color="peach" width="75%" thickness="thick" >}}\n'
+            "\n"
+            "A thin dotted blue line at 40%, right-aligned:\n"
+            "\n"
+            '{{< hr style="dotted" color="#2563eb" width="40%" thickness="thin" align="right" >}}\n'
+            "\n"
+            "## Text + Style + Color\n"
+            "\n"
+            "A labeled rule with custom styling:\n"
+            "\n"
+            '{{< hr text="Chapter Break" color="#6366f1" thickness="thick" >}}\n'
+            "\n"
+            '{{< hr text="§" color="#e11d48" width="50%" >}}\n'
+            "\n"
+            "## Real-World Examples\n"
+            "\n"
+            "### Blog post section break\n"
+            "\n"
+            '{{< hr preset="dots" spacing="spacious" >}}\n'
+            "\n"
+            "### Chapter divider\n"
+            "\n"
+            '{{< hr text="Chapter Two" color="#6366f1" thickness="thick" width="80%" >}}\n'
+            "\n"
+            "### Elegant page separator\n"
+            "\n"
+            '{{< hr preset="ornament" width="60%" spacing="spacious" >}}\n'
+            "\n"
+            "### API section boundary\n"
+            "\n"
+            '{{< hr preset="gradient-shimmer" >}}\n'
+            "\n"
+            "### Light decorative break\n"
+            "\n"
+            '{{< hr preset="fade" thickness="thin" width="50%" >}}\n'
+            "\n"
+            "### Strong visual separator\n"
+            "\n"
+            '{{< hr thickness="thick" color="#1e293b" width="90%" >}}\n'
+        ),
+        # ── README ───────────────────────────────────────────────────────
+        "README.md": (
+            "# gdtest-hr-shortcode\n"
+            "\n"
+            "A synthetic test package that exercises the `{{< hr >}}` Quarto\n"
+            "shortcode with every supported option: line styles, colors,\n"
+            "thickness, width, alignment, embedded text, animated presets,\n"
+            "and combined parameters.\n"
+        ),
+    },
+    "expected": {
+        "detected_name": "gdtest-hr-shortcode",
+        "detected_module": "gdtest_hr_shortcode",
+        "detected_parser": "numpy",
+        "export_names": ["render", "transform"],
+        "num_exports": 2,
+        "has_user_guide": True,
+        "user_guide_files": [
+            "line-styles.qmd",
+            "colors.qmd",
+            "sizing-alignment.qmd",
+            "embedded-text.qmd",
+            "presets.qmd",
+            "combinations.qmd",
+        ],
+        "files_contain": {
+            "great-docs/_site/user-guide/line-styles.html": [
+                "gd-hr",
+                "gd-hr--dashed",
+                "gd-hr--dotted",
+                "gd-hr--double",
+            ],
+            "great-docs/_site/user-guide/colors.html": [
+                "gd-hr",
+                "--gd-hr-color",
+                "gd-palette-sky",
+            ],
+            "great-docs/_site/user-guide/sizing-alignment.html": [
+                "gd-hr",
+                "--gd-hr-thickness",
+                "--gd-hr-width",
+                "gd-hr--left",
+                "gd-hr--right",
+            ],
+            "great-docs/_site/user-guide/embedded-text.html": [
+                "gd-hr--with-text",
+                "gd-hr-text",
+                "gd-hr-line",
+            ],
+            "great-docs/_site/user-guide/presets.html": [
+                "gd-hr--gradient-shimmer",
+                "gd-hr--fade",
+                "gd-hr--dots",
+                "gd-hr--diamond",
+                "gd-hr--ornament",
+                "gd-hr--wave",
+                "gd-hr--double-line",
+            ],
+            "great-docs/_site/user-guide/combinations.html": [
+                "gd-hr",
+                "gd-hr--gradient-shimmer",
+                "--gd-hr-width",
+            ],
+        },
+    },
+}

--- a/user_guide/33-horizontal-rules.qmd
+++ b/user_guide/33-horizontal-rules.qmd
@@ -1,0 +1,453 @@
+---
+title: "Horizontal Rules"
+guide-section: "Site Content"
+tags: [Content, Extensions]
+status: experimental
+upcoming: "0.10"
+versions: ">=0.9"
+---
+
+# Horizontal Rules
+
+Markdown's `---` gives you a plain horizontal rule, but documentation sites often need something
+more expressive. Examples might include: a chapter divider, a gradient accent that matches your
+navbar, a decorative ornament between sections, or a labeled break that tells readers "Part Two
+starts here."
+
+The `{{{< hr >}}}` shortcode turns the humble `<hr>` into a flexible design tool. It supports four
+line styles, eight palette colors (plus any custom CSS color), adjustable thickness and width, text
+labels embedded in the rule, and nine ready-made presets.
+
+## Quick Start
+
+Drop a shortcode into any `.qmd` page to get a styled rule:
+
+````markdown
+{{{< hr >}}}
+````
+
+{{< hr >}}
+
+That gives you a 2px solid line at full width. To make it more interesting:
+
+````markdown
+{{{< hr preset="gradient-shimmer" >}}}
+````
+
+{{< hr preset="gradient-shimmer" >}}
+
+## Line Styles
+
+Four border styles are available via the `style` parameter:
+
+````markdown
+{{{< hr style="solid" >}}}
+{{{< hr style="dashed" >}}}
+{{{< hr style="dotted" >}}}
+{{{< hr style="double" >}}}
+````
+
+**Solid** (default):
+
+{{< hr style="solid" >}}
+
+**Dashed:**
+
+{{< hr style="dashed" >}}
+
+**Dotted:**
+
+{{< hr style="dotted" >}}
+
+**Double:**
+
+{{< hr style="double" >}}
+
+## Colors
+
+### Palette Colors
+
+Great Docs ships with eight gradient palette presets. Each one maps to a distinct color that adapts
+to dark mode automatically:
+
+| Name | Light | Dark | Example |
+|------|-------|------|---------|
+| `sky` | Deep blue | Bright sky | {{< hr color="sky" >}} |
+| `peach` | Warm orange | Soft peach | {{< hr color="peach" >}} |
+| `prism` | Rich purple | Soft violet | {{< hr color="prism" >}} |
+| `lilac` | Bright lilac | Light purple | {{< hr color="lilac" >}} |
+| `slate` | Cool gray | Light slate | {{< hr color="slate" >}} |
+| `honey` | Golden amber | Bright gold | {{< hr color="honey" >}} |
+| `dusk` | Indigo | Soft indigo | {{< hr color="dusk" >}} |
+| `mint` | Teal | Bright mint | {{< hr color="mint" >}} |
+
+### Custom Colors
+
+Any CSS color value works (hex codes, named colors, `rgb()`, or `hsl()`):
+
+````markdown
+{{{< hr color="#e11d48" >}}}
+{{{< hr color="#16a34a" >}}}
+{{{< hr color="#2563eb" >}}}
+````
+
+{{< hr color="#e11d48" >}}
+
+{{< hr color="#16a34a" >}}
+
+{{< hr color="#2563eb" >}}
+
+### Colored Line Styles
+
+Colors combine naturally with line styles:
+
+````markdown
+{{{< hr style="dashed" color="#e11d48" >}}}
+{{{< hr style="dotted" color="#2563eb" >}}}
+````
+
+{{< hr style="dashed" color="#e11d48" >}}
+
+{{< hr style="dotted" color="#2563eb" >}}
+
+## Thickness
+
+Control the line weight with named values or exact pixel sizes:
+
+| Value | Pixels |
+|-------|--------|
+| `thin` | 1px |
+| `medium` | 2px (default) |
+| `thick` | 4px |
+
+````markdown
+{{{< hr thickness="thin" >}}}
+{{{< hr >}}}
+{{{< hr thickness="thick" >}}}
+{{{< hr thickness="6px" >}}}
+````
+
+{{< hr thickness="thin" >}}
+
+{{< hr >}}
+
+{{< hr thickness="thick" >}}
+
+{{< hr thickness="6px" >}}
+
+## Width and Alignment
+
+By default, rules span the full container width. Use `width` to make them narrower, and `align` to
+position them when they don't fill the container:
+
+````markdown
+{{{< hr width="75%" >}}}
+{{{< hr width="50%" align="center" >}}}
+{{{< hr width="50%" align="left" >}}}
+{{{< hr width="50%" align="right" >}}}
+````
+
+{{< hr width="75%" >}}
+
+{{< hr width="50%" align="center" >}}
+
+{{< hr width="50%" align="left" >}}
+
+{{< hr width="50%" align="right" >}}
+
+The `width` parameter accepts any CSS length or percentage. Use `full` as a shorthand for `100%`.
+
+## Spacing
+
+Control the vertical margin around the rule with the `spacing` parameter:
+
+| Value | Margin |
+|-------|--------|
+| `compact` | 1rem |
+| `normal` | 2rem (default) |
+| `spacious` | 4rem |
+
+````markdown
+{{{< hr spacing="compact" >}}}
+{{{< hr spacing="spacious" >}}}
+````
+
+**Compact** (`1rem`):
+
+This is some text before the rule.
+
+{{< hr spacing="compact" >}}
+
+This is some text after the rule. Notice the tight spacing above and below.
+
+**Normal** (`2rem`, default):
+
+This is some text before the rule.
+
+{{< hr spacing="normal" >}}
+
+This is some text after the rule. This is the default amount of breathing room.
+
+**Spacious** (`4rem`):
+
+This is some text before the rule.
+
+{{< hr spacing="spacious" >}}
+
+This is some text after the rule. The extra whitespace creates a clear section break.
+
+## Embedded Text
+
+Place text or symbols in the center of a rule. The rule splits into two lines flanking the text:
+
+````markdown
+{{{< hr text="§" >}}}
+{{{< hr text="Continue Reading" >}}}
+{{{< hr text="★ ★ ★" >}}}
+````
+
+{{< hr text="§" >}}
+
+{{< hr text="Continue Reading" >}}
+
+{{< hr text="★ ★ ★" >}}
+
+### Text Size
+
+The sizes `sm`, `md` (default), and `lg` are available:
+
+````markdown
+{{{< hr text="Small" text-size="sm" >}}}
+{{{< hr text="Medium" >}}}
+{{{< hr text="Large" text-size="lg" >}}}
+````
+
+{{< hr text="Small" text-size="sm" >}}
+
+{{< hr text="Medium" >}}
+
+{{< hr text="Large" text-size="lg" >}}
+
+### Colored Text
+
+Add `text-color` to style the label independently from the line, or use `color` to tint both at once:
+
+````markdown
+{{{< hr text="Warning" color="#e11d48" text-color="#e11d48" >}}}
+{{{< hr text="Chapter One" color="#6366f1" >}}}
+````
+
+{{< hr text="Warning" color="#e11d48" text-color="#e11d48" >}}
+
+{{< hr text="Chapter One" color="#6366f1" >}}
+
+### Text with Width
+
+Text rules respect `width` and `align`:
+
+````markdown
+{{{< hr text="Centered" width="70%" >}}}
+{{{< hr text="Left" width="60%" align="left" >}}}
+````
+
+{{< hr text="Centered" width="70%" >}}
+
+{{< hr text="Left" width="60%" align="left" >}}
+
+## Presets
+
+Presets are ready-made visual styles that go beyond what `style` and `color` can achieve. Use
+`preset` to apply one:
+
+### Gradient Shimmer
+
+We can get a horizontal rule that animates with a gradient. It shimmers smoothly:
+
+````markdown
+{{{< hr preset="gradient-shimmer" >}}}
+````
+
+{{< hr preset="gradient-shimmer" >}}
+
+::: {.callout-note}
+The shimmer animation respects `prefers-reduced-motion`. Users who prefer reduced motion will see a
+static gradient instead.
+:::
+
+### Gradient Static
+
+The same gradient palette without animation:
+
+````markdown
+{{{< hr preset="gradient-static" >}}}
+````
+
+{{< hr preset="gradient-static" >}}
+
+### Fade
+
+Full opacity at center, fading to transparent at both edges:
+
+````markdown
+{{{< hr preset="fade" >}}}
+````
+
+{{< hr preset="fade" >}}
+
+### Fade Edges
+
+Transparent edges blooming into a colored center:
+
+````markdown
+{{{< hr preset="fade-edges" >}}}
+````
+
+{{< hr preset="fade-edges" >}}
+
+### Dots
+
+Three centered dots form a classic section break (with no line):
+
+````markdown
+{{{< hr preset="dots" >}}}
+````
+
+{{< hr preset="dots" >}}
+
+### Diamond
+
+A diamond ornament flanked by fading lines:
+
+````markdown
+{{{< hr preset="diamond" >}}}
+````
+
+{{< hr preset="diamond" >}}
+
+### Ornament
+
+An elegant fleuron (❧) between fading lines:
+
+````markdown
+{{{< hr preset="ornament" >}}}
+````
+
+{{< hr preset="ornament" >}}
+
+### Wave
+
+A subtle repeating diagonal pattern:
+
+````markdown
+{{{< hr preset="wave" >}}}
+````
+
+{{< hr preset="wave" >}}
+
+### Double Line
+
+Two parallel thin lines with a gap between them:
+
+````markdown
+{{{< hr preset="double-line" >}}}
+````
+
+{{< hr preset="double-line" >}}
+
+## Combining Options
+
+Presets define the visual pattern, but `width`, `align`, `spacing`, and `color` can still be
+overridden on top:
+
+````markdown
+{{{< hr preset="gradient-shimmer" width="60%" >}}}
+{{{< hr preset="fade" width="50%" spacing="spacious" >}}}
+{{{< hr preset="dots" color="#e11d48" >}}}
+{{{< hr preset="ornament" width="60%" spacing="spacious" >}}}
+````
+
+{{< hr preset="gradient-shimmer" width="60%" >}}
+
+{{< hr preset="fade" width="50%" spacing="spacious" >}}
+
+{{< hr preset="dots" color="#e11d48" >}}
+
+{{< hr preset="ornament" width="60%" spacing="spacious" >}}
+
+Style, color, and sizing options also combine freely:
+
+````markdown
+{{{< hr style="dashed" color="peach" width="75%" thickness="thick" >}}}
+{{{< hr style="dotted" color="#2563eb" width="40%" thickness="thin" align="right" >}}}
+````
+
+{{< hr style="dashed" color="peach" width="75%" thickness="thick" >}}
+
+{{< hr style="dotted" color="#2563eb" width="40%" thickness="thin" align="right" >}}
+
+## Real-World Patterns
+
+Here are some common documentation patterns and how to achieve them:
+
+**Blog-style section break:**
+
+````markdown
+{{{< hr preset="dots" spacing="spacious" >}}}
+````
+
+{{< hr preset="dots" spacing="spacious" >}}
+
+**Chapter divider with label:**
+
+````markdown
+{{{< hr text="Chapter Two" color="#6366f1" thickness="thick" width="80%" >}}}
+````
+
+{{< hr text="Chapter Two" color="#6366f1" thickness="thick" width="80%" >}}
+
+**Elegant page separator:**
+
+````markdown
+{{{< hr preset="ornament" width="60%" spacing="spacious" >}}}
+````
+
+{{< hr preset="ornament" width="60%" spacing="spacious" >}}
+
+**API section boundary:**
+
+````markdown
+{{{< hr preset="gradient-shimmer" >}}}
+````
+
+{{< hr preset="gradient-shimmer" >}}
+
+**Light decorative pause:**
+
+````markdown
+{{{< hr preset="fade" thickness="thin" width="50%" >}}}
+````
+
+{{< hr preset="fade" thickness="thin" width="50%" >}}
+
+## Parameter Reference
+
+| Parameter | Values | Default | Description |
+|-----------|--------|---------|-------------|
+| `style` | `solid`, `dashed`, `dotted`, `double` | `solid` | Line style |
+| `color` | Palette name, hex, CSS color | Site accent | Line color |
+| `thickness` | `thin`, `medium`, `thick`, or CSS value | `medium` (2px) | Line weight |
+| `width` | `full`, percentage, or CSS length | `100%` | Horizontal extent |
+| `align` | `center`, `left`, `right` | `center` | Position when width < 100% |
+| `spacing` | `compact`, `normal`, `spacious` | `normal` (2rem) | Vertical margin |
+| `text` | Any string | — | Text centered on the rule |
+| `text-size` | `sm`, `md`, `lg` | `md` | Size of embedded text |
+| `text-color` | Hex or CSS color | Inherits `color` | Text label color |
+| `preset` | See [Presets](#presets) | — | Ready-made visual style |
+
+## Dark Mode
+
+All colors adapt automatically in dark mode. Palette colors switch to brighter variants for
+visibility on dark backgrounds, and the overall opacity is reduced slightly for a softer look.
+Custom hex colors are preserved as-is but receive a subtle opacity adjustment.
+
+No extra configuration is needed as the shortcode works identically in both modes.


### PR DESCRIPTION
This PR introduces a new decorative horizontal rule (`hr`) shortcode extension for Quarto, along with styling and configuration support. It adds a flexible Lua shortcode, the SCSS implementation for various line styles and presets, and a new site-wide `accent_color` configuration option. The changes also include test catalog updates (i.e., GDG sites).