### PR TITLE
feat: mock code cells

### DIFF
--- a/great_docs/_mock_code.py
+++ b/great_docs/_mock_code.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# Matches the opening fence of an executable code block:
+#   ```{python}  or  ```{python}   (with trailing whitespace)
+_EXEC_FENCE_RE = re.compile(r"^```\{python\}\s*$")
+
+# Matches the closing fence:
+#   ```
+_CLOSE_FENCE_RE = re.compile(r"^```\s*$")
+
+# Matches a hash-pipe option line:
+#   #| key: value
+_HASHPIPE_RE = re.compile(r"^#\|\s*(\S+?):\s*(.*)$")
+
+# The delimiter that separates display code from eval code:
+_DELIMITER = "# ---"
+
+
+def expand_mock_cells(text: str) -> str:
+    """Rewrite `source-code: mock` cells in *text* into two-cell pairs.
+
+    Parameters
+    ----------
+    text
+        The full content of a `.qmd` file.
+
+    Returns
+    -------
+    str
+        The rewritten content. Unchanged if no mock cells are found.
+    """
+    lines = text.split("\n")
+    out: list[str] = []
+    i = 0
+
+    while i < len(lines):
+        line = lines[i]
+
+        # Look for an opening executable fence
+        if not _EXEC_FENCE_RE.match(line):
+            out.append(line)
+            i += 1
+            continue
+
+        # Collect the entire cell (fence-to-fence)
+        cell_start = i
+        i += 1
+        cell_body: list[str] = []
+        found_close = False
+        while i < len(lines):
+            if _CLOSE_FENCE_RE.match(lines[i]):
+                found_close = True
+                i += 1
+                break
+            cell_body.append(lines[i])
+            i += 1
+
+        if not found_close:
+            # Malformed cell — emit as-is
+            out.append(lines[cell_start])
+            out.extend(cell_body)
+            continue
+
+        # Parse hash-pipe options from the top of the cell body
+        options: dict[str, str] = {}
+        option_lines: list[str] = []
+        body_start = 0
+        for j, bline in enumerate(cell_body):
+            m = _HASHPIPE_RE.match(bline)
+            if m:
+                options[m.group(1)] = m.group(2).strip()
+                option_lines.append(bline)
+                body_start = j + 1
+            else:
+                break
+
+        # Not a mock cell — emit unchanged
+        if options.get("source-code") != "mock":
+            out.append(lines[cell_start])
+            out.extend(cell_body)
+            out.append("```")
+            continue
+
+        # Split the remaining body at the delimiter
+        raw_body = cell_body[body_start:]
+        display_lines: list[str] = []
+        eval_lines: list[str] = []
+        found_delim = False
+        for bline in raw_body:
+            if not found_delim and bline.strip() == _DELIMITER:
+                found_delim = True
+                continue
+            if found_delim:
+                eval_lines.append(bline)
+            else:
+                display_lines.append(bline)
+
+        # Collect options to forward (everything except source-code)
+        # output-title and output-frame are forwarded to the eval cell only
+        output_title = options.pop("output-title", None)
+        output_frame = options.pop("output-frame", None)
+        # Remove source-code from forwarded options
+        options.pop("source-code", None)
+
+        # Build forwarded option lines for both cells
+        forwarded = []
+        for key, val in options.items():
+            forwarded.append(f"#| {key}: {val}")
+
+        # --- Emit the display cell (eval: false) ---
+        out.append("```{python}")
+        out.append("#| eval: false")
+        for fwd in forwarded:
+            # Don't forward echo/output overrides to display cell
+            if not fwd.startswith("#| echo:") and not fwd.startswith("#| output:"):
+                out.append(fwd)
+        out.extend(display_lines)
+        out.append("```")
+
+        # --- Emit the eval cell (echo: false) ---
+        if found_delim and eval_lines:
+            out.append("")
+            out.append("```{python}")
+            out.append("#| echo: false")
+            if output_title:
+                out.append(f"#| output-title: {output_title}")
+            if output_frame:
+                out.append(f"#| output-frame: {output_frame}")
+            for fwd in forwarded:
+                # Don't forward eval overrides to eval cell
+                if not fwd.startswith("#| eval:"):
+                    out.append(fwd)
+            out.extend(eval_lines)
+            out.append("```")
+        elif not found_delim:
+            # No delimiter found — the entire body is display-only (eval: false).
+            # This is a valid use case (equivalent to just eval: false).
+            pass
+
+    return "\n".join(out)
+
+
+def process_qmd_file(path: Path) -> bool:
+    """Process a single `.qmd` file, rewriting mock cells in place.
+
+    Parameters
+    ----------
+    path
+        Path to the `.qmd` file.
+
+    Returns
+    -------
+    bool
+        `True` if the file was modified, `False` otherwise.
+    """
+    content = path.read_text(encoding="utf-8")
+    if "#| source-code: mock" not in content:
+        return False
+
+    rewritten = expand_mock_cells(content)
+    if rewritten == content:
+        return False
+
+    path.write_text(rewritten, encoding="utf-8")
+    return True
+
+
+def process_directory(directory: Path) -> list[str]:
+    """Process all `.qmd` files under *directory*.
+
+    Parameters
+    ----------
+    directory
+        Root directory to scan recursively.
+
+    Returns
+    -------
+    list[str]
+        Relative paths of files that were modified.
+    """
+    modified: list[str] = []
+    for qmd in sorted(directory.rglob("*.qmd")):
+        if process_qmd_file(qmd):
+            try:
+                rel = str(qmd.relative_to(directory))
+            except ValueError:
+                rel = str(qmd)
+            modified.append(rel)
+    return modified

