### PR TITLE
fix: remove requirement to use shift key when sorting in table explorer

### DIFF
--- a/great_docs/assets/tbl-explorer.js
+++ b/great_docs/assets/tbl-explorer.js
@@ -687,13 +687,13 @@
           applyState(el, state);
         }
 
-        th.addEventListener("click", function (e) {
-          doSort(e.shiftKey);
+        th.addEventListener("click", function () {
+          doSort(true);
         });
         th.addEventListener("keydown", function (e) {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
-            doSort(e.shiftKey);
+            doSort(true);
           }
         });
       })(ths[i], i - offset);

--- a/user_guide/32-table-explorer.qmd
+++ b/user_guide/32-table-explorer.qmd
@@ -54,15 +54,9 @@ tbl_explorer("data/students.csv")
 
 ## Sorting
 
-Click any column header to cycle through three states: **ascending → descending → unsorted**. Sort indicators appear as SVG arrows next to column names.
+Click any column header to cycle through three states: **ascending → descending → unsorted**. Sort indicators appear as arrows next to column names.
 
-For multi-column sorting, hold **Shift** while clicking additional columns. Each column sorts within the groups established by prior sort columns. For example, shift-clicking *department* then *salary* will group by department and sort salaries within each department.
-
-```{python}
-#| echo: false
-#| output: false
-# This example is for reference; sorting is demonstrated interactively.
-```
+Multi-column sorting is always active. Clicking additional columns adds them to the sort stack, with each column sorting within the groups established by prior sort columns. For example, clicking *department* then *salary* will group by department and sort salaries within each department. To start over, use the reset button to clear all sort criteria.
 
 ## Token-Based Filtering
 


### PR DESCRIPTION
This PR updates the table explorer's sorting behavior and documentation to simplify multi-column sorting for users. Multi-column sorting is now always enabled, so users no longer need to hold Shift to sort by multiple columns. The documentation is updated to reflect this change and clarify the new interaction model.