### PR TITLE
fix: enable rendering of inherited methods

### DIFF
--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -7228,13 +7228,25 @@ class GreatDocs:
                         continue
 
                     members = item.get("members", True)
+                    include_inherited = item.get("include_inherited", None)
 
                     if members is False:
                         # Don't document methods - just the class
                         section_contents.append({"name": name, "members": []})
+                    elif isinstance(members, list):
+                        # Explicit member list — pass through directly
+                        entry: dict = {"name": name, "members": members}
+                        if include_inherited is not None:
+                            entry["include_inherited"] = include_inherited
+                        section_contents.append(entry)
                     else:
                         # Default: inline documentation (members: true)
-                        section_contents.append(name)
+                        if include_inherited is not None:
+                            section_contents.append(
+                                {"name": name, "include_inherited": include_inherited}
+                            )
+                        else:
+                            section_contents.append(name)
 
             if section_contents:
                 sections.append(
@@ -7350,13 +7362,26 @@ class GreatDocs:
                         continue  # pragma: no cover
 
                     members = item.get("members", True)
+                    include_inherited = item.get("include_inherited", None)
 
                     if members is False:
                         # Don't document methods - just the class
                         section_contents.append({"name": name, "members": []})
+                    elif isinstance(members, list):
+                        # Explicit member list — pass through so inherited
+                        # methods listed here are documented
+                        entry: dict = {"name": name, "members": members}
+                        if include_inherited is not None:
+                            entry["include_inherited"] = include_inherited
+                        section_contents.append(entry)
                     else:
                         # Default: inline documentation (members: true)
-                        section_contents.append(name)  # pragma: no cover
+                        if include_inherited is not None:
+                            section_contents.append(
+                                {"name": name, "include_inherited": include_inherited}
+                            )
+                        else:
+                            section_contents.append(name)
 
             if section_contents:
                 sections.append(

--- a/test-packages/synthetic/catalog.py
+++ b/test-packages/synthetic/catalog.py
@@ -375,6 +375,9 @@ ALL_PACKAGES: list[str] = [
     "gdtest_inline_always",  # 185
     "gdtest_inline_never",  # 186
     "gdtest_inline_threshold",  # 187
+    # 188–189: Inherited member documentation
+    "gdtest_ref_inherited_explicit",  # 188
+    "gdtest_ref_include_inherited",  # 189
 ]
 
 
@@ -570,6 +573,8 @@ DIMENSIONS: dict[str, dict[str, str]] = {
     "P6": {"axis": "reference", "label": "Module expansion"},
     "P7": {"axis": "reference", "label": "Big class ref"},
     "P8": {"axis": "reference", "label": "Reference title"},
+    "P9": {"axis": "reference", "label": "Explicit inherited members"},
+    "P10": {"axis": "reference", "label": "include_inherited flag"},
     # Site/theme axes
     "Q1": {"axis": "theme", "label": "Cosmo theme"},
     "Q2": {"axis": "theme", "label": "Lumen theme"},
@@ -2101,6 +2106,17 @@ PACKAGE_DESCRIPTIONS: dict[str, str] = {
         "Tests inline_methods: 10 custom numeric threshold. CompactClient "
         "(8 methods) stays inline while FullClient (12 methods) gets split "
         "into a separate method section."
+    ),
+    # ── 188–189: Inherited member documentation ────────────────────────────
+    "gdtest_ref_inherited_explicit": (
+        "Reference config listing inherited methods (validate, reset) explicitly "
+        "in the members list of AdvancedProcessor. The child class page should "
+        "document all three listed methods even though two are inherited."
+    ),
+    "gdtest_ref_include_inherited": (
+        "Reference config using include_inherited: true on Circle. The renderer "
+        "should automatically include inherited methods (describe) from Shape "
+        "without the user listing them explicitly."
     ),
 }
 

--- a/test-packages/synthetic/specs/gdtest_ref_include_inherited.py
+++ b/test-packages/synthetic/specs/gdtest_ref_include_inherited.py
@@ -1,0 +1,149 @@
+"""
+gdtest_ref_include_inherited — Reference config with include_inherited: true.
+
+Dimensions: P10
+Focus: Reference config using include_inherited: true to automatically
+       document all inherited methods on a child class without listing them
+       explicitly.
+"""
+
+SPEC = {
+    "name": "gdtest_ref_include_inherited",
+    "description": "Reference config with include_inherited: true flag.",
+    "dimensions": ["P10"],
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-ref-include-inherited",
+            "version": "0.1.0",
+            "description": "Test include_inherited flag in reference config.",
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    },
+    "config": {
+        "reference": [
+            {
+                "title": "Shapes",
+                "desc": "Shape hierarchy",
+                "contents": [
+                    "Shape",
+                    {
+                        "name": "Circle",
+                        "include_inherited": True,
+                    },
+                ],
+            },
+        ],
+    },
+    "files": {
+        "gdtest_ref_include_inherited/__init__.py": '''\
+            """Package testing include_inherited flag."""
+
+            __version__ = "0.1.0"
+            __all__ = ["Shape", "Circle"]
+
+
+            class Shape:
+                """
+                Abstract base shape.
+
+                Parameters
+                ----------
+                color : str
+                    Fill color.
+                """
+
+                def __init__(self, color: str = "red"):
+                    self.color = color
+
+                def area(self) -> float:
+                    """
+                    Compute the area of the shape.
+
+                    Returns
+                    -------
+                    float
+                        Area value.
+                    """
+                    raise NotImplementedError
+
+                def perimeter(self) -> float:
+                    """
+                    Compute the perimeter of the shape.
+
+                    Returns
+                    -------
+                    float
+                        Perimeter value.
+                    """
+                    raise NotImplementedError
+
+                def describe(self) -> str:
+                    """
+                    Return a human-readable description.
+
+                    Returns
+                    -------
+                    str
+                        Description string.
+                    """
+                    return f"{self.__class__.__name__}(color={self.color})"
+
+
+            class Circle(Shape):
+                """
+                A circle shape.
+
+                Parameters
+                ----------
+                radius : float
+                    Circle radius.
+                color : str
+                    Fill color.
+                """
+
+                def __init__(self, radius: float, color: str = "blue"):
+                    super().__init__(color)
+                    self.radius = radius
+
+                def area(self) -> float:
+                    """
+                    Compute the area of the circle.
+
+                    Returns
+                    -------
+                    float
+                        Pi * radius^2.
+                    """
+                    import math
+                    return math.pi * self.radius ** 2
+
+                def perimeter(self) -> float:
+                    """
+                    Compute the circumference.
+
+                    Returns
+                    -------
+                    float
+                        2 * pi * radius.
+                    """
+                    import math
+                    return 2 * math.pi * self.radius
+        ''',
+        "README.md": (
+            "# gdtest-ref-include-inherited\n\n"
+            "Tests include_inherited: true flag for auto-documenting inherited methods.\n"
+        ),
+    },
+    "expected": {
+        "detected_name": "gdtest-ref-include-inherited",
+        "detected_module": "gdtest_ref_include_inherited",
+        "detected_parser": "numpy",
+        "export_names": ["Shape", "Circle"],
+        "num_exports": 2,
+        "section_titles": ["Shapes"],
+        "has_user_guide": False,
+    },
+}

--- a/test-packages/synthetic/specs/gdtest_ref_inherited_explicit.py
+++ b/test-packages/synthetic/specs/gdtest_ref_inherited_explicit.py
@@ -1,0 +1,136 @@
+"""
+gdtest_ref_inherited_explicit — Reference config with explicit inherited members.
+
+Dimensions: P9
+Focus: Reference config listing inherited methods explicitly via members list.
+       The child class's reference page should document both its own and
+       inherited methods specified in the members list.
+"""
+
+SPEC = {
+    "name": "gdtest_ref_inherited_explicit",
+    "description": "Reference config listing inherited methods explicitly.",
+    "dimensions": ["P9"],
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-ref-inherited-explicit",
+            "version": "0.1.0",
+            "description": "Test explicit inherited members in reference config.",
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    },
+    "config": {
+        "reference": [
+            {
+                "title": "Core",
+                "desc": "Core classes",
+                "contents": [
+                    "BaseProcessor",
+                    {
+                        "name": "AdvancedProcessor",
+                        "members": ["process", "validate", "reset"],
+                    },
+                ],
+            },
+        ],
+    },
+    "files": {
+        "gdtest_ref_inherited_explicit/__init__.py": '''\
+            """Package testing explicit inherited member documentation."""
+
+            __version__ = "0.1.0"
+            __all__ = ["BaseProcessor", "AdvancedProcessor"]
+
+
+            class BaseProcessor:
+                """
+                Base processor with core functionality.
+
+                Parameters
+                ----------
+                name : str
+                    Processor name.
+                """
+
+                def __init__(self, name: str):
+                    self.name = name
+
+                def validate(self, data: dict) -> bool:
+                    """
+                    Validate input data.
+
+                    Parameters
+                    ----------
+                    data : dict
+                        Data to validate.
+
+                    Returns
+                    -------
+                    bool
+                        True if valid.
+                    """
+                    return bool(data)
+
+                def reset(self) -> None:
+                    """
+                    Reset the processor state.
+
+                    Returns
+                    -------
+                    None
+                    """
+                    pass
+
+
+            class AdvancedProcessor(BaseProcessor):
+                """
+                Advanced processor that inherits validate and reset from Base.
+
+                Parameters
+                ----------
+                name : str
+                    Processor name.
+                mode : str
+                    Processing mode.
+                """
+
+                def __init__(self, name: str, mode: str = "fast"):
+                    super().__init__(name)
+                    self.mode = mode
+
+                def process(self, data: dict) -> dict:
+                    """
+                    Process data using the configured mode.
+
+                    Parameters
+                    ----------
+                    data : dict
+                        Data to process.
+
+                    Returns
+                    -------
+                    dict
+                        Processed results.
+                    """
+                    if self.validate(data):
+                        return {"result": data, "mode": self.mode}
+                    return {}
+        ''',
+        "README.md": (
+            "# gdtest-ref-inherited-explicit\n\n"
+            "Tests explicit inherited member documentation via reference config.\n"
+        ),
+    },
+    "expected": {
+        "detected_name": "gdtest-ref-inherited-explicit",
+        "detected_module": "gdtest_ref_inherited_explicit",
+        "detected_parser": "numpy",
+        "export_names": ["BaseProcessor", "AdvancedProcessor"],
+        "num_exports": 2,
+        "section_titles": ["Core"],
+        "has_user_guide": False,
+    },
+}