--- a/great_docs/assets/_extensions/output-title/_extension.yml
+++ b/great_docs/assets/_extensions/output-title/_extension.yml
@@ -1,0 +1,7 @@
+title: Output Title
+author: Great Docs
+version: 1.0.0
+quarto-required: ">=1.3.0"
+contributes:
+  filters:
+    - output-title.lua

--- a/great_docs/assets/_extensions/output-title/output-title.lua
+++ b/great_docs/assets/_extensions/output-title/output-title.lua
@@ -1,0 +1,101 @@
+-- output-title.lua — Quarto filter for labelling and framing code cell outputs
+--
+-- Usage in .qmd files:
+--
+--   ```{python}
+--   #| output-title: "Response"
+--   chat.chat("Hello!")
+--   ```
+--
+--   ```{python}
+--   #| output-frame: true
+--   print("framed output, no title")
+--   ```
+--
+-- Wraps the cell's output in a styled container with an optional title.
+-- Works with any executable code cell, and composes with source-code: mock.
+
+--- Extract the output-title value from a cell Div's attributes.
+--- Quarto passes unrecognised hash-pipe options as attributes on the
+--- enclosing div.cell element.
+---@param div pandoc.Div
+---@return string|nil  The title text (unquoted), or nil if absent.
+local function get_output_title(div)
+    -- Quarto passes custom cell options as attributes on the div
+    local title = div.attributes["output-title"]
+    if title == nil then return nil end
+
+    -- Strip surrounding quotes if present
+    title = title:match('^"(.*)"$') or title:match("^'(.*)'$") or title
+    if title == "" then return nil end
+    return title
+end
+
+--- Check whether output-frame is set to a truthy value.
+---@param div pandoc.Div
+---@return boolean
+local function get_output_frame(div)
+    local val = div.attributes["output-frame"]
+    if val == nil then return false end
+    val = val:lower()
+    return val == "true" or val == "yes" or val == "1"
+end
+
+--- Check whether a block element is a cell-output container.
+---@param el pandoc.Block
+---@return boolean
+local function is_cell_output(el)
+    if el.t ~= "Div" then return false end
+    for _, cls in ipairs(el.classes) do
+        if cls:match("^cell%-output") then return true end
+    end
+    return false
+end
+
+function Div(div)
+    -- Only operate on executable code cells
+    if not div.classes:includes("cell") then return nil end
+
+    local title = get_output_title(div)
+    local frame = get_output_frame(div)
+
+    -- Need either a title or an explicit frame request
+    if title == nil and not frame then return nil end
+
+    -- Remove attributes so they don't leak into the HTML
+    div.attributes["output-title"] = nil
+    div.attributes["output-frame"] = nil
+
+    -- Collect output blocks and wrap them
+    local new_content = pandoc.List()
+    local output_blocks = pandoc.List()
+
+    for _, el in ipairs(div.content) do
+        if is_cell_output(el) then
+            output_blocks:insert(el)
+        else
+            new_content:insert(el)
+        end
+    end
+
+    if #output_blocks == 0 then return nil end
+
+    -- Build the container HTML
+    local title_html = '<div class="gd-output-title-container">\n'
+    if title then
+        title_html = title_html
+            .. '<div class="gd-output-title-header">' .. title .. '</div>\n'
+    end
+    title_html = title_html .. '<div class="gd-output-title-body">\n'
+    local close_html = '</div>\n</div>'
+
+    -- Wrap: open tag, output blocks, close tag
+    new_content:insert(pandoc.RawBlock("html", title_html))
+    for _, ob in ipairs(output_blocks) do
+        new_content:insert(ob)
+    end
+    new_content:insert(pandoc.RawBlock("html", close_html))
+
+    div.content = new_content
+    return div
+end

--- a/great_docs/assets/great-docs.scss
+++ b/great_docs/assets/great-docs.scss
@@ -7809,6 +7809,77 @@ html[data-bs-theme="dark"] {
 }
 
 
