### PR TITLE
fix: add per-container min-scale overrides in scale-to-fit div

### DIFF
--- a/great_docs/assets/responsive-tables.js
+++ b/great_docs/assets/responsive-tables.js
@@ -148,6 +148,11 @@
 
   function applyScaleToFit(container, minScaleObj) {
     // minScaleObj: parsed result from parseMinScale(), or null.
+    // Per-container data-min-scale overrides the page/global threshold.
+    var containerMinScale = parseMinScale(container.getAttribute("data-min-scale"));
+    if (containerMinScale) {
+      minScaleObj = containerMinScale;
+    }
     // Find the content to scale — first child element that has measurable width
     var inner = container.querySelector(".cell-output-display, .cell-output, table, .gt_table");
     if (!inner) {

--- a/test-packages/synthetic/specs/gdtest_scale_to_fit.py
+++ b/test-packages/synthetic/specs/gdtest_scale_to_fit.py
@@ -11,7 +11,10 @@ Focus: Exercises the 3-level scale-to-fit configuration system by rendering
           One page overrides the global selectors so only ``#page_gt`` scales.
        3. **Manual div** (``:::{.scale-to-fit}``):
           One page wraps output in a ``.scale-to-fit`` div manually.
-       4. **No-scale page**: A narrow GT table that matches no selectors,
+       4. **Per-div min-scale** (``:::{.scale-to-fit data-min-scale="0.5"}``):
+          A ``.scale-to-fit`` div with its own ``data-min-scale`` attribute,
+          overriding the global/page threshold for that single element.
+       5. **No-scale page**: A narrow GT table that matches no selectors,
           verifying that tables which don't match aren't affected.
 
        Verification targets:
@@ -19,6 +22,7 @@ Focus: Exercises the 3-level scale-to-fit configuration system by rendering
        - ``gd-scale-to-fit-page`` meta tag present only on page-override page
        - ``.scale-to-fit`` class on auto-targeted containers
        - ``.gd-scale-wrapper`` div inside scaled containers
+       - ``data-min-scale`` attribute on per-div containers
        - Non-targeted elements have no scale-to-fit classes
        - ID-based targeting works (``#wide_gt`` scaled, ``#narrow_gt`` not)
 """
@@ -348,10 +352,95 @@ SPEC = {
             ")\n"
             "```\n"
         ),
-        # ── User guide: Page 4 — Multiple widths comparison ──────────────
+        # ── User guide: Page 4 — Per-div data-min-scale ──────────────────
+        # This page uses :::{.scale-to-fit data-min-scale="..."} to set
+        # per-container min-scale thresholds, overriding the global one.
+        "user_guide/04-per-div-min-scale.qmd": (
+            "---\n"
+            "title: Per-Div Min Scale\n"
+            "---\n"
+            "\n"
+            "## Wide Table with Numeric Threshold\n"
+            "\n"
+            "This table is inside a `.scale-to-fit` div with\n"
+            '`data-min-scale="0.5"`, which overrides the global\n'
+            "`tablet` keyword threshold.\n"
+            "\n"
+            ':::{.scale-to-fit data-min-scale="0.5"}\n'
+            "```{python}\n"
+            "#| echo: false\n"
+            "from great_tables import GT\n"
+            "import pandas as pd\n"
+            "\n"
+            "df = pd.DataFrame({\n"
+            '    f"Col_{i:02d}": [f"val_{r}_{i}" for r in range(4)]\n'
+            "    for i in range(1, 13)\n"
+            "})\n"
+            "\n"
+            "(\n"
+            '    GT(df, id="perdiv_numeric")\n'
+            '    .tab_header(title="Per-Div Numeric Threshold (0.5)")\n'
+            '    .cols_width(**{f"Col_{i:02d}": "110px" for i in range(1, 13)})\n'
+            "    .tab_options(quarto_disable_processing=True)\n"
+            ")\n"
+            "```\n"
+            ":::\n"
+            "\n"
+            "## Wide Table with Keyword Threshold\n"
+            "\n"
+            "This table is inside a `.scale-to-fit` div with\n"
+            '`data-min-scale="mobile"`, so it only scrolls on\n'
+            "viewports at or below 576 px.\n"
+            "\n"
+            ':::{.scale-to-fit data-min-scale="mobile"}\n'
+            "```{python}\n"
+            "#| echo: false\n"
+            "from great_tables import GT\n"
+            "import pandas as pd\n"
+            "\n"
+            "df = pd.DataFrame({\n"
+            '    f"Col_{i:02d}": [f"val_{r}_{i}" for r in range(4)]\n'
+            "    for i in range(1, 13)\n"
+            "})\n"
+            "\n"
+            "(\n"
+            '    GT(df, id="perdiv_keyword")\n'
+            '    .tab_header(title="Per-Div Keyword Threshold (mobile)")\n'
+            '    .cols_width(**{f"Col_{i:02d}": "110px" for i in range(1, 13)})\n'
+            "    .tab_options(quarto_disable_processing=True)\n"
+            ")\n"
+            "```\n"
+            ":::\n"
+            "\n"
+            "## Wide Table without Per-Div Override\n"
+            "\n"
+            "This table uses a plain `.scale-to-fit` div with no\n"
+            "`data-min-scale`, so it inherits the global `tablet` threshold.\n"
+            "\n"
+            ":::{.scale-to-fit}\n"
+            "```{python}\n"
+            "#| echo: false\n"
+            "from great_tables import GT\n"
+            "import pandas as pd\n"
+            "\n"
+            "df = pd.DataFrame({\n"
+            '    f"Col_{i:02d}": [f"val_{r}_{i}" for r in range(4)]\n'
+            "    for i in range(1, 13)\n"
+            "})\n"
+            "\n"
+            "(\n"
+            '    GT(df, id="perdiv_inherit")\n'
+            '    .tab_header(title="Plain Div (inherits global threshold)")\n'
+            '    .cols_width(**{f"Col_{i:02d}": "110px" for i in range(1, 13)})\n'
+            "    .tab_options(quarto_disable_processing=True)\n"
+            ")\n"
+            "```\n"
+            ":::\n"
+        ),
+        # ── User guide: Page 5 — Multiple widths comparison ──────────────
         # Shows tables of 4, 8, 12, and 16 columns side-by-side with a
         # shared class selector for testing class-based targeting.
-        "user_guide/04-width-comparison.qmd": (
+        "user_guide/05-width-comparison.qmd": (
             "---\n"
             "title: Width Comparison\n"
             "---\n"
@@ -421,6 +510,7 @@ SPEC = {
             "global-targeting.html",
             "page-override.html",
             "manual-div.html",
+            "per-div-min-scale.html",
             "width-comparison.html",
         ],
         "reference_pages": [
@@ -456,5 +546,13 @@ SPEC = {
         "manual_div_id": "manual_gt",
         # Manual div page: #unwrapped_gt is NOT inside .scale-to-fit
         "unwrapped_id": "unwrapped_gt",
+        # Per-div min-scale page: element IDs
+        "perdiv_ids": ["perdiv_numeric", "perdiv_keyword", "perdiv_inherit"],
+        # Per-div min-scale page: expected data-min-scale values (None = no attr)
+        "perdiv_min_scales": {
+            "perdiv_numeric": "0.5",
+            "perdiv_keyword": "mobile",
+            "perdiv_inherit": None,
+        },
     },
 }

--- a/tests/test_gdg_rendered.py
+++ b/tests/test_gdg_rendered.py
@@ -7702,7 +7702,13 @@ def _stf_skip():
 def test_SCALE_TO_FIT_global_meta_on_all_pages():
     """All user-guide pages should have the global gd-scale-to-fit meta tag."""
     _stf_skip()
-    for page_name in ("global-targeting", "page-override", "manual-div", "width-comparison"):
+    for page_name in (
+        "global-targeting",
+        "page-override",
+        "manual-div",
+        "per-div-min-scale",
+        "width-comparison",
+    ):
         page = _stf_site() / "user-guide" / f"{page_name}.html"
         assert page.exists(), f"Missing page: {page_name}"
         soup = _load_html(page)
@@ -7729,7 +7735,7 @@ def test_SCALE_TO_FIT_page_override_meta_present():
 def test_SCALE_TO_FIT_page_meta_absent_elsewhere():
     """Pages without scale-to-fit frontmatter should NOT have gd-scale-to-fit-page."""
     _stf_skip()
-    for page_name in ("global-targeting", "manual-div", "width-comparison"):
+    for page_name in ("global-targeting", "manual-div", "per-div-min-scale", "width-comparison"):
         page = _stf_site() / "user-guide" / f"{page_name}.html"
         soup = _load_html(page)
         meta = soup.find("meta", attrs={"name": "gd-scale-to-fit-page"})
@@ -7832,7 +7838,13 @@ def test_SCALE_TO_FIT_width_comparison_tables():
 def test_SCALE_TO_FIT_gt_tables_have_gt_class():
     """All GT tables should have the gt_table class."""
     _stf_skip()
-    for page_name in ("global-targeting", "page-override", "manual-div", "width-comparison"):
+    for page_name in (
+        "global-targeting",
+        "page-override",
+        "manual-div",
+        "per-div-min-scale",
+        "width-comparison",
+    ):
         page = _stf_site() / "user-guide" / f"{page_name}.html"
         soup = _load_html(page)
         gt_tables = soup.select("table.gt_table")
@@ -7844,7 +7856,13 @@ def test_SCALE_TO_FIT_gt_tables_no_bootstrap():
     """GT tables should NOT have Bootstrap table-bordered/table-sm classes."""
     _stf_skip()
     bootstrap_classes = {"table-bordered", "table-sm", "table-striped"}
-    for page_name in ("global-targeting", "page-override", "manual-div", "width-comparison"):
+    for page_name in (
+        "global-targeting",
+        "page-override",
+        "manual-div",
+        "per-div-min-scale",
+        "width-comparison",
+    ):
         page = _stf_site() / "user-guide" / f"{page_name}.html"
         soup = _load_html(page)
         for gt in soup.select("table.gt_table"):
@@ -7857,7 +7875,13 @@ def test_SCALE_TO_FIT_gt_tables_no_bootstrap():
 def test_SCALE_TO_FIT_gt_tables_not_responsive_wrapped():
     """GT tables should NOT be inside gd-table-responsive wrappers."""
     _stf_skip()
-    for page_name in ("global-targeting", "page-override", "manual-div", "width-comparison"):
+    for page_name in (
+        "global-targeting",
+        "page-override",
+        "manual-div",
+        "per-div-min-scale",
+        "width-comparison",
+    ):
         page = _stf_site() / "user-guide" / f"{page_name}.html"
         soup = _load_html(page)
         for gt in soup.select("table.gt_table"):
@@ -7883,6 +7907,80 @@ def test_SCALE_TO_FIT_custom_html_widget_rendered():
     assert widget.name == "div", f"Expected div, got {widget.name}"
     text = widget.get_text()
     assert "CustomWidget" in text, "Widget content not rendered"
+
+
+# ── Per-div data-min-scale ───────────────────────────────────────────────────
+
+
+@requires_bs4
+def test_SCALE_TO_FIT_perdiv_page_has_expected_ids():
+    """The per-div-min-scale page should have all three GT table IDs."""
+    _stf_skip()
+    page = _stf_site() / "user-guide" / "per-div-min-scale.html"
+    soup = _load_html(page)
+    for eid in ("perdiv_numeric", "perdiv_keyword", "perdiv_inherit"):
+        el = soup.find(id=eid)
+        assert el is not None, f"Missing element with id={eid}"
+
+
+@requires_bs4
+def test_SCALE_TO_FIT_perdiv_numeric_has_data_attr():
+    """The perdiv_numeric table's .scale-to-fit container should have data-min-scale='0.5'."""
+    _stf_skip()
+    page = _stf_site() / "user-guide" / "per-div-min-scale.html"
+    soup = _load_html(page)
+    gt = soup.find(id="perdiv_numeric")
+    assert gt is not None
+    parent = gt.parent
+    while parent:
+        classes = parent.get("class", [])
+        if "scale-to-fit" in classes:
+            val = parent.get("data-min-scale")
+            assert val == "0.5", f"Expected data-min-scale='0.5', got '{val}'"
+            break
+        parent = parent.parent
+    else:
+        pytest.fail("#perdiv_numeric is not inside a .scale-to-fit container")
+
+
+@requires_bs4
+def test_SCALE_TO_FIT_perdiv_keyword_has_data_attr():
+    """The perdiv_keyword table's .scale-to-fit container should have data-min-scale='mobile'."""
+    _stf_skip()
+    page = _stf_site() / "user-guide" / "per-div-min-scale.html"
+    soup = _load_html(page)
+    gt = soup.find(id="perdiv_keyword")
+    assert gt is not None
+    parent = gt.parent
+    while parent:
+        classes = parent.get("class", [])
+        if "scale-to-fit" in classes:
+            val = parent.get("data-min-scale")
+            assert val == "mobile", f"Expected data-min-scale='mobile', got '{val}'"
+            break
+        parent = parent.parent
+    else:
+        pytest.fail("#perdiv_keyword is not inside a .scale-to-fit container")
+
+
+@requires_bs4
+def test_SCALE_TO_FIT_perdiv_inherit_no_data_attr():
+    """The perdiv_inherit table's .scale-to-fit container should NOT have data-min-scale."""
+    _stf_skip()
+    page = _stf_site() / "user-guide" / "per-div-min-scale.html"
+    soup = _load_html(page)
+    gt = soup.find(id="perdiv_inherit")
+    assert gt is not None
+    parent = gt.parent
+    while parent:
+        classes = parent.get("class", [])
+        if "scale-to-fit" in classes:
+            val = parent.get("data-min-scale")
+            assert val is None, f"Expected no data-min-scale, got '{val}'"
+            break
+        parent = parent.parent
+    else:
+        pytest.fail("#perdiv_inherit is not inside a .scale-to-fit container")
 
 
 # ── Reference pages ──────────────────────────────────────────────────────────

--- a/user_guide/28-scale-to-fit.qmd
+++ b/user_guide/28-scale-to-fit.qmd
@@ -8,7 +8,135 @@ versions: ">=0.7"
 
 # Scale-to-Fit
 
-Wide content like GT tables, DataFrames, and custom `_repr_html_` objects often overflow the content area on smaller screens. Great Docs includes a **scale-to-fit** system that automatically shrinks targeted elements so they fit within the container width, and falls back to horizontal scrolling when the element would need to shrink beyond a configurable threshold.
+Wide content like tables created with [Great Tables](https://github.com/posit-dev/great-tables), DataFrames, and custom `_repr_html_` objects often overflow the content area on smaller screens. When a table is just slightly wider than the container, the reader has to scroll horizontally to see a small sliver of remaining content, which is a frustrating experience. Shrinking the element by a few percent makes it fit cleanly and nobody notices the difference. On the other hand, when an element is dramatically wider than the container, scaling it down would make the text unreadably small. In that case, horizontal scrolling is the better option.
+
+Great Docs includes a **scale-to-fit** system that handles both situations. It automatically shrinks targeted elements so they fit within the container width, and falls back to horizontal scrolling when the element would need to shrink beyond a configurable threshold.
+
+## See It in Action
+
+The examples below use `:::{.scale-to-fit}` divs to demonstrate the scaling behavior, but this is just one of three ways to enable scale-to-fit. You can also target elements globally through `great-docs.yml` or per-page through frontmatter (both covered in later sections). Try resizing your browser window to see elements shrink. The third example uses a per-div `data-min-scale` attribute to show the scrolling fallback.
+
+### A Table That Fits Normally
+
+This table is narrow enough to fit the content area without any scaling. It renders at its natural size.
+
+````markdown
+:::{.scale-to-fit}
+```{=html}
+<table style="width: 400px; ...">
+  ...
+```
+:::
+````
+
+:::{.scale-to-fit}
+```{=html}
+<table style="width: 400px; border-collapse: collapse; font-size: 14px;">
+  <thead>
+    <tr style="background: var(--bs-tertiary-bg, #f0f0f0);">
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Name</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Value</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Alpha</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">42</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Active</td></tr>
+    <tr><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Beta</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">87</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Pending</td></tr>
+  </tbody>
+</table>
+```
+:::
+
+At 400px, this table fits comfortably within the content area. No scaling is applied and no scrollbar appears.
+
+### A Wide Table That Scales Down
+
+This table is 1600px wide, wider than most content areas. Scale-to-fit shrinks it proportionally so it fits without overflow.
+
+````markdown
+:::{.scale-to-fit}
+```{=html}
+<table style="width: 1600px; ...">
+  ...
+```
+:::
+````
+
+:::{.scale-to-fit}
+```{=html}
+<table style="width: 1600px; border-collapse: collapse; font-size: 14px;">
+  <thead>
+    <tr style="background: var(--bs-tertiary-bg, #f0f0f0);">
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">ID</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Name</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Category</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Region</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Q1 Revenue</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Q2 Revenue</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Q3 Revenue</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Q4 Revenue</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Total</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">001</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Acme Corp</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Enterprise</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">North America</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">$1,245,000</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">$1,389,000</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">$1,102,000</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">$1,567,000</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">$5,303,000</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Active</td></tr>
+    <tr><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">002</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Globex Inc</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Mid-Market</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Europe</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">$892,000</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">$1,045,000</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">$978,000</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">$1,123,000</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">$4,038,000</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Active</td></tr>
+    <tr><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">003</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Initech</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Startup</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Asia Pacific</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">$234,000</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">$312,000</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">$289,000</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">$401,000</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">$1,236,000</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Review</td></tr>
+  </tbody>
+</table>
+```
+:::
+
+Notice that the text is slightly smaller than in the first table. The system shrank the 1600px table to fit the content area, and the reduction is modest enough that everything stays readable.
+
+### A Very Wide Element (Scrolling Fallback)
+
+This element is 2400px wide. It has `data-min-scale="0.65"` set directly on the div, so when the computed scale factor drops below 0.65 the system falls back to horizontal scrolling instead of shrinking the content to an unreadable size.
+
+````markdown
+:::{.scale-to-fit data-min-scale="0.65"}
+```{=html}
+<table style="width: 2400px; ...">
+  ...
+```
+:::
+````
+
+:::{.scale-to-fit data-min-scale="0.65"}
+```{=html}
+<table style="width: 2400px; border-collapse: collapse; font-size: 14px;">
+  <thead>
+    <tr style="background: var(--bs-tertiary-bg, #f0f0f0);">
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">ID</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Product</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">SKU</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Category</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Supplier</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Region</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Warehouse</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Stock</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Unit Price</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Q1 Sales</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Q2 Sales</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Q3 Sales</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Q4 Sales</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Annual Total</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">YoY Growth</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Margin</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Rating</th>
+      <th style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">P-001</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Widget Pro Max</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">WPM-2024-A</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Hardware</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">TechSource Ltd</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">North America</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Dallas-TX</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">12,450</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">$149.99</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">3,200</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">4,150</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">3,890</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">5,100</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">16,340</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">+18.2%</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">34.5%</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">4.7/5</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Active</td></tr>
+    <tr><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">P-002</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Gadget Elite</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">GE-2024-B</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Electronics</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">CircuitWorks</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Europe</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Munich-DE</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">8,320</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">$249.50</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">1,800</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">2,450</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">2,100</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">3,200</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">9,550</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">+12.7%</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">28.3%</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">4.5/5</td><td style="padding: 8px 12px; border: 1px solid var(--bs-border-color, #ddd);">Active</td></tr>
+  </tbody>
+</table>
+```
+:::
+
+This table is so wide that scaling it down would make the text unreadable. Because `data-min-scale="0.65"` is set on the div, the system switches to horizontal scrolling instead. Scroll right to see the rest of the columns.
 
 ## How It Works
 
@@ -98,7 +226,7 @@ To disable scale-to-fit entirely, remove the `scale_to_fit` key from your config
 scale_to_fit: false
 ```
 
-With `scale_to_fit` and `scale_to_fit_min_scale`, the global configuration covers most sites. For pages that need different behavior, use page-level overrides.
+With `scale_to_fit` and `scale_to_fit_min_scale`, the global configuration covers most sites. Every page inherits the same selectors and threshold, so you only need to set it once. For pages that need different behavior, use page-level overrides.
 
 ## Page-Level Overrides
 
@@ -172,6 +300,21 @@ my_wide_widget()
 
 The `.scale-to-fit` class provides the same scaling behavior: content is measured, scaled to fit, and scrolled if it would exceed the minimum threshold. This approach requires no configuration at all; the elements inside the div are always considered for scaling. Use manual wrapping for isolated wide outputs that don't warrant a global selector.
 
+### Per-Div Minimum Scale
+
+You can set a minimum scale threshold directly on an individual div using the `data-min-scale` attribute. This accepts the same values as the global and page-level settings: a viewport keyword (`mobile`, `tablet`, `desktop`) or a numeric fraction between 0 and 1.
+
+````markdown
+:::{.scale-to-fit data-min-scale="0.5"}
+```{{python}}
+#| echo: false
+my_extremely_wide_table()
+```
+:::
+````
+
+The per-div threshold takes precedence over any page-level or global threshold. This is useful when a single element on a page needs a different scrolling cutoff than the rest.
+
 ## Typical Selectors
 
 The selectors you provide are standard CSS selectors. These examples show common patterns:
@@ -215,3 +358,7 @@ As long as your output element has a stable `id` or class name, it can be target
 | `scale-to-fit-min-scale` | string or float | Overrides global threshold for this page |
 
 Note the key naming: global config uses **underscores** (`scale_to_fit`) to match Python property names, while page frontmatter uses **hyphens** (`scale-to-fit`) to match Quarto's built-in key style. Between these two tables you have the full set of options available for controlling scale-to-fit behavior at both the site and page level.
+
+## Putting It All Together
+
+For most projects, a single `scale_to_fit` entry in `great-docs.yml` is all you need. Pick the selectors that match your wide outputs, choose a minimum scale threshold that feels right, and every page on your site benefits automatically. When a particular page calls for something different, override the selectors or threshold in that page's frontmatter. And for the occasional one-off table or widget that just needs to fit, wrap it in a `:::{.scale-to-fit}` div and move on. The three levels work together so you can start simple and add precision only where it matters.


### PR DESCRIPTION
This pull request adds support for per-container minimum scale overrides in the scale-to-fit feature for tables. Now, individual `.scale-to-fit` containers can specify their own `data-min-scale` attribute, which takes precedence over global or page-level thresholds.