--- a/tests/test_gdg_rendered.py
+++ b/tests/test_gdg_rendered.py
@@ -8765,3 +8765,115 @@ def test_DED_inline_never_both_methods_sections_in_sidebar():
     content = index_html.read_text(encoding="utf-8")
     assert "TinyWidget Methods" in content, "Should have TinyWidget Methods section"
     assert "MediumService Methods" in content, "Should have MediumService Methods section"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# DED: Inherited Member Documentation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+_INHERITED_EXPLICIT_PKG = "gdtest_ref_inherited_explicit"
+_INCLUDE_INHERITED_PKG = "gdtest_ref_include_inherited"
+
+
+@requires_bs4
+def test_DED_ref_inherited_explicit_page_exists():
+    """gdtest_ref_inherited_explicit: AdvancedProcessor page exists."""
+    pkg = _INHERITED_EXPLICIT_PKG
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+
+    ref = _ref_dir(pkg)
+    assert (ref / "AdvancedProcessor.html").exists(), "AdvancedProcessor page should exist"
+
+
+@requires_bs4
+def test_DED_ref_inherited_explicit_own_method():
+    """gdtest_ref_inherited_explicit: own method 'process' documented."""
+    pkg = _INHERITED_EXPLICIT_PKG
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+
+    soup = _load_html(_ref_dir(pkg) / "AdvancedProcessor.html")
+    text = soup.get_text()
+    assert "process" in text, "Own method 'process' should appear on page"
+
+
+@requires_bs4
+def test_DED_ref_inherited_explicit_inherited_methods():
+    """gdtest_ref_inherited_explicit: inherited methods 'validate' and 'reset' documented."""
+    pkg = _INHERITED_EXPLICIT_PKG
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+
+    soup = _load_html(_ref_dir(pkg) / "AdvancedProcessor.html")
+    text = soup.get_text()
+    assert "validate" in text, "Inherited method 'validate' should appear on page"
+    assert "reset" in text, "Inherited method 'reset' should appear on page"
+
+
+@requires_bs4
+def test_DED_ref_inherited_explicit_section_title():
+    """gdtest_ref_inherited_explicit: reference index has 'Core' section title."""
+    pkg = _INHERITED_EXPLICIT_PKG
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+
+    index_html = _ref_dir(pkg) / "index.html"
+    if not index_html.exists():
+        pytest.skip("Reference index not found")
+
+    content = index_html.read_text(encoding="utf-8")
+    assert "Core" in content, "Section title 'Core' should appear in reference index"
+
+
+@requires_bs4
+def test_DED_ref_include_inherited_page_exists():
+    """gdtest_ref_include_inherited: Circle page exists."""
+    pkg = _INCLUDE_INHERITED_PKG
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+
+    ref = _ref_dir(pkg)
+    assert (ref / "Circle.html").exists(), "Circle page should exist"
+
+
+@requires_bs4
+def test_DED_ref_include_inherited_own_methods():
+    """gdtest_ref_include_inherited: own methods 'area' and 'perimeter' documented."""
+    pkg = _INCLUDE_INHERITED_PKG
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+
+    soup = _load_html(_ref_dir(pkg) / "Circle.html")
+    text = soup.get_text()
+    assert "area" in text, "Own method 'area' should appear on page"
+    assert "perimeter" in text, "Own method 'perimeter' should appear on page"
+
+
+@requires_bs4
+def test_DED_ref_include_inherited_inherited_method():
+    """gdtest_ref_include_inherited: inherited method 'describe' auto-documented."""
+    pkg = _INCLUDE_INHERITED_PKG
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+
+    soup = _load_html(_ref_dir(pkg) / "Circle.html")
+    text = soup.get_text()
+    assert "describe" in text, (
+        "Inherited method 'describe' should appear via include_inherited: true"
+    )
+
+
+@requires_bs4
+def test_DED_ref_include_inherited_section_title():
+    """gdtest_ref_include_inherited: reference index has 'Shapes' section title."""
+    pkg = _INCLUDE_INHERITED_PKG
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+
+    index_html = _ref_dir(pkg) / "index.html"
+    if not index_html.exists():
+        pytest.skip("Reference index not found")
+
+    content = index_html.read_text(encoding="utf-8")
+    assert "Shapes" in content, "Section title 'Shapes' should appear in reference index"

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -2066,6 +2066,53 @@ def test_build_sections_from_reference_config_with_members():
         assert "SimpleClass" in sections[0]["contents"]
 
 
