### PR TITLE
enh: fix prefixed .qmd links

### DIFF
--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -2688,6 +2688,9 @@ class GreatDocs:
 
             content = src_file.read_text(encoding="utf-8")
 
+            # Fix links to .qmd files with numeric prefixes
+            content = self._fix_numeric_prefix_links(content)
+
             # Parse frontmatter for metadata
             title = clean_name.replace(".qmd", "").replace(".md", "").replace("-", " ").title()
             description = ""
@@ -4305,6 +4308,38 @@ class GreatDocs:
         pattern = r"^\d+-|^\d+_"
         return re.sub(pattern, "", filename)
 
+    def _fix_numeric_prefix_links(self, content: str) -> str:
+        """
+        Rewrite relative Markdown links to `.qmd` files, stripping numeric prefixes.
+
+        When numeric prefixes are stripped from filenames during the copy step (e.g.,
+        `11-theming.qmd` -> `theming.qmd`), any cross-references between pages that use the original
+        prefixed names would break. This method fixes those links so authors can write
+        `[Theming](11-theming.qmd)` in source and it resolves correctly in the rendered site.
+
+        Only relative links to `.qmd` files are affected; absolute URLs and anchors are left
+        untouched.
+        """
+
+        def _rewrite(m: re.Match) -> str:
+            path = m.group(1)
+            # Split off anchor / query string
+            anchor = ""
+            for sep in ("#", "?"):
+                idx = path.find(sep)
+                if idx != -1:
+                    anchor = path[idx:]
+                    path = path[:idx]
+                    break
+            # Strip numeric prefix from each path component
+            parts = path.split("/")
+            clean_parts = [re.sub(r"^\d+[-_]", "", p) for p in parts]
+            return "](" + "/".join(clean_parts) + anchor + ")"
+
+        # Match markdown link targets that are relative paths ending in .qmd
+        # (skip absolute URLs starting with http://, https://, or /)
+        return re.sub(r"\]\((?!https?://|/)([^)]+\.qmd(?:[#?][^)]*)?)\)", _rewrite, content)
+
     def _copy_user_guide_to_docs(self, user_guide_info: dict) -> list[str]:
         """
         Copy user guide files from project root to docs directory.
@@ -4359,6 +4394,10 @@ class GreatDocs:
             # Read the source file and modify frontmatter
             with open(src_path, "r", encoding="utf-8") as f:
                 content = f.read()
+
+            # In auto-discovery mode, fix links to .qmd files with numeric prefixes
+            if not is_explicit:
+                content = self._fix_numeric_prefix_links(content)
 
             # Add bread-crumbs: false to frontmatter
             content = self._add_frontmatter_option(content, "bread-crumbs", False)

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -2671,6 +2671,116 @@ def test_strip_numeric_prefix_preserves_internal_numbers():
         assert docs._strip_numeric_prefix("02-chapter-10.qmd") == "chapter-10.qmd"
 
 
+def test_fix_numeric_prefix_links_basic():
+    """Test that basic .qmd links with numeric prefixes are rewritten."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        pyproject = Path(tmp_dir) / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        content = "- [Theming](11-theming.qmd): customize colors"
+        result = docs._fix_numeric_prefix_links(content)
+        assert result == "- [Theming](theming.qmd): customize colors"
+
+
+def test_fix_numeric_prefix_links_with_anchors():
+    """Test that anchors and query strings are preserved."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        pyproject = Path(tmp_dir) / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        assert (
+            docs._fix_numeric_prefix_links("[Config](05-configuration.qmd#options)")
+            == "[Config](configuration.qmd#options)"
+        )
+        assert (
+            docs._fix_numeric_prefix_links("[Config](05-configuration.qmd?v=2)")
+            == "[Config](configuration.qmd?v=2)"
+        )
+
+
+def test_fix_numeric_prefix_links_skips_absolute_urls():
+    """Test that absolute URLs are not modified."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        pyproject = Path(tmp_dir) / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        content = "[Docs](https://example.com/11-theming.qmd)"
+        assert docs._fix_numeric_prefix_links(content) == content
+
+        content_http = "[Docs](http://example.com/05-config.qmd)"
+        assert docs._fix_numeric_prefix_links(content_http) == content_http
+
+        content_abs = "[Docs](/root/11-theming.qmd)"
+        assert docs._fix_numeric_prefix_links(content_abs) == content_abs
+
+
+def test_fix_numeric_prefix_links_no_prefix():
+    """Test that links without numeric prefixes are unchanged."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        pyproject = Path(tmp_dir) / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        content = "[Theming](theming.qmd)"
+        assert docs._fix_numeric_prefix_links(content) == content
+
+
+def test_fix_numeric_prefix_links_subdirectory():
+    """Test that numeric prefixes are stripped from subdirectory components too."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        pyproject = Path(tmp_dir) / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        content = "[Guide](01-getting-started/02-install.qmd)"
+        result = docs._fix_numeric_prefix_links(content)
+        assert result == "[Guide](getting-started/install.qmd)"
+
+
+def test_fix_numeric_prefix_links_multiple():
+    """Test that multiple links in the same content are all fixed."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        pyproject = Path(tmp_dir) / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        content = (
+            "- [Theming](11-theming.qmd): colors\n"
+            "- [Config](05-configuration.qmd): options\n"
+            "- [Building](13-building.qmd): build pipeline"
+        )
+        result = docs._fix_numeric_prefix_links(content)
+        assert result == (
+            "- [Theming](theming.qmd): colors\n"
+            "- [Config](configuration.qmd): options\n"
+            "- [Building](building.qmd): build pipeline"
+        )
+
+
+def test_fix_numeric_prefix_links_ignores_non_qmd():
+    """Test that non-.qmd links are not affected."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        pyproject = Path(tmp_dir) / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        content = "[Image](11-diagram.png)"
+        assert docs._fix_numeric_prefix_links(content) == content
+
+        content_html = "[Page](11-theming.html)"
+        assert docs._fix_numeric_prefix_links(content_html) == content_html
+
+
 def test_user_guide_files_renamed_on_copy():
     """Test that user guide files are renamed when copied to docs directory."""
     with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
This PR automatically fixes internal Markdown links to `.qmd` files that have numeric prefixes in their filenames. When numeric prefixes are stripped from filenames during the documentation build process, this ensures that all cross-references between pages remain valid.