### PR TITLE
enh: improve section sidebar in desktop view

### DIFF
--- a/great_docs/assets/great-docs.scss
+++ b/great_docs/assets/great-docs.scss
@@ -1148,6 +1148,228 @@ a.sidebar-item-text.sidebar-link.text-start > span {
     padding-bottom: 8px;
 }
 
+/* ==========================================================================
+   Floating Sidebar Navigation (desktop only)
+   Transforms #quarto-sidebar into a pinned, independently-scrollable panel
+   with blur background, rounded border, and scroll affordances.
+   ========================================================================== */
+
+@media (min-width: 992px) {
+    #quarto-sidebar.gd-sidebar-float {
+        /* Sticky keeps the sidebar in the CSS grid flow.
+           JS sets top (stick offset) and max-height (shrinks for footer). */
+        display: flex;
+        flex-direction: column;
+        overflow: hidden !important; /* clip children to rounded corners; override .overflow-auto */
+        position: sticky;
+        transition: top 0.15s ease, max-height 0.15s ease;
+        /* Widen sidebar to reclaim space lost to border+padding.
+           Negative margin-right lets it extend slightly into the gap. */
+        margin-right: -12px;
+        /* align-self keeps the sidebar at the grid-row start so it
+           sticks near the top, not stretched to the full row height. */
+        align-self: start;
+    }
+
+    /* Suppress the old bottom border on the menu container —
+       it is now inside the float body. */
+    #quarto-sidebar.gd-sidebar-float .sidebar-menu-container {
+        border-bottom: none;
+    }
+
+    /* Remove default Bootstrap margin-bottom on the sidebar list
+       so the float body hugs the last item tightly. */
+    #quarto-sidebar.gd-sidebar-float .sidebar-menu-container > ul {
+        margin-bottom: 0;
+    }
+
+    #quarto-sidebar.gd-sidebar-float .sidebar-menu-container > ul > li:last-child {
+        padding-bottom: 7px;
+    }
+
+    /* Tighten vertical spacing between nav items inside the float */
+    #quarto-sidebar.gd-sidebar-float .sidebar-item {
+        margin-top: 0.1rem;
+        margin-bottom: 0.1em;
+    }
+
+    /* Override the ::before hover pill with a direct background on the link.
+       The ::before pseudo extends beyond the scroll container and gets clipped;
+       using the link's own background avoids that entirely. */
+    #quarto-sidebar.gd-sidebar-float .sidebar-link[href]::before {
+        display: none !important;
+        content: none !important;
+    }
+
+    #quarto-sidebar.gd-sidebar-float .sidebar-link[href] {
+        border-radius: 6px;
+        padding-left: 8px;
+        padding-right: 8px;
+        padding-top: 3px;
+        padding-bottom: 3px;
+        margin-left: -8px;
+        margin-right: 0;
+        transition: background-color 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    #quarto-sidebar.gd-sidebar-float .sidebar-link[href]:hover {
+        background-color: rgba(0, 0, 0, 0.04);
+        box-shadow: 0 1px 4px rgba(0, 0, 0, 0.10);
+    }
+
+    #quarto-sidebar.gd-sidebar-float.sidebar-navigation > * {
+        padding-top: 0.4em;
+    }
+
+    #quarto-sidebar.gd-sidebar-float > * {
+        padding-right: 0;
+    }
+}
+
+
+
+/* Scrollable body */
+.gd-sidebar-float-body {
+    display: none; /* hidden below 992px */
+}
+
+@media (min-width: 992px) {
+    .gd-sidebar-float-body {
+        display: block;
+        flex: 1 1 auto;
+        overflow-y: auto;
+        overscroll-behavior: contain;
+        position: relative;
+        /* Thin scrollbar for Webkit/Blink */
+        scrollbar-width: thin;
+        scrollbar-color: rgba(0, 0, 0, 0.15) transparent;
+
+        &::-webkit-scrollbar {
+            width: 5px;
+        }
+        &::-webkit-scrollbar-track {
+            background: transparent;
+        }
+        &::-webkit-scrollbar-thumb {
+            background: rgba(0, 0, 0, 0.12);
+            border-radius: 4px;
+        }
+    }
+}
+
+/* Scroll affordance indicators (top / bottom) */
+.gd-sidebar-scroll-indicator {
+    display: none; /* hidden below 992px */
+}
+
+@media (min-width: 992px) {
+    /* Indicators are inside .gd-sidebar-float-body (the scroll container)
+       and use position:sticky so they pin to the top/bottom of the
+       visible scroll area without covering the "Pages" header above. */
+    .gd-sidebar-scroll-indicator {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        position: sticky;
+        left: 0;
+        right: 0;
+        min-height: 32px;
+        margin-top: -32px;  /* collapse out of flow so content isn't pushed */
+        pointer-events: none;
+        opacity: 0;
+        transition: opacity 0.2s ease;
+        z-index: 3;
+    }
+
+    .gd-sidebar-scroll-indicator.visible {
+        opacity: 1;
+        pointer-events: auto;
+        cursor: pointer;
+    }
+
+    .gd-sidebar-scroll-top {
+        top: 0;
+        background: linear-gradient(to bottom, rgba(250, 250, 253, 0.92) 0%, transparent 100%);
+    }
+
+    .gd-sidebar-scroll-bottom {
+        bottom: 0;
+        position: sticky;
+        margin-top: 0;
+        margin-bottom: -32px;
+        background: linear-gradient(to top, rgba(250, 250, 253, 0.92) 0%, transparent 100%);
+    }
+
+    .gd-sidebar-scroll-arrow {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 24px;
+        height: 24px;
+        border-radius: 50%;
+        background: rgba(0, 0, 0, 0.06);
+        color: $gray-600;
+        font-size: 0.65rem;
+        line-height: 1;
+        transition: background 0.15s ease, color 0.15s ease;
+    }
+
+    .gd-sidebar-scroll-indicator:hover .gd-sidebar-scroll-arrow {
+        background: rgba(0, 0, 0, 0.12);
+        color: $gray-800;
+    }
+}
+
+/* ── Dark mode: Floating Sidebar ── */
+body.quarto-dark {
+    @media (min-width: 992px) {
+        #quarto-sidebar.gd-sidebar-float {
+            background: rgba(30, 30, 30, 0.55);
+            border-color: rgba(255, 255, 255, 0.10);
+            box-shadow: 0 1px 6px rgba(0, 0, 0, 0.25);
+        }
+
+
+        .gd-sidebar-float-body {
+            scrollbar-color: rgba(255, 255, 255, 0.15) transparent;
+
+            &::-webkit-scrollbar-thumb {
+                background: rgba(255, 255, 255, 0.12);
+            }
+        }
+
+        #quarto-sidebar.gd-sidebar-float .sidebar-link[href]:hover {
+            background-color: rgba(255, 255, 255, 0.08);
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+        }
+
+        .gd-sidebar-scroll-top {
+            background: linear-gradient(to bottom, rgba(30, 30, 30, 0.92) 0%, transparent 100%);
+        }
+
+        .gd-sidebar-scroll-bottom {
+            background: linear-gradient(to top, rgba(30, 30, 30, 0.92) 0%, transparent 100%);
+        }
+
+        .gd-sidebar-scroll-arrow {
+            background: rgba(255, 255, 255, 0.08);
+            color: $gray-400;
+        }
+
+        .gd-sidebar-scroll-indicator:hover .gd-sidebar-scroll-arrow {
+            background: rgba(255, 255, 255, 0.15);
+            color: $gray-200;
+        }
+    }
+}
+
+/* Print: hide floating sidebar affordances */
+@media print {
+    .gd-sidebar-scroll-indicator {
+        display: none !important;
+    }
+}
+
 #quarto-header > nav > div {
     margin-left: 2%;
     margin-right: 2%;