+def test_build_sections_from_reference_config_explicit_members_list():
+    """Test building sections with explicit members list passes through correctly."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        docs = GreatDocs(project_path=tmp_dir)
+
+        reference_config = [
+            {
+                "title": "Classes",
+                "desc": "Parent and child",
+                "contents": [
+                    {"name": "foo", "members": ["__init__", "a"]},
+                    {"name": "bar", "members": ["__init__", "a", "b"]},
+                ],
+            }
+        ]
+
+        sections = docs._build_sections_from_reference_config(reference_config)
+
+        assert sections is not None
+        assert len(sections) == 1
+        contents = sections[0]["contents"]
+        assert {"name": "foo", "members": ["__init__", "a"]} in contents
+        assert {"name": "bar", "members": ["__init__", "a", "b"]} in contents
+
+
+def test_build_sections_from_reference_config_include_inherited():
+    """Test building sections with include_inherited option."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        docs = GreatDocs(project_path=tmp_dir)
+
+        reference_config = [
+            {
+                "title": "Classes",
+                "contents": [
+                    {"name": "bar", "include_inherited": True},
+                ],
+            }
+        ]
+
+        sections = docs._build_sections_from_reference_config(reference_config)
+
+        assert sections is not None
+        contents = sections[0]["contents"]
+        assert len(contents) == 1
+        assert contents[0] == {"name": "bar", "include_inherited": True}
+
+
 def test_build_sections_from_reference_config_empty_and_none():
     """Test that empty reference config returns None."""
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -24796,6 +24843,140 @@ def test_create_api_sections_from_config_dict_items():
             assert found
         finally:
             sys.path.remove(tmp_dir)