+/* ── Output Title Container ─────────────────────────────────────────
+   Wraps code cell output with a labelled header.
+   Used by #| output-title: "..." hash-pipe option.
+*/
+.gd-output-title-container {
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    border-radius: 0.375rem;
+    margin-top: 0.5rem;
+    margin-bottom: 1rem;
+    overflow: hidden;
+}
+
+.gd-output-title-header {
+    background: rgba(0, 0, 0, 0.03);
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    padding: 0.35rem 0.75rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: rgba(0, 0, 0, 0.55);
+    letter-spacing: 0.02em;
+}
+
+.gd-output-title-body {
+    padding: 0.5rem 0.75rem;
+}
+
+.gd-output-title-body .cell-output {
+    margin: 0;
+    padding: 0;
+}
+
+.gd-output-title-body .cell-output pre {
+    margin: 0;
+    border: none;
+    background: transparent;
+    padding: 0;
+}
+
+/* Frameless variant for rich HTML outputs (GT tables, styled DataFrames, etc.)
+   These objects carry their own visual structure; a surrounding frame creates
+   an ugly double-border.  We keep the title label but drop the container
+   border and body padding so the HTML output breathes.
+   We target display outputs that contain a child div (rich HTML wrapper)
+   rather than just a <pre> block (which is a plain return value). */
+.gd-output-title-container:has(.gd-output-title-body .cell-output-display > div) {
+    border: none;
+}
+
+.gd-output-title-container:has(.gd-output-title-body .cell-output-display > div)
+    .gd-output-title-header {
+    background: transparent;
+    border-bottom: none;
+    padding-left: 0;
+}
+
+.gd-output-title-container:has(.gd-output-title-body .cell-output-display > div)
+    .gd-output-title-body {
+    padding: 0;
+}
+
+body.quarto-dark .gd-output-title-container {
+    border-color: rgba(255, 255, 255, 0.12);
+}
+
+body.quarto-dark .gd-output-title-header {
+    background: rgba(255, 255, 255, 0.04);
+    border-bottom-color: rgba(255, 255, 255, 0.12);
+    color: rgba(255, 255, 255, 0.55);
+}
+
+
 /*-- scss:functions --*/
 
 /*-- scss:uses --*/

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -11179,6 +11179,13 @@ body-classes: "gd-homepage"
             print("No GitHub repository info available; skipping version badge metadata")
             meta_path.unlink(missing_ok=True)
 
+        # Register Quarto extension filters (output-title wraps cell
+        # outputs in a titled container when #| output-title: is set)
+        if "filters" not in config:
+            config["filters"] = []
+        if "output-title" not in config["filters"]:
+            config["filters"].append("output-title")
+
         # Write back to file
         self._write_quarto_yml(quarto_yml, config)
 
@@ -12897,6 +12904,11 @@ body-classes: "gd-homepage"
             # Normalize freeze shorthand (runs right before render in a full build)
             self._normalize_freeze_shorthand()
 
+            # Expand source-code: mock cells
+            from great_docs._mock_code import process_directory as _expand_mock
+
+            _expand_mock(self.project_path)
+
             # Update quarto config (ensures _quarto.yml has pre-render, freeze, etc.)
             with redirect_stdout(devnull):
                 self._update_quarto_config()
@@ -13482,6 +13494,16 @@ body-classes: "gd-homepage"
                     log.step_done("Freeze cache will be restored during render")
             else:
                 log.step_skip(step, "no frozen pages")
+
+            # Expand source-code: mock cells before Quarto sees them
+            from great_docs._mock_code import process_directory as _expand_mock_cells
+
+            mock_modified = _expand_mock_cells(self.project_path)
+            if mock_modified:
+                log.detail(
+                    f"Expanded {len(mock_modified)} mock-code cell(s): "
+                    + ", ".join(mock_modified)
+                )
 
             # Get environment with QUARTO_PYTHON set
             quarto_env = self._get_quarto_env()

--- a/test-packages/synthetic/catalog.py
+++ b/test-packages/synthetic/catalog.py
@@ -378,6 +378,8 @@ ALL_PACKAGES: list[str] = [
     # 188–189: Inherited member documentation
     "gdtest_ref_inherited_explicit",  # 188
     "gdtest_ref_include_inherited",  # 189
+    # 190: Mock code cells and output-title containers
+    "gdtest_mock_code",  # 190
 ]
 
 
@@ -2117,6 +2119,14 @@ PACKAGE_DESCRIPTIONS: dict[str, str] = {
         "Reference config using include_inherited: true on Circle. The renderer "
         "should automatically include inherited methods (describe) from Shape "
         "without the user listing them explicitly."
+    ),
+    # ── 190: Mock code cells and output-title containers ───────────────────
+    "gdtest_mock_code": (
+        "Mock code cells (source-code: mock) and output-title containers. "
+        "Tests that the preprocessor splits mock cells into display + eval pairs, "
+        "output-title wraps output in titled containers on both mock and regular "
+        "cells, mock cells with no delimiter are display-only, and multiple mock "
+        "cells work on a single page."
     ),
 }
 

