### PR TITLE
fix: Include hidden files in Pages artifact upload

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,6 +64,7 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           path: great-docs/_site
+          include-hidden-files: true
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/great_docs/assets/github-workflow-template.yml
+++ b/great_docs/assets/github-workflow-template.yml
@@ -62,6 +62,7 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           path: great-docs/_site
+          include-hidden-files: true
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/user_guide/14-deployment.qmd
+++ b/user_guide/14-deployment.qmd
@@ -132,6 +132,7 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           path: great-docs/_site
+          include-hidden-files: true
 
   publish-docs:
     needs: build-docs


### PR DESCRIPTION
This PR makes a small but important change to the documentation deployment workflows: it ensures that hidden files (such as those starting with a dot) are included when uploading the documentation site for deployment.