+
+
+def test_create_api_sections_from_config_explicit_members_passthrough():
+    """Test _create_api_sections_from_config passes explicit member lists through."""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        pkg_dir = Path(tmp_dir) / "inhpkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text(
+            'class Parent:\n    """Parent."""\n    def inherited(self): pass\n'
+            'class Child(Parent):\n    """Child."""\n    def own(self): pass\n',
+            encoding="utf-8",
+        )
+
+        sys.path.insert(0, tmp_dir)
+        try:
+            docs = GreatDocs(project_path=tmp_dir)
+            docs._config = type(
+                "Config",
+                (),
+                {
+                    "reference": [
+                        {
+                            "title": "API",
+                            "contents": [
+                                {
+                                    "name": "Child",
+                                    "members": ["own", "inherited"],
+                                },
+                            ],
+                        },
+                    ],
+                    "should_split_methods": lambda self, n: n > 5,
+                },
+            )()
+
+            with (
+                patch.object(docs, "_get_package_exports", return_value=["Child"]),
+                patch.object(docs, "_write_object_types_json"),
+            ):
+                result = docs._create_api_sections_from_config("inhpkg")
+
+            assert result is not None
+            section = result[0]
+            # The explicit members list should be passed through intact
+            found = False
+            for item in section["contents"]:
+                if isinstance(item, dict) and item.get("name") == "Child":
+                    assert item["members"] == ["own", "inherited"]
+                    found = True
+            assert found
+        finally:
+            sys.path.remove(tmp_dir)
+
+
+def test_create_api_sections_from_config_include_inherited():
+    """Test _create_api_sections_from_config passes include_inherited flag."""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        pkg_dir = Path(tmp_dir) / "inhpkg2"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text(
+            'class Base:\n    """Base."""\n    def base_method(self): pass\n'
+            'class Derived(Base):\n    """Derived."""\n    def derived_method(self): pass\n',
+            encoding="utf-8",
+        )
+
+        sys.path.insert(0, tmp_dir)
+        try:
+            docs = GreatDocs(project_path=tmp_dir)
+            docs._config = type(
+                "Config",
+                (),
+                {
+                    "reference": [
+                        {
+                            "title": "API",
+                            "contents": [
+                                {
+                                    "name": "Derived",
+                                    "include_inherited": True,
+                                },
+                            ],
+                        },
+                    ],
+                    "should_split_methods": lambda self, n: n > 5,
+                },
+            )()
+
+            with (
+                patch.object(docs, "_get_package_exports", return_value=["Derived"]),
+                patch.object(docs, "_write_object_types_json"),
+            ):
+                result = docs._create_api_sections_from_config("inhpkg2")
+
+            assert result is not None
+            section = result[0]
+            # Should have include_inherited flag set
+            found = False
+            for item in section["contents"]:
+                if isinstance(item, dict) and item.get("name") == "Derived":
+                    assert item["include_inherited"] is True
+                    found = True
+            assert found
+        finally:
+            sys.path.remove(tmp_dir)
+
+
+def test_build_sections_from_reference_config_explicit_members():
+    """Test _build_sections_from_reference_config passes explicit members list."""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        docs = GreatDocs(project_path=tmp_dir)
+        config = [
+            {
+                "title": "Classes",
+                "contents": [
+                    {"name": "Child", "members": ["own", "inherited"]},
+                    {"name": "Other", "members": ["x"], "include_inherited": True},
+                ],
+            },
+        ]
+        result = docs._build_sections_from_reference_config(config)
+
+        assert result is not None
+        contents = result[0]["contents"]
+        # Explicit members list passed through
+        assert contents[0] == {"name": "Child", "members": ["own", "inherited"]}
+        # include_inherited also attached
+        assert contents[1] == {
+            "name": "Other",
+            "members": ["x"],
+            "include_inherited": True,
+        }
 
 
 def test_build_sections_from_reference_config_empty():