@@ -1351,6 +1573,10 @@ body.quarto-light .navbar .gd-navbar-icon:hover {
         overflow-x: auto;
         -webkit-overflow-scrolling: touch;
     }
+}
+
+footer.footer .nav-footer {
+    margin-top: 10px;
 }
 
 .nav-footer {

--- a/great_docs/assets/navbar-style.js
+++ b/great_docs/assets/navbar-style.js
@@ -42,6 +42,8 @@
 
     var els = document.querySelectorAll(".sidebar, .headroom-target");
     els.forEach(function (el) {
+      // Skip the floating sidebar — sidebar-float.js manages its own bounds
+      if (el.classList.contains('gd-sidebar-float')) return;
       el.style.top = h + "px";
       el.style.maxHeight = "calc(100vh - " + h + "px)";
     });

--- a/great_docs/assets/sidebar-float.js
+++ b/great_docs/assets/sidebar-float.js
@@ -1,0 +1,197 @@
+/**
+ * Floating Sidebar Navigation for Great Docs
+ *
+ * Transforms the default Quarto left sidebar on desktop (>= 992px) into a
+ * floating, pinned navigation panel with:
+ *   - Independent scroll containment (no bleed to page body)
+ *   - Dynamic top/bottom bounds that react to navbar and footer
+ *   - A sticky "Pages" header label
+ *   - Gradient + arrow scroll affordances (top & bottom)
+ *   - Auto-scroll to the active page on load
+ *
+ * On tablet/mobile (< 992px) this script is a no-op — the overlay modal
+ * approach handles the sidebar there.
+ */
+(function () {
+    'use strict';
+
+    // ── Constants ──────────────────────────────────────────────
+    var GAP = 12;           // breathing room (px) between sidebar and navbar/footer
+    var FOOTER_BUFFER = 7;  // extra px buffer before footer encroaches
+
+
+    // ── Media query guard ──────────────────────────────────────
+    var mql = window.matchMedia('(min-width: 992px)');
+
+    // ── State ──────────────────────────────────────────────────
+    var sidebar = null;         // #quarto-sidebar
+    var menuContainer = null;   // .sidebar-menu-container
+    var floatBody = null;       // .gd-sidebar-float-body (scrollable wrapper)
+    var resizeObs = null;       // ResizeObserver instance
+    var rafId = null;
+    var initialised = false;
+
+    // ── Helpers ────────────────────────────────────────────────
+    function getHeader() {
+        return document.getElementById('quarto-header');
+    }
+
+    function getFooter() {
+        return document.querySelector('footer.footer');
+    }
+
+    // ── Build the float structure ──────────────────────────────
+    function buildFloat() {
+        sidebar = document.getElementById('quarto-sidebar');
+        if (!sidebar) return false;
+        menuContainer = sidebar.querySelector('.sidebar-menu-container');
+        if (!menuContainer) return false;
+
+        // Scrollable body wrapper
+        floatBody = document.createElement('div');
+        floatBody.className = 'gd-sidebar-float-body';
+
+        // Move the menu container inside the scroll body
+        floatBody.appendChild(menuContainer);
+
+
+
+        // Assemble inside #quarto-sidebar
+        sidebar.appendChild(floatBody);
+
+        // Mark as enhanced
+        sidebar.classList.add('gd-sidebar-float');
+
+        return true;
+    }
+
+    // ── Update sidebar bounds ──────────────────────────────────
+    // With position:sticky, `top` sets the stick offset from the viewport top.
+    // We can't use `bottom` to shrink the sidebar — instead we compute a
+    // dynamic `max-height` that accounts for the navbar and footer overlap.
+    function updateBounds() {
+        if (!sidebar || !mql.matches) return;
+
+        var header = getHeader();
+        var footer = getFooter();
+        var viewportH = window.innerHeight;
+
+        var navBottom = header ? header.getBoundingClientRect().bottom : 0;
+        var footerTop = footer ? footer.getBoundingClientRect().top : viewportH;
+
+        var top = Math.max(0, navBottom) + GAP;
+
+        // Available height = viewport minus navbar minus any footer overlap minus gaps
+        var footerOverlap = Math.max(0, viewportH - footerTop);
+        var maxH = viewportH - top - footerOverlap - GAP - FOOTER_BUFFER;
+
+        sidebar.style.top = top + 'px';
+        // Always apply maxHeight so the sidebar never overflows its bounds
+        sidebar.style.maxHeight = Math.max(100, maxH) + 'px';
+    }
+
+
+
+    // ── Scroll-to-active ───────────────────────────────────────
+    function scrollToActive() {
+        if (!floatBody) return;
+        var active = floatBody.querySelector('.sidebar-link.active');
+        if (active) {
+            // Scroll only the float body — NOT the main page.
+            // scrollIntoView() would bubble up and shift the document.
+            requestAnimationFrame(function () {
+                var bodyRect = floatBody.getBoundingClientRect();
+                var activeRect = active.getBoundingClientRect();
+                var offset = activeRect.top - bodyRect.top - (bodyRect.height / 2) + (activeRect.height / 2);
+                floatBody.scrollTop += offset;
+            });
+        }
+    }
+
+    // ── rAF-throttled scroll/resize handler ────────────────────
+    function onFrameUpdate() {
+        updateBounds();
+        rafId = null;
+    }
+
+    function scheduleUpdate() {
+        if (rafId) return;
+        rafId = requestAnimationFrame(onFrameUpdate);
+    }
+
+    // Immediate update on resize for more responsive bounds
+    function onResize() {
+        updateBounds();
+        scheduleUpdate(); // also schedule a follow-up in case layout settles
+    }
+
+    // ── Teardown (for breakpoint changes) ──────────────────────
+    function teardown() {
+        if (!initialised) return;
+
+        // Move menu container back to sidebar root
+        if (menuContainer && sidebar) {
+            sidebar.appendChild(menuContainer);
+        }
+
+        // Remove added elements
+
+        if (floatBody && floatBody.parentNode) floatBody.parentNode.removeChild(floatBody);
+
+        sidebar.classList.remove('gd-sidebar-float');
+        sidebar.style.top = '';
+        sidebar.style.maxHeight = '';
+
+        // Remove listeners
+        window.removeEventListener('scroll', scheduleUpdate);
+        window.removeEventListener('resize', onResize);
+        window.removeEventListener('quarto-hrChanged', scheduleUpdate);
+        if (resizeObs) {
+            resizeObs.disconnect();
+            resizeObs = null;
+        }
+        floatBody = null;
+        initialised = false;
+    }
+
+    // ── Initialise ─────────────────────────────────────────────
+    function init() {
+        if (initialised) return;
+        if (!mql.matches) return;
+
+        if (!buildFloat()) return;
+
+        // Bind events
+        window.addEventListener('scroll', scheduleUpdate, { passive: true });
+        window.addEventListener('resize', onResize, { passive: true });
+        window.addEventListener('quarto-hrChanged', scheduleUpdate);
+
+        // ResizeObserver for more reliable size tracking
+        if (typeof ResizeObserver !== 'undefined') {
+            resizeObs = new ResizeObserver(scheduleUpdate);
+            resizeObs.observe(document.documentElement);
+        }
+
+        initialised = true;
+
+        // Initial measurements
+        updateBounds();
+        scrollToActive();
+    }
+
+    // ── Respond to breakpoint changes ──────────────────────────
+    mql.addEventListener('change', function () {
+        if (mql.matches) {
+            init();
+        } else {
+            teardown();
+        }
+    });
+
+    // ── Boot ───────────────────────────────────────────────────
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -197,6 +197,7 @@ class GreatDocs:
             "github-widget.js",
             "sidebar-filter.js",
             "sidebar-wrap.js",
+            "sidebar-float.js",
             "reference-switcher.js",
             "dark-mode-toggle.js",
             "theme-init.js",
@@ -9820,6 +9821,7 @@ body-classes: "gd-homepage"
             "github-widget.js",
             "sidebar-filter.js",
             "sidebar-wrap.js",
+            "sidebar-float.js",
             "dark-mode-toggle.js",
             "theme-init.js",
             "copy-code.js",
@@ -10188,6 +10190,27 @@ body-classes: "gd-homepage"
         )
         if not has_wrap:
             config["format"]["html"]["include-after-body"].append(wrap_script_entry)
+
+        # Add floating sidebar script (pinned, scrollable sidebar on desktop).
+        # Quarto does not always rewrite bare src paths in text entries for
+        # newly-added files, so we use an inline loader that reads the
+        # quarto:offset meta tag (always present) to resolve the site root.
+        float_inline = (
+            "<script>"
+            "(function(){"
+            "var s=document.createElement('script');"
+            "var m=document.querySelector('meta[name=\"quarto:offset\"]');"
+            "s.src=(m?m.content:'')+'sidebar-float.js';"
+            "document.body.appendChild(s);"
+            "})();"
+            "</script>"
+        )
+        float_script_entry = {"text": float_inline}
+        has_float = any(
+            "sidebar-float" in str(item) for item in config["format"]["html"]["include-after-body"]
+        )
+        if not has_float:
+            config["format"]["html"]["include-after-body"].append(float_script_entry)
 
         # Add sidebar filter script if enabled
         if metadata.get("sidebar_filter_enabled", True):

--- a/test-packages/synthetic/catalog.py
+++ b/test-packages/synthetic/catalog.py
@@ -132,6 +132,7 @@ ALL_PACKAGES: list[str] = [
     "gdtest_source_disabled",  # 05
     "gdtest_sidebar_disabled",  # 06
     "gdtest_sidebar_min_items",  # 07
+    "gdtest_sidebar_float",  # 07b
     "gdtest_cli_name",  # 08
     "gdtest_dynamic_false",  # 09
     "gdtest_parser_google",  # 10
@@ -1218,6 +1219,13 @@ PACKAGE_DESCRIPTIONS: dict[str, str] = {
         "Tests sidebar_filter.min_items: 3 (low threshold). The sidebar "
         "filter should appear even with just 4 items because the threshold "
         "is set low. Four functions (w, x, y, z)."
+    ),
+    "gdtest_sidebar_float": (
+        "Stress test for the floating sidebar. Has 32 user guide pages "
+        "organized into 5 sections (Getting Started, Core Concepts, "
+        "Advanced Usage, Deployment, Reference). The sidebar should be "
+        "tall enough to require scrolling, with gradient affordances "
+        "visible and active-page auto-scrolling."
     ),
     "gdtest_cli_name": (
         "Tests cli.name: 'mytool' (explicit CLI name). The CLI reference "

--- a/test-packages/synthetic/specs/gdtest_sidebar_float.py
+++ b/test-packages/synthetic/specs/gdtest_sidebar_float.py
@@ -1,0 +1,212 @@
+"""
+gdtest_sidebar_float — Floating sidebar stress test.
+
+Dimensions: N10
+Focus: 30+ user guide pages in multiple sections to stress-test the floating
+       sidebar with scroll containment, affordances, and active-page highlighting.
+"""
+
+# ── User guide page definitions ──────────────────────────────────────────────
+# Organized into sections with many pages per section to make the sidebar tall.
+
+_SECTIONS = {
+    "Getting Started": [
+        ("welcome", "Welcome"),
+        ("installation", "Installation"),
+        ("quickstart", "Quickstart"),
+        ("first-project", "First Project"),
+        ("editor-setup", "Editor Setup"),
+    ],
+    "Core Concepts": [
+        ("architecture", "Architecture"),
+        ("configuration", "Configuration"),
+        ("themes", "Themes"),
+        ("layouts", "Layouts"),
+        ("templates", "Templates"),
+        ("data-sources", "Data Sources"),
+        ("routing", "Routing"),
+    ],
+    "Advanced Usage": [
+        ("plugins", "Plugins"),
+        ("custom-directives", "Custom Directives"),
+        ("internationalization", "Internationalization"),
+        ("performance", "Performance Tuning"),
+        ("caching", "Caching Strategies"),
+        ("security", "Security Best Practices"),
+        ("accessibility", "Accessibility"),
+    ],
+    "Deployment": [
+        ("local-preview", "Local Preview"),
+        ("static-hosting", "Static Hosting"),
+        ("ci-cd", "CI/CD Pipelines"),
+        ("docker", "Docker Containers"),
+        ("cdn-setup", "CDN Setup"),
+        ("monitoring", "Monitoring"),
+    ],
+    "Reference": [
+        ("cli-reference", "CLI Reference"),
+        ("config-reference", "Config Reference"),
+        ("api-reference", "API Reference"),
+        ("changelog", "Changelog"),
+        ("migration-guide", "Migration Guide"),
+        ("troubleshooting", "Troubleshooting"),
+        ("faq", "FAQ"),
+    ],
+}
+
+# Build numbered user_guide files and expected outputs
+_ug_files: dict[str, str] = {}
+_expected_files: list[str] = []
+_counter = 1
+
+for section_name, pages in _SECTIONS.items():
+    for slug, title in pages:
+        filename = f"{_counter:02d}-{slug}.qmd"
+        _ug_files[f"user_guide/{filename}"] = (
+            f"---\n"
+            f'title: "{title}"\n'
+            f"---\n"
+            f"\n"
+            f"## {title}\n"
+            f"\n"
+            f"This is the **{title}** page in the _{section_name}_ section.\n"
+            f"\n"
+            f"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do\n"
+            f"eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim\n"
+            f"ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut\n"
+            f"aliquip ex ea commodo consequat.\n"
+        )
+        html_name = filename.replace(".qmd", ".html")
+        _expected_files.append(f"great-docs/user-guide/{html_name}")
+        _counter += 1
+
+
+SPEC = {
+    "name": "gdtest_sidebar_float",
+    "description": "30+ user guide pages in 5 sections to stress-test floating sidebar.",
+    "dimensions": ["N10"],
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-sidebar-float",
+            "version": "0.1.0",
+            "description": "Floating sidebar stress test with 32 user guide pages.",
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    },
+    "config": {
+        "user_guide": "user_guide",
+        "user_guide_sections": {
+            "Getting Started": [
+                "01-welcome",
+                "02-installation",
+                "03-quickstart",
+                "04-first-project",
+                "05-editor-setup",
+            ],
+            "Core Concepts": [
+                "06-architecture",
+                "07-configuration",
+                "08-themes",
+                "09-layouts",
+                "10-templates",
+                "11-data-sources",
+                "12-routing",
+            ],
+            "Advanced Usage": [
+                "13-plugins",
+                "14-custom-directives",
+                "15-internationalization",
+                "16-performance",
+                "17-caching",
+                "18-security",
+                "19-accessibility",
+            ],
+            "Deployment": [
+                "20-local-preview",
+                "21-static-hosting",
+                "22-ci-cd",
+                "23-docker",
+                "24-cdn-setup",
+                "25-monitoring",
+            ],
+            "Reference": [
+                "26-cli-reference",
+                "27-config-reference",
+                "28-api-reference",
+                "29-changelog",
+                "30-migration-guide",
+                "31-troubleshooting",
+                "32-faq",
+            ],
+        },
+    },
+    "files": {
+        "gdtest_sidebar_float/__init__.py": (
+            '"""Floating sidebar test package."""\n'
+            "\n"
+            '__version__ = "0.1.0"\n'
+            '__all__ = ["configure", "build", "deploy"]\n'
+            "\n"
+            "\n"
+            "def configure(path: str) -> dict:\n"
+            '    """Configure the project.\n'
+            "\n"
+            "    Parameters\n"
+            "    ----------\n"
+            "    path : str\n"
+            "        Path to the config file.\n"
+            "\n"
+            "    Returns\n"
+            "    -------\n"
+            "    dict\n"
+            "        Parsed configuration.\n"
+            '    """\n'
+            "    return {}\n"
+            "\n"
+            "\n"
+            "def build(config: dict) -> None:\n"
+            '    """Build the site from configuration.\n'
+            "\n"
+            "    Parameters\n"
+            "    ----------\n"
+            "    config : dict\n"
+            "        Project configuration.\n"
+            '    """\n'
+            "    pass\n"
+            "\n"
+            "\n"
+            "def deploy(target: str = 'production') -> bool:\n"
+            '    """Deploy the built site.\n'
+            "\n"
+            "    Parameters\n"
+            "    ----------\n"
+            "    target : str\n"
+            "        Deployment target name.\n"
+            "\n"
+            "    Returns\n"
+            "    -------\n"
+            "    bool\n"
+            "        True if deployment succeeded.\n"
+            '    """\n'
+            "    return True\n"
+        ),
+        **_ug_files,
+        "README.md": (
+            "# gdtest-sidebar-float\n"
+            "\n"
+            "Stress test for the floating sidebar with 32 user guide pages\n"
+            "organized into 5 sections.\n"
+        ),
+    },
+    "expected": {
+        "detected_name": "gdtest-sidebar-float",
+        "detected_module": "gdtest_sidebar_float",
+        "detected_parser": "numpy",
+        "export_names": ["configure", "build", "deploy"],
+        "num_exports": 3,
+        "files_exist": _expected_files,
+    },
+}


### PR DESCRIPTION
This PR implements a new floating, pinned sidebar navigation for Great Docs on desktop devices (≥992px). The sidebar becomes an independently scrollable panel with dynamic bounds and visual scroll affordances. The implementation includes both the JavaScript logic and SCSS styling, integrates the feature into the build and Quarto config, and adds a synthetic test case to exercise the new sidebar.