--- a/test-packages/synthetic/specs/gdtest_mock_code.py
+++ b/test-packages/synthetic/specs/gdtest_mock_code.py
@@ -1,0 +1,332 @@
+"""
+gdtest_mock_code — Mock code cells and output-title containers.
+
+Dimensions: A1, B1, C1, D1, E6, F6, G1, H7
+Focus: Tests the ``source-code: mock`` preprocessor and ``output-title``
+       Lua filter working together.  User-guide pages exercise:
+       • Basic mock cell split (display + eval)
+       • Mock cell with ``output-title``
+       • Standalone ``output-title`` on a regular executable cell
+       • Mock cell with no delimiter (display-only)
+       • Multiple mock cells on one page
+       • Mock cell with extra forwarded options
+"""
+
+SPEC = {
+    "name": "gdtest_mock_code",
+    "description": "Mock code cells and output-title containers",
+    "dimensions": ["A1", "B1", "C1", "D1", "E6", "F6", "G1", "H7"],
+    # ── Project metadata ─────────────────────────────────────────────
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-mock-code",
+            "version": "0.1.0",
+            "description": "Synthetic test for mock code cells and output-title",
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    },
+    # ── Source files ──────────────────────────────────────────────────
+    "files": {
+        "gdtest_mock_code/__init__.py": '''\
+            """Test package for mock code cells and output-title."""
+
+            __version__ = "0.1.0"
+            __all__ = ["add", "multiply", "greet"]
+
+
+            def add(a: int, b: int) -> int:
+                """
+                Add two numbers.
+
+                Parameters
+                ----------
+                a
+                    First number.
+                b
+                    Second number.
+
+                Returns
+                -------
+                int
+                    Sum of a and b.
+
+                Examples
+                --------
+                ```python
+                from gdtest_mock_code import add
+
+                add(2, 3)
+                ```
+                """
+                return a + b
+
+
+            def multiply(a: int, b: int) -> int:
+                """
+                Multiply two numbers.
+
+                Parameters
+                ----------
+                a
+                    First number.
+                b
+                    Second number.
+
+                Returns
+                -------
+                int
+                    Product of a and b.
+                """
+                return a * b
+
+
+            def greet(name: str) -> str:
+                """
+                Greet someone by name.
+
+                Parameters
+                ----------
+                name
+                    The person to greet.
+
+                Returns
+                -------
+                str
+                    A greeting string.
+                """
+                return f"Hello, {name}!"
+        ''',
+        # ── User guide pages ──────────────────────────────────────────
+        "user_guide/01-basic-mock.qmd": """\
+            ---
+            title: Basic Mock Cell
+            ---
+
+            A basic mock cell splits display code from eval code.
+
+            ```{python}
+            #| source-code: mock
+            import gdtest_mock_code
+
+            gdtest_mock_code.add(10, 20)
+            # ---
+            from gdtest_mock_code import add
+            add(10, 20)
+            ```
+
+            The reader sees `gdtest_mock_code.add(10, 20)` but the cell
+            actually runs `from gdtest_mock_code import add; add(10, 20)`.
+        """,
+        "user_guide/02-mock-output-title.qmd": """\
+            ---
+            title: Mock with Output Title
+            ---
+
+            Combines `source-code: mock` with `output-title`.
+
+            ```{python}
+            #| source-code: mock
+            #| output-title: Addition Result
+            gdtest_mock_code.add(3, 4)
+            # ---
+            from gdtest_mock_code import add
+            add(3, 4)
+            ```
+
+            The output should appear inside a titled container
+            labelled "Addition Result".
+        """,
+        "user_guide/03-standalone-output-title.qmd": """\
+            ---
+            title: Standalone Output Title
+            ---
+
+            `output-title` works on regular (non-mock) executable cells too.
+
+            ```{python}
+            #| output-title: Greeting Output
+            from gdtest_mock_code import greet
+            greet("World")
+            ```
+
+            The output should appear inside a titled container
+            labelled "Greeting Output".
+        """,
+        "user_guide/04-no-delimiter.qmd": """\
+            ---
+            title: No Delimiter Mock
+            ---
+
+            A mock cell with no `# ---` delimiter is display-only
+            (equivalent to `eval: false`).
+
+            ```{python}
+            #| source-code: mock
+            gdtest_mock_code.multiply(6, 7)
+            ```
+
+            There is no eval cell emitted, so no output appears.
+        """,
+        "user_guide/05-multiple-mocks.qmd": """\
+            ---
+            title: Multiple Mock Cells
+            ---
+
+            A page with several mock cells interleaved with prose.
+
+            ## First calculation
+
+            ```{python}
+            #| source-code: mock
+            gdtest_mock_code.add(1, 2)
+            # ---
+            from gdtest_mock_code import add
+            add(1, 2)
+            ```
+
+            ## Second calculation
+
+            ```{python}
+            #| source-code: mock
+            #| output-title: Product
+            gdtest_mock_code.multiply(3, 4)
+            # ---
+            from gdtest_mock_code import multiply
+            multiply(3, 4)
+            ```
+
+            ## Third — a greeting
+
+            ```{python}
+            #| source-code: mock
+            #| output-title: Greeting
+            gdtest_mock_code.greet("GDG")
+            # ---
+            from gdtest_mock_code import greet
+            greet("GDG")
+            ```
+        """,
+        "user_guide/06-html-repr-output-title.qmd": """\
+            ---
+            title: HTML Repr with Output Title
+            ---
+
+            When `output-title` wraps a rich HTML object like a GT table
+            the container should go frameless — no double border.
+
+            ### GT table with output-title
+
+            ```{python}
+            #| source-code: mock
+            #| output-title: Example Table
+            import great_tables as gt
+            import pandas as pd
+
+            gt.GT(pd.DataFrame({"x": [1, 2], "y": [3, 4]}))
+            # ---
+            from great_tables import GT
+            import pandas as pd
+
+            GT(pd.DataFrame({"x": [1, 2], "y": [3, 4]}))
+            ```
+
+            ### GT table without output-title (baseline)
+
+            ```{python}
+            #| source-code: mock
+            import great_tables as gt
+            import pandas as pd
+
+            gt.GT(pd.DataFrame({"a": [10, 20], "b": [30, 40]}))
+            # ---
+            from great_tables import GT
+            import pandas as pd
+
+            GT(pd.DataFrame({"a": [10, 20], "b": [30, 40]}))
+            ```
+
+            ### Plain text with output-title (framed)
+
+            ```{python}
+            #| output-title: Text Output
+            from gdtest_mock_code import greet
+            greet("comparison")
+            ```
+
+            The GT table with output-title should show a floating label
+            with no frame.  The baseline GT table (no output-title) should
+            render identically to any other GT table.  The text output
+            should keep its frame.
+        """,
+        "user_guide/07-output-frame.qmd": """\
+            ---
+            title: Output Frame (No Title)
+            ---
+
+            The `output-frame` option adds a bordered container around
+            cell output without a title label.
+
+            ### Framed output (no title)
+
+            ```{python}
+            #| output-frame: true
+            from gdtest_mock_code import greet
+            greet("framed")
+            ```
+
+            ### Framed output with mock cell
+
+            ```{python}
+            #| source-code: mock
+            #| output-frame: true
+            gdtest_mock_code.add(5, 5)
+            # ---
+            from gdtest_mock_code import add
+            add(5, 5)
+            ```
+
+            ### Unframed output (baseline)
+
+            ```{python}
+            from gdtest_mock_code import greet
+            greet("no frame")
+            ```
+
+            The first two outputs should have a border but no title
+            header.  The third should render as a normal cell output.
+        """,
+        "README.md": """\
+            # gdtest-mock-code
+
+            Synthetic test for `source-code: mock` and `output-title`.
+
+            ## Purpose
+
+            Tests that Great Docs correctly:
+
+            - Splits mock cells into display + eval pairs
+            - Wraps output in titled containers when `output-title` is set
+            - Frames output without a title when `output-frame: true` is set
+            - Handles `output-title` on non-mock cells
+            - Handles mock cells with no delimiter (display-only)
+            - Handles multiple mock cells on one page
+            - Goes frameless for rich HTML outputs (GT tables)
+        """,
+    },
+    # ── Expected outcomes ─────────────────────────────────────────────
+    "expected": {
+        "detected_name": "gdtest-mock-code",
+        "detected_module": "gdtest_mock_code",
+        "detected_parser": "numpy",
+        "export_names": ["add", "multiply", "greet"],
+        "num_exports": 3,
+        "section_titles": ["Functions"],
+        "has_user_guide": True,
+        "has_license_page": False,
+        "has_citation_page": False,
+        "coverage_exclude": ["nodoc", "bigcl", "ug", "supp", "hdg"],
+    },
+}