--- a/user_guide/05-api-documentation.qmd
+++ b/user_guide/05-api-documentation.qmd
@@ -267,6 +267,43 @@ reference:
 
 When `members: false` is set, only the class itself is documented. You can then place individual methods wherever you want in your reference structure.
 
+### Documenting Inherited Methods
+
+By default, only methods defined directly on a class are documented. If your class hierarchy uses inheritance and you want child classes to show inherited methods, there are two approaches.
+
+**Explicit member list.** List the methods you want documented (including inherited ones) in the `members` key:
+
+```{.yaml filename="great-docs.yml"}
+reference:
+  - title: API
+    contents:
+      - BaseProcessor
+      - name: AdvancedProcessor
+        members:
+          - process        # own method
+          - validate       # inherited from BaseProcessor
+          - reset          # inherited from BaseProcessor
+```
+
+This gives you full control over which inherited methods appear and in what order.
+
+**Auto-include inherited methods.** Use `include_inherited: true` to automatically document all inherited methods without listing them explicitly:
+
+```{.yaml filename="great-docs.yml"}
+reference:
+  - title: Shapes
+    contents:
+      - Shape
+      - name: Circle
+        include_inherited: true  # includes area(), perimeter(), describe() from Shape
+```
+
+With this flag, the child class page will show its own methods plus all public methods inherited from parent classes.
+
+::: {.callout-tip}
+You can combine both approaches. Use `include_inherited: true` for convenience, or provide an explicit `members` list when you want to cherry-pick specific inherited methods or control ordering.
+:::
+
 ### Excluding Items with `exclude`
 
 To exclude items from documentation, add them to the `exclude` list in `great-docs.yml`:

--- a/user_guide/05-api-documentation.qmd
+++ b/user_guide/05-api-documentation.qmd
@@ -269,7 +269,9 @@ When `members: false` is set, only the class itself is documented. You can then 
 
 ### Documenting Inherited Methods
 
-By default, only methods defined directly on a class are documented. If your class hierarchy uses inheritance and you want child classes to show inherited methods, there are two approaches.
+By default, only methods defined directly on a class are documented. Inherited methods are excluded unless you opt in. This keeps reference pages focused and avoids duplicating parent class methods on every child page (especially important in deep class hierarchies where it would add significant clutter).
+
+If your class hierarchy uses inheritance and you want child classes to show inherited methods, there are two approaches.
 
 **Explicit member list.** List the methods you want documented (including inherited ones) in the `members` key:
 


### PR DESCRIPTION
This PR adds support for documenting inherited class members in reference configurations, both when inherited members are explicitly listed and when an `include_inherited` flag is set. It introduces new test cases and synthetic test packages to ensure correct handling of these scenarios.

Fixes: https://github.com/posit-dev/great-docs/issues/141
