### PR TITLE
feat: 'On This Page' listing access on mobile views

### DIFF
--- a/great_docs/assets/great-docs.scss
+++ b/great_docs/assets/great-docs.scss
@@ -7084,6 +7084,185 @@ body.gd-menu-open {
 }
 
 
+/* ---- On This Page – Mobile Floating Button & Panel ---- */
+
+.gd-otp-btn {
+    position: fixed;
+    bottom: 4.5rem; /* above back-to-top; JS fine-tunes this */
+    right: 1.25rem;
+    z-index: 1040;
+    display: none; /* JS controls visibility via inline style */
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.92);
+    color: #495057;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+    transition: opacity 0.25s ease, bottom 0.25s ease,
+                background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+
+    &:hover, &.gd-otp-btn-active {
+        background: rgba(255, 255, 255, 1);
+        color: #212529;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+    }
+
+    &:focus-visible {
+        outline: 2px solid $primary;
+        outline-offset: 2px;
+    }
+
+    svg {
+        display: block;
+    }
+}
+
+/* Backdrop for dismissing the panel */
+.gd-otp-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 1041;
+    background: rgba(0, 0, 0, 0.25);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+}
+
+.gd-otp-backdrop-visible {
+    opacity: 1;
+    visibility: visible;
+}
+
+/* Floating panel */
+.gd-otp-panel {
+    position: fixed;
+    bottom: 6rem;
+    right: 1.25rem;
+    z-index: 1042;
+    width: min(280px, calc(100vw - 2.5rem));
+    max-height: min(360px, 60vh);
+    overflow-y: auto;
+    background: #fff;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    border-radius: 12px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(12px) scale(0.95);
+    transform-origin: bottom right;
+    transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
+    -webkit-overflow-scrolling: touch;
+}
+
+.gd-otp-panel-visible {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0) scale(1);
+}
+
+.gd-otp-panel-heading {
+    padding: 0.75rem 1rem 0.375rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #6c757d;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.gd-otp-panel-list {
+    list-style: none;
+    margin: 0;
+    padding: 0.375rem 0;
+}
+
+.gd-otp-panel-list li {
+    margin: 0;
+    padding: 0;
+}
+
+.gd-otp-panel-list li.gd-otp-nested {
+    padding-left: 0.75rem;
+}
+
+.gd-otp-panel-link {
+    display: block;
+    padding: 0.5rem 1rem;
+    font-size: 0.85rem;
+    line-height: 1.35;
+    color: #343a40;
+    text-decoration: none;
+    border-radius: 0;
+    transition: background-color 0.1s ease;
+
+    &:hover {
+        background: rgba(0, 0, 0, 0.04);
+        color: #212529;
+        text-decoration: none;
+    }
+
+    &:active {
+        background: rgba(0, 0, 0, 0.08);
+    }
+}
+
+/* Dark mode */
+[data-bs-theme="dark"] .gd-otp-btn {
+    background: rgba(52, 58, 64, 0.92);
+    color: #dee2e6;
+    border-color: rgba(255, 255, 255, 0.12);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+
+    &:hover, &.gd-otp-btn-active {
+        background: rgba(73, 80, 87, 1);
+        color: #f8f9fa;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+    }
+}
+
+[data-bs-theme="dark"] .gd-otp-backdrop {
+    background: rgba(0, 0, 0, 0.45);
+}
+
+[data-bs-theme="dark"] .gd-otp-panel {
+    background: #2b3035;
+    border-color: rgba(255, 255, 255, 0.1);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+[data-bs-theme="dark"] .gd-otp-panel-heading {
+    color: #adb5bd;
+    border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+
+[data-bs-theme="dark"] .gd-otp-panel-link {
+    color: #dee2e6;
+
+    &:hover {
+        background: rgba(255, 255, 255, 0.06);
+        color: #f8f9fa;
+    }
+
+    &:active {
+        background: rgba(255, 255, 255, 0.1);
+    }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+    .gd-otp-btn,
+    .gd-otp-panel,
+    .gd-otp-backdrop {
+        transition: none;
+    }
+}
+
+
 /*-- License Features Dropdown (mirrors Skills-page install dropdown) ----------*/
 
 .gd-license-features {

--- a/great_docs/assets/on-this-page.js
+++ b/great_docs/assets/on-this-page.js
@@ -1,0 +1,290 @@
+/**
+ * On This Page – Mobile Floating Button for Great Docs
+ *
+ * Features:
+ * - Round floating button visible only on mobile (< 768px)
+ * - Positioned above the back-to-top button to avoid collision
+ * - Opens a floating panel with the page's table-of-contents links
+ * - Tapping a section link scrolls there and dismisses the panel
+ * - Tapping outside the panel dismisses it without navigation
+ * - Dark mode aware
+ * - Keyboard accessible
+ * - Respects reduced-motion preferences
+ */
+
+(function () {
+    'use strict';
+
+    // Only activate on mobile-width viewports
+    var MQ = window.matchMedia('(max-width: 767.98px)');
+
+    /**
+     * Collect TOC entries from the existing Quarto sidebar TOC.
+     * Returns an array of { text, href, level } objects.
+     */
+    function collectTocEntries() {
+        // Quarto renders the right-hand TOC inside #quarto-margin-sidebar or
+        // nav#TOC. On mobile it's hidden via CSS, but the DOM is still there.
+        var tocNav = document.getElementById('TOC') ||
+                     document.querySelector('#quarto-margin-sidebar nav');
+        if (!tocNav) return [];
+
+        var links = tocNav.querySelectorAll('a.nav-link');
+        var entries = [];
+        for (var i = 0; i < links.length; i++) {
+            var a = links[i];
+            // Prefer data-scroll-target (always has the raw #hash);
+            // fall back to href and extract the hash fragment
+            var target = a.getAttribute('data-scroll-target');
+            if (!target) {
+                var href = a.getAttribute('href') || '';
+                var hashIdx = href.indexOf('#');
+                target = hashIdx >= 0 ? href.substring(hashIdx) : null;
+            }
+            if (!target || target.charAt(0) !== '#') continue;
+            // Determine nesting level from parent <li> depth
+            var depth = 0;
+            var el = a.parentElement;
+            while (el && el !== tocNav) {
+                if (el.tagName === 'UL') depth++;
+                el = el.parentElement;
+            }
+            entries.push({
+                text: a.textContent.trim(),
+                href: target,
+                level: depth
+            });
+        }
+        return entries;
+    }
+
+    /**
+     * Create the floating trigger button.
+     */
+    function createButton() {
+        var btn = document.createElement('button');
+        btn.className = 'gd-otp-btn';
+        btn.setAttribute('aria-label', 'On this page');
+        btn.setAttribute('title', 'On this page');
+        btn.setAttribute('type', 'button');
+
+        // List / table-of-contents icon (Lucide-style)
+        btn.innerHTML =
+            '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" ' +
+            'fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" ' +
+            'stroke-linejoin="round" aria-hidden="true">' +
+            '<line x1="8" y1="6" x2="21" y2="6"></line>' +
+            '<line x1="8" y1="12" x2="21" y2="12"></line>' +
+            '<line x1="8" y1="18" x2="21" y2="18"></line>' +
+            '<line x1="3" y1="6" x2="3.01" y2="6"></line>' +
+            '<line x1="3" y1="12" x2="3.01" y2="12"></line>' +
+            '<line x1="3" y1="18" x2="3.01" y2="18"></line>' +
+            '</svg>';
+
+        return btn;
+    }
+
+    /**
+     * Create the floating panel that shows the TOC entries.
+     */
+    function createPanel(entries) {
+        var panel = document.createElement('div');
+        panel.className = 'gd-otp-panel';
+        panel.setAttribute('role', 'dialog');
+        panel.setAttribute('aria-label', 'On this page');
+
+        var heading = document.createElement('div');
+        heading.className = 'gd-otp-panel-heading';
+        heading.textContent = 'On this page';
+        panel.appendChild(heading);
+
+        var list = document.createElement('ul');
+        list.className = 'gd-otp-panel-list';
+
+        for (var i = 0; i < entries.length; i++) {
+            var entry = entries[i];
+            var li = document.createElement('li');
+            if (entry.level > 1) {
+                li.className = 'gd-otp-nested';
+            }
+            var a = document.createElement('a');
+            a.href = entry.href;
+            a.textContent = entry.text;
+            a.className = 'gd-otp-panel-link';
+            li.appendChild(a);
+            list.appendChild(li);
+        }
+
+        panel.appendChild(list);
+        return panel;
+    }
+
+    /**
+     * Create the backdrop overlay for dismissing the panel.
+     */
+    function createBackdrop() {
+        var backdrop = document.createElement('div');
+        backdrop.className = 'gd-otp-backdrop';
+        return backdrop;
+    }
+
+    /**
+     * Coordinate the button position relative to the back-to-top button
+     * so they never collide.
+     */
+    /**
+     * Coordinate the button position relative to the back-to-top button
+     * so they never collide. Computes from the same source of truth
+     * (page-navigation element) that back-to-top uses, avoiding animation lag.
+     */
+    function syncPosition(btn) {
+        var btt = document.querySelector('.gd-back-to-top');
+        if (!btt) return;
+
+        var bttHeight = btt.offsetHeight || 36;
+        var gap = 12;
+
+        // Mirror the same page-nav overlap logic that back-to-top.js uses
+        var baseBottom = 20; // matches mobile CSS default (1.25rem)
+        var pageNav = document.querySelector('.page-navigation');
+        if (pageNav) {
+            var navRect = pageNav.getBoundingClientRect();
+            var viewportHeight = window.innerHeight;
+            if (navRect.top < viewportHeight && navRect.bottom > 0) {
+                var overlap = viewportHeight - navRect.top + 16;
+                baseBottom = Math.max(overlap, 32);
+            }
+        }
+
+        // Stack OTP above back-to-top
+        var otpBottom = baseBottom + bttHeight + gap;
+        btn.style.bottom = otpBottom + 'px';
+    }
+
+    function init() {
+        var entries = collectTocEntries();
+        // Don't show the button if there are no TOC entries
+        if (entries.length === 0) return;
+
+        var btn = createButton();
+        var panel = createPanel(entries);
+        var backdrop = createBackdrop();
+        var isOpen = false;
+
+        document.body.appendChild(btn);
+        document.body.appendChild(backdrop);
+        document.body.appendChild(panel);
+
+        function open() {
+            if (isOpen) return;
+            isOpen = true;
+            panel.classList.add('gd-otp-panel-visible');
+            backdrop.classList.add('gd-otp-backdrop-visible');
+            btn.classList.add('gd-otp-btn-active');
+            btn.setAttribute('aria-expanded', 'true');
+
+            // Position the panel above the button
+            var btnRect = btn.getBoundingClientRect();
+            var panelHeight = panel.offsetHeight;
+            var bottomOffset = window.innerHeight - btnRect.top + 8;
+            panel.style.bottom = bottomOffset + 'px';
+            panel.style.right = btn.style.right || '1.25rem';
+        }
+
+        function close() {
+            if (!isOpen) return;
+            isOpen = false;
+            panel.classList.remove('gd-otp-panel-visible');
+            backdrop.classList.remove('gd-otp-backdrop-visible');
+            btn.classList.remove('gd-otp-btn-active');
+            btn.setAttribute('aria-expanded', 'false');
+        }
+
+        // Toggle on button tap
+        btn.addEventListener('click', function (e) {
+            e.stopPropagation();
+            if (isOpen) {
+                close();
+            } else {
+                open();
+            }
+        });
+
+        // Dismiss on backdrop tap (outside panel)
+        backdrop.addEventListener('click', function () {
+            close();
+        });
+
+        // Handle link taps: navigate + dismiss
+        var links = panel.querySelectorAll('.gd-otp-panel-link');
+        for (var i = 0; i < links.length; i++) {
+            links[i].addEventListener('click', function (e) {
+                e.preventDefault();
+                var targetId = this.getAttribute('href');
+                close();
+
+                // Navigate to the section
+                var target = document.querySelector(targetId);
+                if (target) {
+                    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+                        target.scrollIntoView();
+                    } else {
+                        target.scrollIntoView({ behavior: 'smooth' });
+                    }
+                    // Update URL hash without triggering scroll
+                    history.pushState(null, '', targetId);
+                }
+            });
+        }
+
+        // Close on Escape key
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape' && isOpen) {
+                close();
+                btn.focus();
+            }
+        });
+
+        // Show/hide based on media query
+        function onMediaChange(mq) {
+            if (mq.matches) {
+                btn.style.display = 'flex';
+            } else {
+                btn.style.display = 'none';
+                close();
+            }
+        }
+
+        // Sync position with back-to-top button on scroll
+        var ticking = false;
+        window.addEventListener('scroll', function () {
+            if (!ticking) {
+                window.requestAnimationFrame(function () {
+                    syncPosition(btn);
+                    ticking = false;
+                });
+                ticking = true;
+            }
+        }, { passive: true });
+
+        // Initial position sync
+        syncPosition(btn);
+
+        // Listen for media query changes
+        if (MQ.addEventListener) {
+            MQ.addEventListener('change', onMediaChange);
+        } else if (MQ.addListener) {
+            MQ.addListener(onMediaChange);
+        }
+
+        // Set initial visibility
+        onMediaChange(MQ);
+    }
+
+    // DOM ready
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -238,6 +238,7 @@ class GreatDocs:
             js_files.append("page-metadata.js")  # pragma: no cover
         if self._config.back_to_top:
             js_files.append("back-to-top.js")
+            js_files.append("on-this-page.js")
         if self._config.keyboard_nav:
             js_files.append("keyboard-nav.js")
         if self._config.tags_show_on_pages:
@@ -10004,6 +10005,7 @@ body-classes: "gd-homepage"
             js_resource_files.append("page-metadata.js")  # pragma: no cover
         if self._config.back_to_top:
             js_resource_files.append("back-to-top.js")
+            js_resource_files.append("on-this-page.js")
         if self._config.keyboard_nav:
             js_resource_files.append("keyboard-nav.js")
         if self._config.tags_show_on_pages:
@@ -10479,6 +10481,23 @@ body-classes: "gd-homepage"
             )
             if not has_back_to_top:
                 config["format"]["html"]["include-after-body"].append(back_to_top_entry)
+
+            on_this_page_entry = {
+                "text": (
+                    "<script>(function(){var s=document.createElement('script');"
+                    "var m=document.querySelector('meta[name=\"quarto:offset\"]');"
+                    "s.src=(m?m.content:'')+'on-this-page.js';"
+                    "document.body.appendChild(s);})();</script>"
+                )
+            }
+            has_on_this_page = any(
+                "on-this-page.js" in str(item)
+                for item in config["format"]["html"]["include-after-body"]
+            )
+            if not has_on_this_page:
+                config["format"]["html"]["include-after-body"].append(
+                    on_this_page_entry
+                )
 
         # Add keyboard navigation script (if enabled)
         if metadata.get("keyboard_nav_enabled", True):

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -40200,6 +40200,169 @@ def test_back_to_top_scss_styles_exist():
     assert "prefers-reduced-motion" in content
 
 
+# On-this-page mobile widget tests ---------------------------------------------
+
+
+def test_on_this_page_enabled_by_default():
+    """on-this-page.js is in resources and include-after-body by default."""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        docs, quarto_yml = _make_uqc_docs(tmp_dir)
+
+        docs._update_quarto_config()
+
+        with open(quarto_yml) as f:
+            result = read_yaml(f)
+
+        resources = result["project"].get("resources", [])
+
+        assert "on-this-page.js" in resources
+
+        after_body = result["format"]["html"].get("include-after-body", [])
+        has_on_this_page = any("on-this-page.js" in str(item) for item in after_body)
+
+        assert has_on_this_page
+
+
+def test_on_this_page_disabled_via_config():
+    """on-this-page.js is excluded when back_to_top is false."""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        docs, quarto_yml = _make_uqc_docs(
+            tmp_dir,
+            gd_yml_content="back_to_top: false\n",
+        )
+
+        docs._update_quarto_config()
+
+        with open(quarto_yml) as f:
+            result = read_yaml(f)
+
+        resources = result["project"].get("resources", [])
+
+        assert "on-this-page.js" not in resources
+
+        after_body = result["format"]["html"].get("include-after-body", [])
+        has_on_this_page = any("on-this-page.js" in str(item) for item in after_body)
+
+        assert not has_on_this_page
+
+
+def test_on_this_page_script_tag_uses_quarto_offset():
+    """The on-this-page include-after-body entry uses the quarto:offset pattern."""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        docs, quarto_yml = _make_uqc_docs(tmp_dir)
+
+        docs._update_quarto_config()
+
+        with open(quarto_yml) as f:
+            result = read_yaml(f)
+
+        after_body = result["format"]["html"]["include-after-body"]
+        otp_entries = [item for item in after_body if "on-this-page.js" in str(item)]
+
+        assert len(otp_entries) == 1
+        assert "quarto:offset" in str(otp_entries[0])
+
+
+def test_on_this_page_not_duplicated():
+    """Running _update_quarto_config twice does not duplicate the script tag."""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        docs, quarto_yml = _make_uqc_docs(tmp_dir)
+
+        docs._update_quarto_config()
+        docs._update_quarto_config()
+
+        with open(quarto_yml) as f:
+            result = read_yaml(f)
+
+        after_body = result["format"]["html"]["include-after-body"]
+        otp_count = sum(1 for item in after_body if "on-this-page.js" in str(item))
+
+        assert otp_count == 1
+
+
+def test_on_this_page_js_copied_to_project():
+    """on-this-page.js is copied from assets to the project directory."""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        docs, _ = _make_uqc_docs(tmp_dir)
+        docs._prepare_build_directory()
+
+        js_file = docs.project_path / "on-this-page.js"
+
+        assert js_file.exists()
+
+
+def test_on_this_page_js_not_copied_when_disabled():
+    """on-this-page.js is not copied when back_to_top is disabled."""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        docs, _ = _make_uqc_docs(
+            tmp_dir,
+            gd_yml_content="back_to_top: false\n",
+        )
+        docs._prepare_build_directory()
+
+        js_file = docs.project_path / "on-this-page.js"
+
+        assert not js_file.exists()
+
+
+def test_on_this_page_js_file_has_expected_content():
+    """The on-this-page.js asset exists and contains the expected patterns."""
+
+    js_path = Path(__file__).parent.parent / "great_docs" / "assets" / "on-this-page.js"
+
+    assert js_path.exists()
+
+    content = js_path.read_text()
+
+    # Verify IIFE wrapping
+    assert "(function ()" in content
+    assert "})();" in content
+
+    # Verify mobile-only media query
+    assert "max-width: 767.98px" in content
+
+    # Verify TOC collection uses data-scroll-target
+    assert "data-scroll-target" in content
+
+    # Verify key DOM creation
+    assert "gd-otp-btn" in content
+    assert "gd-otp-panel" in content
+    assert "gd-otp-backdrop" in content
+    assert "aria-label" in content
+
+    # Verify reduced motion support
+    assert "prefers-reduced-motion" in content
+
+    # Verify page nav collision avoidance (same logic as back-to-top)
+    assert ".page-navigation" in content
+    assert ".gd-back-to-top" in content
+
+
+def test_on_this_page_scss_styles_exist():
+    """The SCSS file contains on-this-page widget styles."""
+
+    scss_path = Path(__file__).parent.parent / "great_docs" / "assets" / "great-docs.scss"
+    content = scss_path.read_text()
+
+    assert ".gd-otp-btn {" in content
+    assert ".gd-otp-panel {" in content
+    assert ".gd-otp-backdrop {" in content
+    assert ".gd-otp-panel-visible {" in content
+
+    # Dark mode
+    assert '[data-bs-theme="dark"] .gd-otp-btn' in content
+    assert '[data-bs-theme="dark"] .gd-otp-panel' in content
+
+    # Reduced motion
+    assert ".gd-otp-btn," in content  # in the reduced-motion block
+
+
 # Keyboard navigation tests ----------------------------------------------------
 
 

--- a/user_guide/11-theming.qmd
+++ b/user_guide/11-theming.qmd
@@ -101,6 +101,12 @@ back_to_top: false   # Disable the button
 The button respects the visitor's `prefers-reduced-motion` setting: when reduced motion is
 preferred, scrolling is instant rather than animated.
 
+When `back_to_top` is enabled, a companion **On this page** button also appears on mobile
+viewports (below 768 px). This round floating button sits directly above the back-to-top button
+and opens a compact table-of-contents panel. Tapping a heading scrolls to that section and
+dismisses the panel whereas tapping outside the panel dismisses it without navigating. The button is
+hidden on tablet and desktop widths where the sidebar TOC is already visible.
+
 ## Keyboard Navigation [version-badge new 0.5]
 
 Great Docs includes built-in keyboard shortcuts that let visitors navigate the site and access


### PR DESCRIPTION
This PR introduces a new "On This Page" mobile floating button and panel view. This widget appears on mobile viewports (below 768px) when the `back_to_top` feature is enabled (it is enabled by default), providing users with a convenient and accessible way to navigate the page's ToC.