--- a/tests/test_mock_code.py
+++ b/tests/test_mock_code.py
@@ -1,0 +1,413 @@
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from great_docs._mock_code import expand_mock_cells, process_directory, process_qmd_file
+
+
+# ---------------------------------------------------------------------------
+# expand_mock_cells — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestExpandMockCells:
+    """Test the core text-rewriting function."""
+
+    def test_basic_mock_cell(self):
+        """A mock cell is split into display (eval: false) + eval (echo: false)."""
+        src = textwrap.dedent("""\
+            Some text.
+
+            ```{python}
+            #| source-code: mock
+            display_code()
+            # ---
+            eval_code()
+            ```
+
+            More text.
+        """)
+        result = expand_mock_cells(src)
+
+        # Display cell
+        assert "#| eval: false" in result
+        assert "display_code()" in result
+
+        # Eval cell
+        assert "#| echo: false" in result
+        assert "eval_code()" in result
+
+        # Original option removed
+        assert "#| source-code: mock" not in result
+
+        # Delimiter removed
+        assert "# ---" not in result
+
+        # Surrounding text preserved
+        assert "Some text." in result
+        assert "More text." in result
+
+    def test_no_delimiter_is_display_only(self):
+        """Without a delimiter, the cell becomes display-only (eval: false)."""
+        src = textwrap.dedent("""\
+            ```{python}
+            #| source-code: mock
+            display_only()
+            ```
+        """)
+        result = expand_mock_cells(src)
+
+        assert "#| eval: false" in result
+        assert "display_only()" in result
+        # No eval cell should be emitted
+        assert "#| echo: false" not in result
+
+    def test_output_title_forwarded(self):
+        """output-title is forwarded to the eval cell only."""
+        src = textwrap.dedent("""\
+            ```{python}
+            #| source-code: mock
+            #| output-title: "Response"
+            show_this()
+            # ---
+            run_this()
+            ```
+        """)
+        result = expand_mock_cells(src)
+
+        lines = result.split("\n")
+
+        # output-title should appear in the eval cell block, not display
+        # Find the eval cell (starts with echo: false)
+        eval_start = None
+        display_start = None
+        for i, line in enumerate(lines):
+            if line.strip() == "#| echo: false":
+                eval_start = i
+            if line.strip() == "#| eval: false":
+                display_start = i
+
+        assert eval_start is not None
+        assert display_start is not None
+
+        # output-title should be between eval_start and the next closing fence
+        eval_section = "\n".join(lines[eval_start:])
+        assert '#| output-title: "Response"' in eval_section
+
+        # output-title should NOT be in the display cell
+        display_section = "\n".join(lines[display_start:eval_start])
+        assert "output-title" not in display_section
+
+    def test_other_options_forwarded(self):
+        """Non-mock options like warning: false are forwarded to both cells."""
+        src = textwrap.dedent("""\
+            ```{python}
+            #| source-code: mock
+            #| warning: false
+            show()
+            # ---
+            run()
+            ```
+        """)
+        result = expand_mock_cells(src)
+
+        # warning: false should appear twice (once per cell)
+        assert result.count("#| warning: false") == 2
+
+    def test_multiple_mock_cells(self):
+        """Multiple mock cells in one file are all expanded."""
+        src = textwrap.dedent("""\
+            ```{python}
+            #| source-code: mock
+            a()
+            # ---
+            a_real()
+            ```
+
+            Text between.
+
+            ```{python}
+            #| source-code: mock
+            b()
+            # ---
+            b_real()
+            ```
+        """)
+        result = expand_mock_cells(src)
+
+        assert result.count("#| eval: false") == 2
+        assert result.count("#| echo: false") == 2
+        assert "a()" in result
+        assert "a_real()" in result
+        assert "b()" in result
+        assert "b_real()" in result
+        assert "Text between." in result
+
+    def test_non_mock_cells_unchanged(self):
+        """Regular code cells are not modified."""
+        src = textwrap.dedent("""\
+            ```{python}
+            #| echo: false
+            normal_code()
+            ```
+        """)
+        result = expand_mock_cells(src)
+        assert result.strip() == src.strip()
+
+    def test_static_code_blocks_unchanged(self):
+        """Non-executable code blocks (```python) are not touched."""
+        src = textwrap.dedent("""\
+            ```python
+            #| source-code: mock
+            not_executable()
+            # ---
+            hidden()
+            ```
+        """)
+        result = expand_mock_cells(src)
+        # Should be unchanged since it's not ```{python}
+        assert result.strip() == src.strip()
+
+    def test_multiline_display_and_eval(self):
+        """Multi-line code in both display and eval regions."""
+        src = textwrap.dedent("""\
+            ```{python}
+            #| source-code: mock
+            import chatlas as ctl
+            chat = ctl.ChatOpenAI()
+            chat.chat("Hello")
+            # ---
+            import chatlas as ctl
+            chat = ctl.ChatOpenAI(debug=True)
+            chat.chat("Hello", header=False)
+            ```
+        """)
+        result = expand_mock_cells(src)
+
+        lines = result.split("\n")
+        # Find display cell body
+        in_display = False
+        display_body = []
+        for line in lines:
+            if line.strip() == "#| eval: false":
+                in_display = True
+                continue
+            if in_display and line.strip() == "```":
+                break
+            if in_display and not line.startswith("#|"):
+                display_body.append(line)
+
+        assert 'chat.chat("Hello")' in "\n".join(display_body)
+        assert "debug=True" not in "\n".join(display_body)
+
+    def test_multiple_delimiters_only_first_splits(self):
+        """Only the first # --- delimiter is used to split."""
+        src = textwrap.dedent("""\
+            ```{python}
+            #| source-code: mock
+            display()
+            # ---
+            eval_line_1()
+            # ---
+            eval_line_2()
+            ```
+        """)
+        result = expand_mock_cells(src)
+
+        # eval_line_2 should be in the eval cell (after the split)
+        assert "eval_line_1()" in result
+        assert "eval_line_2()" in result
+        # The second # --- should remain as part of the eval code
+        # (it's just a comment in the eval section)
+
+    def test_empty_eval_section(self):
+        """Delimiter at the end with no eval code: display-only cell."""
+        src = textwrap.dedent("""\
+            ```{python}
+            #| source-code: mock
+            display()
+            # ---
+            ```
+        """)
+        result = expand_mock_cells(src)
+
+        assert "#| eval: false" in result
+        assert "display()" in result
+        # No eval cell emitted (empty eval_lines)
+        assert "#| echo: false" not in result
+
+    def test_empty_display_section(self):
+        """No code before delimiter: empty display cell, eval cell has code."""
+        src = textwrap.dedent("""\
+            ```{python}
+            #| source-code: mock
+            # ---
+            hidden_eval()
+            ```
+        """)
+        result = expand_mock_cells(src)
+
+        assert "#| eval: false" in result
+        assert "#| echo: false" in result
+        assert "hidden_eval()" in result
+
+    def test_echo_not_forwarded_to_display(self):
+        """echo: option is not forwarded to the display cell."""
+        src = textwrap.dedent("""\
+            ```{python}
+            #| source-code: mock
+            #| echo: true
+            show()
+            # ---
+            run()
+            ```
+        """)
+        result = expand_mock_cells(src)
+        lines = result.split("\n")
+
+        # Find display cell section
+        eval_false_idx = next(i for i, l in enumerate(lines) if "#| eval: false" in l)
+        echo_false_idx = next(i for i, l in enumerate(lines) if "#| echo: false" in l)
+
+        # Between eval: false and echo: false (the display cell),
+        # there should be no echo: option
+        display_section = lines[eval_false_idx:echo_false_idx]
+        assert not any("#| echo:" in l for l in display_section)
+
+    def test_preserves_surrounding_content(self):
+        """YAML frontmatter, text, and other cells are preserved."""
+        src = textwrap.dedent("""\
+            ---
+            title: "Test"
+            ---
+
+            # Introduction
+
+            Some text.
+
+            ```{python}
+            normal_cell()
+            ```
+
+            ```{python}
+            #| source-code: mock
+            display()
+            # ---
+            eval()
+            ```
+
+            ## Conclusion
+
+            Final text.
+        """)
+        result = expand_mock_cells(src)
+
+        assert '---\ntitle: "Test"\n---' in result
+        assert "# Introduction" in result
+        assert "normal_cell()" in result
+        assert "## Conclusion" in result
+        assert "Final text." in result
+
+    def test_no_mock_cells_returns_unchanged(self):
+        """A file with no mock cells is returned unchanged."""
+        src = textwrap.dedent("""\
+            ---
+            title: "No mocks"
+            ---
+
+            ```{python}
+            x = 1
+            ```
+        """)
+        result = expand_mock_cells(src)
+        assert result == src
+
+
+# ---------------------------------------------------------------------------
+# process_qmd_file — file-level tests
+# ---------------------------------------------------------------------------
+
+
+class TestProcessQmdFile:
+    """Test the file-level processing function."""
+
+    def test_modifies_file_with_mock(self, tmp_path: Path):
+        qmd = tmp_path / "test.qmd"
+        qmd.write_text(
+            textwrap.dedent("""\
+                ```{python}
+                #| source-code: mock
+                a()
+                # ---
+                b()
+                ```
+            """),
+            encoding="utf-8",
+        )
+
+        result = process_qmd_file(qmd)
+        assert result is True
+
+        content = qmd.read_text(encoding="utf-8")
+        assert "#| eval: false" in content
+        assert "#| echo: false" in content
+
+    def test_skips_file_without_mock(self, tmp_path: Path):
+        qmd = tmp_path / "test.qmd"
+        original = textwrap.dedent("""\
+            ```{python}
+            x = 1
+            ```
+        """)
+        qmd.write_text(original, encoding="utf-8")
+
+        result = process_qmd_file(qmd)
+        assert result is False
+        assert qmd.read_text(encoding="utf-8") == original
+
+
+# ---------------------------------------------------------------------------
+# process_directory — directory-level tests
+# ---------------------------------------------------------------------------
+
+
+class TestProcessDirectory:
+    """Test recursive directory processing."""
+
+    def test_processes_nested_files(self, tmp_path: Path):
+        # Create a file with mock code in a subdirectory
+        subdir = tmp_path / "user-guide"
+        subdir.mkdir()
+
+        (subdir / "page.qmd").write_text(
+            textwrap.dedent("""\
+                ```{python}
+                #| source-code: mock
+                show()
+                # ---
+                run()
+                ```
+            """),
+            encoding="utf-8",
+        )
+
+        # And a file without mock code
+        (tmp_path / "index.qmd").write_text(
+            textwrap.dedent("""\
+                ```{python}
+                normal()
+                ```
+            """),
+            encoding="utf-8",
+        )
+
+        modified = process_directory(tmp_path)
+        assert len(modified) == 1
+        assert "user-guide/page.qmd" in modified[0] or "page.qmd" in modified[0]
+
+    def test_empty_directory(self, tmp_path: Path):
+        modified = process_directory(tmp_path)
+        assert modified == []

--- a/user_guide/03-authoring-qmd-files.qmd
+++ b/user_guide/03-authoring-qmd-files.qmd
@@ -533,10 +533,99 @@ Common hash-pipe options:
 | `#| warning: false` | Suppress warning messages |
 | `#| fig-cap: "..."` | Add a caption to figure output |
 | `#| label: fig-name` | Create a referenceable label for the figure |
+| `#| output-title: "..."` | Wrap the output in a labelled container |
+| `#| output-frame: true` | Wrap the output in a bordered container (no title) |
+| `#| source-code: mock` | Display one code block but execute another (see below) |
 
 Executable code blocks are what make `.qmd` files more powerful than plain Markdown. They ensure
 that your documentation's code examples are always tested: if the code breaks, the build fails, so
 your docs stay in sync with your actual API.
+
+### Output Titles and Frames
+
+Cell output can be wrapped in a styled container using `#| output-title` and `#| output-frame`.
+These options work on any executable code cell and compose with `source-code: mock`.
+
+**Adding a title.** Use `#| output-title` to wrap output in a bordered container with a label
+displayed above it. This is useful for marking chat responses, returned values, or any output that
+benefits from a heading:
+
+````markdown
+```{{python}}
+#| output-title: "Response"
+chat.chat("Tell me a joke.")
+```
+````
+
+**Adding a frame without a title.** Use `#| output-frame: true` to wrap output in a bordered
+container *without* a title label. This gives text-based output visual containment that it doesn't
+normally have:
+
+````markdown
+```{{python}}
+#| output-frame: true
+from mypackage import greet
+greet("World")
+```
+````
+
+**Rich HTML outputs.** When the output is a rich HTML object (such as a GT table or a styled
+DataFrame), the frame is automatically removed to avoid a double-border — these objects already
+carry their own visual structure. With `output-title`, the title appears as a floating label above
+the output; with `output-frame`, the container is effectively invisible since the object supplies
+its own styling.
+
+**Composing with mock cells.** Both `output-title` and `output-frame` work naturally with
+`source-code: mock`. The title or frame applies to the eval cell's output:
+
+````markdown
+```{{python}}
+#| source-code: mock
+#| output-title: "Response"
+chat.chat("I need your help.")
+# ---
+chat.chat("I need your help.", debug=True, header=False)
+```
+````
+
+### Mocked Code Cells
+
+Sometimes you need the code the reader *sees* to differ from the code that actually *runs*. Common
+reasons include:
+
+- an output requires a debug parameter that shouldn't be shown
+- the displayed code uses simplified imports
+- you want to hide boilerplate setup
+
+Normally this requires two separate code cells: one for display (`eval: false`) and one for
+execution (`echo: false`). The `source-code: mock` option collapses these into a single cell.
+
+Place `#| source-code: mock` at the top and separate the display code from the eval code with a
+`# ---` delimiter:
+
+````markdown
+```{{python}}
+#| source-code: mock
+import chatlas as ctl
+
+chat = ctl.ChatOpenAI()
+chat.chat("I need your help.")
+# ---
+import chatlas as ctl
+chat = ctl.ChatOpenAI(debug=True)
+chat.chat("I need your help.", header=False)
+```
+````
+
+The reader sees only the clean code above `# ---`, while the code below `# ---` runs and produces
+the output. Other hash-pipe options (`output-title`, `output-frame`, `warning`, etc.) compose
+naturally — see [Output Titles and Frames] above for examples.
+
+**Edge cases:**
+
+- **No delimiter**: the entire cell is display-only (equivalent to `eval: false`)
+- **Multiple `# ---`**: only the first one splits; subsequent ones are part of the eval code
+- **Empty eval section**: display-only cell (no output produced)
 
 ### Inline Code
 


### PR DESCRIPTION
This PR introduces support for "mock" code cells and output-title containers in the documentation build process. It adds a preprocessor for expanding special code cells (marked with `source-code: mock`) into display/eval cell pairs, and a Quarto extension for wrapping code cell outputs in a titled container when the `output-title` or `output-frame` option is set. These features improve the clarity and presentation of code examples and their outputs in the generated documentation.
