### PR TITLE
feat: parse and render Click CLI documentation

### DIFF
--- a/great_docs/assets/_extensions/details/details.lua
+++ b/great_docs/assets/_extensions/details/details.lua
@@ -25,6 +25,13 @@ local function escape_html(s)
     return s:gsub("&", "&amp;"):gsub("<", "&lt;"):gsub(">", "&gt;"):gsub('"', "&quot;")
 end
 
+--- Render inline backtick code in summary text as <code> elements.
+--- First escapes HTML, then converts `...` to <code>...</code>.
+local function render_summary(s)
+    local escaped = escape_html(s)
+    return escaped:gsub("`([^`]+)`", "<code>%1</code>")
+end
+
 --- Read a named attribute from a Pandoc Div, returning "" if absent.
 local function attr_str(div, key)
     local val = div.attributes[key]
@@ -152,7 +159,7 @@ function Div(div)
         .. '<span class="gd-details-chevron" aria-hidden="true"></span>'
         .. icon_html
         .. '<span class="gd-details-title">'
-        .. escape_html(summary) .. '</span>'
+        .. render_summary(summary) .. '</span>'
         .. '</summary>\n'
         .. '<div class="gd-details-body">'
     local html_close = '</div>\n</details>'

--- a/great_docs/assets/great-docs.scss
+++ b/great_docs/assets/great-docs.scss
@@ -19,6 +19,8 @@ $label-exception-color: mix($primary, $red-600, 20%);
 $label-property-color: mix($primary, $teal-600, 20%);
 $label-constant-color: mix($primary, $orange-500, 20%);
 $label-typealias-color: mix($primary, $yellow-500, 20%);
+$label-cli-color: mix($primary, $green-600, 20%);
+$label-cli-group-color: mix($primary, $green-600, 20%);
 
 $signature-background-color: shade-color(tint-color($primary, 96%), 2%);
 
@@ -463,7 +465,9 @@ $all_labels: (
   exception,
   property,
   constant,
-  typealias
+  typealias,
+  cli,
+  cli-group
 );
 $class-like-labels: (class, dataclass, namedtuple, typeddict, protocol, abc, enum);
 $method-like-labels: (method, classmethod, staticmethod);
@@ -530,6 +534,19 @@ $method-like-labels: (method, classmethod, staticmethod);
   color: $label-typealias-color;
   border-color: $label-typealias-color;
   background-color: tint-color($label-typealias-color, 95%);
+}
+
+.content span.doc-label-cli::after {
+  color: $label-cli-color;
+  border-color: $label-cli-color;
+  background-color: tint-color($label-cli-color, 95%);
+}
+
+.content span.doc-label-cli-group::after {
+  content: "cli-group";
+  color: $label-cli-group-color;
+  border-color: $label-cli-group-color;
+  background-color: tint-color($label-cli-group-color, 95%);
 }
 
 // Adorn callables with ()
@@ -2750,8 +2767,6 @@ h1.title.cli-title {
 }
 
 .cli-manpage {
-    max-width: 90ch;
-    margin: 0 auto;
     width: 100%;
 }
 
@@ -2789,37 +2804,20 @@ h1.title.cli-title {
 /* On large screens, expand CLI content area into the unused right margin space */
 /* The right sidebar ("On this page") is ~250px; we use half of that */
 @media (min-width: 992px) and (max-width: 1199.98px) {
-    /* Expand the main content area on pages with CLI help */
-    main.content:has(.cli-manpage) {
-        width: calc(90ch + 30px);
-        max-width: none;
-    }
-
     .cli-manpage {
-        width: calc(90ch + 30px);
-        max-width: none;
         margin-top: 1.5rem;
     }
 }
 
-/* On extra large screens, we can use a bit more of that space */
 @media (min-width: 1200px) {
-    main.content:has(.cli-manpage) {
-        width: calc(90ch + 50px);
-        max-width: none;
-    }
-
     .cli-manpage {
-        width: calc(90ch + 50px);
-        max-width: none;
+        margin-top: 1.5rem;
     }
 }
 
 /* Responsive adjustments for CLI docs */
 @media (min-width: 768px) and (max-width: 991.98px) {
     .cli-manpage {
-        width: calc(100% + 150px);
-        max-width: none;
         margin-top: 1.5rem;
     }
 

--- a/great_docs/cli.py
+++ b/great_docs/cli.py
@@ -130,7 +130,7 @@ class OrderedGroup(click.Group):
 @click.group(cls=OrderedGroup)
 @click.version_option(version=__version__, prog_name="great-docs")
 def cli():
-    """Great Docs - Beautiful documentation for Python packages.
+    """Great Docs: Beautiful documentation for Python packages.
 
     Great Docs generates professional documentation sites with auto-generated
     API references, CLI documentation, smart navigation, and modern styling.
@@ -155,19 +155,20 @@ def cli():
 def init(project_path: str | None, force: bool) -> None:
     """Initialize great-docs in your project (one-time bootstrap).
 
-    Creates a fresh great-docs.yml configuration file with discovered
+    Creates a fresh 'great-docs.yml' configuration file with discovered
     package exports and sensible defaults. Refuses to run if
-    great-docs.yml already exists (use --force to reset).
+    'great-docs.yml' already exists (use '--force' to reset).
 
     \b
-    • Creates great-docs.yml with discovered API exports
+    • Creates 'great-docs.yml' with discovered API exports
     • Auto-detects your package name and public API
     • Updates .gitignore to exclude the build directory
     • Detects docstring style (numpy, google, sphinx)
 
-    After init, customize great-docs.yml then use 'great-docs build'
-    for all subsequent builds. You should never need to run init again
-    unless you want to completely reset your configuration.
+    After init, customize 'great-docs.yml' then use 'great-docs build'
+    for all subsequent builds. You should never need to run
+    'great-docs init' again unless you want to completely reset your
+    configuration.
 
     \b
     Examples:
@@ -255,29 +256,30 @@ def build(
 ) -> None:
     """Build your documentation site.
 
-    Requires great-docs.yml to exist (run 'great-docs init' first).
+    Requires 'great-docs.yml' to exist (run 'great-docs init' first).
     This is the only command you need day-to-day and in CI.
 
     Creates the 'great-docs/' build directory, copies all assets,
     and builds the documentation site. The build directory is ephemeral and
     should not be committed to version control.
 
-    Use --project-path to point to a project in a different directory.
-    Use --watch to automatically rebuild when source files change.
+    Use '--project-path' to point to a project in a different directory.
+    Use '--watch' to automatically rebuild when source files change.
 
-    Use --no-refresh to skip API discovery for faster rebuilds when your
+    Use '--no-refresh' to skip API discovery for faster rebuilds when your
     package's public API hasn't changed.
 
-    When multi-version documentation is configured, use --versions to build
-    only specific versions, or --latest-only to skip historical versions.
+    When multi-version documentation is configured, use '--versions' to
+    build only specific versions, or '--latest-only' to skip historical
+    versions.
 
-    Use --from-repo to build documentation from a remote Git repository.
+    Use '--from-repo' to build documentation from a remote Git repository.
     This clones the repo into a temporary directory, creates an isolated
     virtual environment, installs the package and great-docs, builds the
-    site, and copies the output to --output-dir (or ./great-docs/_site).
+    site, and copies the output to '--output-dir' (or './great-docs/_site').
 
-    Add --preview to automatically start a local server after a --from-repo
-    build completes, opening the site in your browser.
+    Add '--preview' to automatically start a local server after a
+    '--from-repo' build completes, opening the site in your browser.
 
     \b
     Examples:
@@ -358,10 +360,10 @@ def uninstall(project_path: str | None) -> None:
     This command removes the great-docs configuration and build directory:
 
     \b
-    • Deletes great-docs.yml configuration file
-    • Removes great-docs/ build directory
+    • Deletes the 'great-docs.yml' configuration file
+    • Removes the 'great-docs/' build directory
 
-    Your source files (user_guide/, README.md, etc.) are preserved.
+    Your source files ('user_guide/', 'README.md', etc.) are preserved.
 
     \b
     Examples:
@@ -400,11 +402,11 @@ def preview(project_path: str | None, port: int, site_dir: str | None) -> None:
     Starts a local HTTP server and opens the built documentation site in your
     default browser. If the site hasn't been built yet, it will build it first.
 
-    The site is served from great-docs/_site/. Use 'great-docs build' to
+    The site is served from 'great-docs/_site/'. Use 'great-docs build' to
     rebuild if you've made changes.
 
-    Use --site-dir to preview a site from any directory (e.g. output from
-    a --from-repo build).
+    Use '--site-dir' to preview a site from any directory (e.g. output from
+    a '--from-repo' build).
 
     \b
     Examples:
@@ -444,7 +446,7 @@ def preview(project_path: str | None, port: int, site_dir: str | None) -> None:
 def config(project_path: str | None, force: bool) -> None:
     """Generate a great-docs.yml configuration file.
 
-    Creates a great-docs.yml file with all available options documented.
+    Creates a 'great-docs.yml' file with all available options documented.
     The generated file contains commented examples for each setting.
 
     \b
@@ -822,20 +824,20 @@ def freeze(
     """Execute specific pages and persist their freeze cache.
 
     Renders one or more QMD pages (always executing their code), then copies
-    the resulting _freeze/ entries back to a persistent location so they
+    the resulting '_freeze/' entries back to a persistent location so they
     survive future builds.
 
     PAGES are paths to .qmd files relative to your project root (e.g.,
     'user_guide/benchmarks.qmd'). Quarto always executes code when rendering
-    individual files, even with freeze enabled — this is how you update
-    frozen outputs.
+    individual files, even with freeze enabled (this is how you update
+    frozen outputs).
 
-    Use --clean to wipe the entire _freeze/ cache before re-executing.
+    Use '--clean' to wipe the entire '_freeze/' cache before re-executing.
     This forces a full refresh of all specified pages from scratch.
 
-    Use --info to see the freeze status of all pages without rendering.
+    Use '--info' to see the freeze status of all pages without rendering.
 
-    After running, the updated _freeze/ entries are ready to commit to
+    After running, the updated '_freeze/' entries are ready to commit to
     version control.
 
     \b
@@ -1241,15 +1243,16 @@ def setup_github_pages(
     • Install dev dependencies (auto-detected from your package manager)
 
     The Python version is automatically detected from your pyproject.toml's
-    `requires-python` field. Use --python-version to override.
+    `requires-python` field. Use '--python-version' to override.
 
     The package manager is auto-detected by checking for lock files:
-    • uv.lock → uses uv (installs dev dependencies automatically)
-    • poetry.lock → uses poetry (installs with dev dependencies)
-    • Otherwise → uses pip with optional extras like [dev,docs]
+    • uv.lock -> uses uv (installs dev dependencies automatically)
+    • poetry.lock -> uses poetry (installs with dev dependencies)
+    • Otherwise -> uses pip with optional extras like [dev,docs]
 
     After running this command, commit the workflow file and enable GitHub
-    Pages in your repository settings (Settings → Pages → Source: GitHub Actions).
+    Pages in your repository settings (Settings -> Pages ->
+    Source: GitHub Actions).
 
     \b
     Examples:
@@ -1439,7 +1442,7 @@ def check_links(
 ) -> None:
     """Check for broken links in source code and documentation.
 
-    This command scans Python source files and documentation (`.qmd`, `.md`)
+    This command scans Python source files and documentation ('.qmd', '.md')
     for URLs and checks their HTTP status. It reports broken links (404s)
     and warns about redirects.
 
@@ -1581,12 +1584,12 @@ def changelog(project_path: str | None, max_releases: int | None) -> None:
     """Generate a Changelog page from GitHub Releases.
 
     Fetches published releases from the GitHub API and renders them as a
-    changelog.qmd page in the build directory. The page is also linked in
+    'changelog.qmd' page in the build directory. The page is also linked in
     the navbar automatically.
 
     \b
-    Requires the project to have a GitHub repository URL in pyproject.toml.
-    Set GITHUB_TOKEN or GH_TOKEN to avoid API rate limits.
+    Requires the project to have a GitHub repository URL in 'pyproject.toml'.
+    Set 'GITHUB_TOKEN' or 'GH_TOKEN' to avoid API rate limits.
     """
     try:
         docs = GreatDocs(project_path=project_path)
@@ -1736,8 +1739,8 @@ def proofread(
     \b
     By default, checks all documentation files (.qmd, .md) in the project.
     Uses smart defaults to reduce noise in technical documentation:
-      - Ignores formatting rules that conflict with code/YAML (unless --strict)
-      - Includes a built-in dictionary of technical terms (unless --no-builtin-dictionary)
+      - Ignores formatting rules that conflict with code/YAML (unless '--strict')
+      - Includes a built-in dictionary of technical terms (unless '--no-builtin-dictionary')
 
     \b
     Examples:
@@ -2336,13 +2339,13 @@ def lint(project_path: str | None, checks: tuple[str, ...], json_output: bool) -
     \b
     Checks performed:
       • missing-docstring    Public exports or methods without docstrings
-      • broken-xref          %seealso references to unknown symbols
+      • broken-xref          '%seealso' references to unknown symbols
       • style-mismatch       Docstrings not matching configured style (numpy/google/sphinx)
-      • unknown-directive    Unrecognized %directive names
-      • empty-seealso        %seealso entries with empty references
+      • unknown-directive    Unrecognized '%directive' names
+      • empty-seealso        '%seealso' entries with empty references
       • stale-badge          Version badges far behind latest release
       • stale-callout        Version callouts that are very old
-      • stale-upcoming       upcoming: frontmatter for already-released versions
+      • stale-upcoming       'upcoming:' frontmatter for already-released versions
 
     \b
     Examples:
@@ -2502,12 +2505,13 @@ def api_diff_cmd(
 ) -> None:
     """Compare the public API between two versions.
 
-    Analyzes how the API surface changed between OLD_VERSION and NEW_VERSION
-    (git tags). Detects added, removed, and changed symbols, tracks parameter
-    changes, and flags breaking changes with migration hints.
+    Analyzes how the API surface changed between 'OLD_VERSION' and
+    'NEW_VERSION' (git tags). Detects added, removed, and changed symbols,
+    tracks parameter changes, and flags breaking changes with migration
+    hints.
 
     \b
-    Use "HEAD" as NEW_VERSION to compare against the working tree.
+    Use 'HEAD' as 'NEW_VERSION' to compare against the working tree.
 
     \b
     Examples:
@@ -2759,7 +2763,7 @@ cli.add_command(api_diff_cmd)
 def versions(project_path: str | None, check: bool) -> None:
     """List configured documentation versions.
 
-    Shows the multi-version documentation configuration from great-docs.yml,
+    Shows the multi-version documentation configuration from 'great-docs.yml',
     including version tags, labels, and status indicators.
 
     \b
@@ -2835,13 +2839,13 @@ cli.add_command(versions)
 )
 @click.option(
     "--package",
-    help="Python package name (auto-detected from pyproject.toml if omitted)",
+    help="Python package name (auto-detected from 'pyproject.toml' if omitted)",
 )
 @click.option(
     "--output",
     "-o",
     type=click.Path(dir_okay=False),
-    help="Output file path (default: .great-docs/snapshots/<version>.json)",
+    help="Output file path (default: '.great-docs/snapshots/<version>.json')",
 )
 @click.option(
     "--all-tags",
@@ -2869,18 +2873,18 @@ def api_snapshot_cmd(
 
     \b
     With no arguments, snapshot the *current* working-tree API:
-      great-docs api-snapshot
+      'great-docs api-snapshot'
 
     \b
     Snapshot a specific git tag:
-      great-docs api-snapshot v1.0.0
+      'great-docs api-snapshot v1.0.0'
 
     \b
     Snapshot all version tags at once:
-      great-docs api-snapshot --all-tags
+      'great-docs api-snapshot --all-tags'
 
     \b
-    Snapshots are saved to .great-docs/snapshots/<version>.json by default.
+    Snapshots are saved to '.great-docs/snapshots/<version>.json' by default.
     """
     from ._api_diff import (
         _detect_package_name,

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -3654,7 +3654,7 @@ class GreatDocs:
 
     def _get_cli_entry_point_name(self, package_name: str) -> str | None:
         """
-        Get the CLI entry point name from pyproject.toml.
+        Get the CLI entry point name from `pyproject.toml`.
 
         Parameters
         ----------
@@ -3664,8 +3664,8 @@ class GreatDocs:
         Returns
         -------
         str | None
-            The entry point name (e.g., "great-docs" from "[project.scripts]"),
-            or None if not found.
+            The entry point name (e.g., `"great-docs"` from `"[project.scripts]"`), or `None` if not
+            found.
         """
         package_root = self._find_package_root()
         pyproject_path = package_root / "pyproject.toml"
@@ -3711,7 +3711,8 @@ class GreatDocs:
         Returns
         -------
         dict
-            Dictionary containing command information.
+            Dictionary containing command information including options, arguments, and parsed
+            examples.
         """
         import click
 
@@ -3720,16 +3721,42 @@ class GreatDocs:
         # Get the actual --help output from Click
         help_text = self._get_click_help_text(cmd, full_path)
 
+        # Extract options and arguments from Click params
+        options = []
+        arguments = []
+        for param in cmd.params:
+            if isinstance(param, click.Option):
+                opt_info = self._extract_click_option(param)
+                if opt_info:
+                    options.append(opt_info)
+            elif isinstance(param, click.Argument):
+                arg_info = self._extract_click_argument(param)
+                if arg_info:
+                    arguments.append(arg_info)
+
+        # Parse description and examples from the help text
+        description, examples = self._parse_click_help_parts(cmd.help or "")
+
+        # Extract the short help (Click may auto-derive it, but sometimes it's
+        # empty for subcommands).  Fall back to the first line/sentence of help.
+        short_help = getattr(cmd, "short_help", "") or ""
+        if not short_help and cmd.help:
+            short_help = cmd.get_short_help_str(limit=150)
+
         info = {
             "name": name,
             "full_path": full_path,
             "help": cmd.help or "",
-            "short_help": getattr(cmd, "short_help", "") or "",
+            "short_help": short_help,
             "help_text": help_text,  # The actual --help output
             "deprecated": getattr(cmd, "deprecated", False),
             "hidden": getattr(cmd, "hidden", False),
             "commands": [],
             "is_group": isinstance(cmd, click.Group),
+            "options": options,
+            "arguments": arguments,
+            "description": description,
+            "examples": examples,
         }
 
         # Extract subcommands if this is a group
@@ -3741,21 +3768,169 @@ class GreatDocs:
 
         return info
 
+    @staticmethod
+    def _extract_click_option(param) -> dict | None:
+        """Extract structured info from a Click Option parameter."""
+        # Skip the --help option itself
+        if param.name == "help":
+            return None
+
+        decls = param.opts + param.secondary_opts
+        names = sorted(decls, key=len)  # short first, long second
+
+        type_name = param.type.name if hasattr(param.type, "name") else str(param.type)
+
+        # Normalise the default: Click uses sentinel objects for unset values
+        default = param.default
+        if default is None or (
+            type(default).__name__ in ("Sentinel", "_DEFAULT_SENTINEL")
+            or repr(default).startswith("Sentinel")
+        ):
+            default = None
+
+        return {
+            "names": names,
+            "name_display": ", ".join(names),
+            "help": param.help or "",
+            "type": type_name.upper() if type_name != "BOOL" else None,
+            "default": default,
+            "required": param.required,
+            "is_flag": param.is_flag,
+            "multiple": param.multiple,
+            "envvar": param.envvar,
+            "show_default": getattr(param, "show_default", False),
+            "is_eager": param.is_eager,
+            "hidden": getattr(param, "hidden", False),
+        }
+
+    @staticmethod
+    def _extract_click_argument(param) -> dict | None:
+        """Extract structured info from a Click Argument parameter."""
+        type_name = param.type.name if hasattr(param.type, "name") else str(param.type)
+
+        return {
+            "name": param.name,
+            "name_display": param.human_readable_name,
+            "type": type_name.upper() if type_name != "TEXT" else None,
+            "required": param.required,
+            "nargs": param.nargs,
+        }
+
+    @staticmethod
+    def _parse_click_help_parts(help_text: str) -> tuple[str, list[str]]:
+        """
+        Parse a Click command's help string into description and examples.
+
+        Parameters
+        ----------
+        help_text
+            The raw help string from `cmd.help`.
+
+        Returns
+        -------
+        tuple[str, list[str]]
+            A (description, examples) pair. `description` is the prose before the examples block;
+            `examples` is a list of example lines (without the `Examples:` header).
+        """
+        if not help_text:
+            return "", []
+
+        lines = help_text.split("\n")
+        desc_lines: list[str] = []
+        example_lines: list[str] = []
+        in_examples = False
+
+        for line in lines:
+            stripped = line.strip()
+
+            # Click uses \x08 (literal backspace) as the "don't rewrap" marker;
+            # skip lines that are just that marker.
+            if stripped in ("\x08", "\\b"):
+                continue
+
+            # Detect the examples block header
+            if stripped.lower() == "examples:" and not in_examples:
+                in_examples = True
+                continue
+
+            if in_examples:
+                # Strip common Click indentation (2 or 4 spaces)
+                dedented = line
+                if line.startswith("    "):
+                    dedented = line[4:]
+                elif line.startswith("  "):
+                    dedented = line[2:]
+                example_lines.append(dedented)
+            else:
+                desc_lines.append(line)
+
+        # Clean up: strip leading/trailing blank lines
+        description = "\n".join(desc_lines).strip()
+        # Remove any remaining \x08 bytes from the description
+        description = description.replace("\x08", "")
+        # Remove literal \b if present
+        description = description.replace("\\b", "")
+        # Collapse runs of blank lines to a single blank line
+        import re
+
+        description = re.sub(r"\n{3,}", "\n\n", description)
+
+        # Clean trailing blanks from examples
+        while example_lines and not example_lines[-1].strip():
+            example_lines.pop()
+
+        return description, example_lines
+
+    @staticmethod
+    def _backtick_cli_prose(text: str, option_names: set[str]) -> str:
+        """Wrap CLI option names and single-quoted tokens in backticks.
+
+        Handles two cases:
+
+        1. Known option names (e.g. `--watch`) -> `--watch`
+        2. Single-quoted text (e.g. `'great-docs/'`) -> `great-docs/`
+
+        Only wraps tokens not already inside backticks.  Avoids matching
+        apostrophes in contractions/possessives (e.g. "package's", "hasn't").
+        """
+        import re
+
+        if not text:
+            return text
+
+        # 1. Wrap single-quoted text in backticks.
+        # Require the opening quote to be preceded by whitespace or start-of-string
+        # and the content to be at least 2 chars (avoids possessives like package's).
+        text = re.sub(r"(?<=\s)'([^']{2,})'(?=[\s,.\)!?;:]|$)", r"`\1`", text)
+        text = re.sub(r"^'([^']{2,})'(?=[\s,.\)!?;:]|$)", r"`\1`", text)
+
+        # 2. Wrap known option names
+        if option_names:
+            sorted_names = sorted(option_names, key=len, reverse=True)
+            pattern = "|".join(re.escape(n) for n in sorted_names)
+            text = re.sub(
+                rf"(?<!`)({pattern})(?!`)",
+                r"`\1`",
+                text,
+            )
+
+        return text
+
     def _get_click_help_text(self, cmd: "click.Command", full_path: str) -> str:
         """
-        Get the formatted --help output from a Click command.
+        Get the formatted `--help` output from a Click command.
 
         Parameters
         ----------
         cmd
             The Click Command object.
         full_path
-            The full command path (e.g., "great-docs build").
+            The full command path (e.g., `"great-docs build"`).
 
         Returns
         -------
         str
-            The formatted help text as it would appear from --help.
+            The formatted help text as it would appear from `--help`.
         """
         import click
 
@@ -3770,12 +3945,12 @@ class GreatDocs:
         Parameters
         ----------
         cli_info
-            Dictionary containing CLI structure from _discover_click_cli.
+            Dictionary containing CLI structure from `_discover_click_cli`.
 
         Returns
         -------
         list[str | dict]
-            Sidebar items — plain path strings for leaf commands, or
+            Sidebar items: plain path strings for leaf commands, or
             `{"section": ..., "contents": [...]}` dicts for groups.
         """
         if not cli_info:
@@ -3825,13 +4000,13 @@ class GreatDocs:
         output_dir
             Directory to write pages to.
         rel_prefix
-            The relative path prefix for sidebar entries (e.g. `reference/cli`
-            or `reference/cli/task` for nested groups).
+            The relative path prefix for sidebar entries (e.g. `reference/cli` or
+            `reference/cli/task` for nested groups).
 
         Returns
         -------
         list[str | dict]
-            Sidebar items — plain path strings for leaf commands, or
+            Sidebar items: plain path strings for leaf commands, or
             `{"section": ..., "contents": [...]}` dicts for groups.
         """
         sidebar_items: list[str | dict] = []
@@ -3864,40 +4039,242 @@ class GreatDocs:
 
     def _generate_cli_command_page(self, cmd_info: dict, is_main: bool = False) -> str:
         """
-        Generate Quarto page content for a CLI command showing --help output.
+        Generate a structured Quarto reference page for a CLI command.
+
+        Produces output modelled on the API reference pages: a title with semantic class labels, a
+        short description, a usage/signature block, structured Options / Arguments / Subcommands
+        sections, an examples block, and a collapsible `<details>` containing the raw `--help`
+        output.
 
         Parameters
         ----------
         cmd_info
-            Command information dictionary.
+            Command information dictionary (from `_extract_click_command`).
         is_main
             Whether this is the main CLI entry point.
 
         Returns
         -------
         str
-            Quarto markdown content with the CLI help output.
+            Quarto markdown content.
         """
-        lines = []
+        lines: list[str] = []
 
-        # Front matter: use just the command name/path as title
         title = cmd_info["full_path"] if not is_main else cmd_info["name"]
+        label_class = "doc-label-cli-group" if cmd_info.get("is_group") else "doc-label-cli"
+
+        # --- Front matter ---
         lines.append("---")
-        lines.append(f'title: "{title}"')
+        lines.append(
+            f'title: "[{title}]{{.doc-object-name .doc-function .doc-label .{label_class}}}"'
+        )
+        lines.append("body-classes: doc-api-page")
         lines.append("sidebar: cli-reference")
         lines.append("page-navigation: false")
         lines.append("---")
         lines.append("")
 
-        # Output the help text in a styled div
-        lines.append("::: {.cli-manpage}")
+        # --- Heading ---
+        lines.append(f"# [{title}]{{.doc-object-name .doc-function .doc-label .{label_class}}}")
         lines.append("")
+
+        # --- Description ---
+        description = cmd_info.get("description", "") or cmd_info.get("help", "")
+        # Collect option names for auto-backticking in prose
+        option_names = set()
+        for opt in cmd_info.get("options", []):
+            for n in opt.get("names", []):
+                option_names.add(n)
+        if description:
+            # Take first paragraph as the short subject
+            paragraphs = description.split("\n\n")
+            short_desc = paragraphs[0].replace("\n", " ").strip()
+            short_desc = self._backtick_cli_prose(short_desc, option_names)
+            lines.append("::: {.doc-subject}")
+            lines.append(short_desc)
+            lines.append(":::")
+            lines.append("")
+
+        # --- Usage / Signature ---
+        # Build the usage string from the command path + arguments
+        arguments = cmd_info.get("arguments", [])
+        options = cmd_info.get("options", [])
+        usage_parts = [title]
+        if options:
+            usage_parts.append("[OPTIONS]")
+        for arg in arguments:
+            arg_display = arg.get("name_display", arg.get("name", "")).upper()
+            if not arg.get("required", True):
+                arg_display = f"[{arg_display}]"
+            if arg.get("nargs", 1) == -1:
+                arg_display += "..."
+            usage_parts.append(arg_display)
+        if cmd_info.get("is_group") and cmd_info.get("commands"):
+            usage_parts.append("COMMAND [ARGS]...")
+
+        lines.append("::: {.doc-signature .doc-Kind.FUNCTION}")
+        lines.append("```bash")
+        lines.append(" ".join(usage_parts))
         lines.append("```")
-        lines.append(cmd_info.get("help_text", "").rstrip())
-        lines.append("```")
-        lines.append("")
         lines.append(":::")
         lines.append("")
+
+        # --- Extended description ---
+        if description:
+            paragraphs = description.split("\n\n")
+            extra = [p.strip() for p in paragraphs[1:] if p.strip()]
+            if extra:
+                lines.append("::: {.doc-text}")
+                for para in extra:
+                    para_lines = para.split("\n")
+                    # Handle bullet lists (Click uses • or - )
+                    if any(
+                        line.strip().startswith(("•", "- ", "* "))
+                        for line in para_lines
+                        if line.strip()
+                    ):
+                        for bline in para_lines:
+                            stripped = bline.strip()
+                            if not stripped:
+                                continue
+                            # Normalise • bullets to markdown -
+                            if stripped.startswith("•"):
+                                stripped = stripped[1:].strip()
+                            elif stripped.startswith(("- ", "* ")):
+                                stripped = stripped[2:].strip()
+                            if stripped:
+                                stripped = self._backtick_cli_prose(stripped, option_names)
+                                lines.append(f"- {stripped}")
+                    # Preserve blocks with indented content (e.g. "Quick start:")
+                    elif any(line.startswith("  ") for line in para_lines):
+                        for bline in para_lines:
+                            bline = self._backtick_cli_prose(bline, option_names)
+                            lines.append(bline)
+                    else:
+                        text = para.replace("\n", " ")
+                        text = self._backtick_cli_prose(text, option_names)
+                        lines.append(text)
+                    lines.append("")
+                lines.append(":::")
+                lines.append("")
+
+        # --- Collapsible --help output ---
+        help_text = cmd_info.get("help_text", "")
+        if help_text:
+            lines.append('::: {.details summary="Full --help output"}')
+            lines.append("")
+            lines.append("::: {.cli-manpage}")
+            lines.append("")
+            lines.append("```")
+            lines.append(help_text.rstrip())
+            lines.append("```")
+            lines.append("")
+            lines.append(":::")
+            lines.append("")
+            lines.append(":::")
+            lines.append("")
+
+        # --- Arguments section ---
+        if arguments:
+            lines.append("## Arguments {.doc-parameters}")
+            lines.append("")
+            lines.append("::: {.doc-definition-items}")
+            for arg in arguments:
+                display = arg.get("name_display", arg.get("name", "")).upper()
+                type_str = arg.get("type")
+                if type_str:
+                    lines.append(
+                        f'<code><span class="doc-parameter-name">{display}</span>'
+                        f'<span class="doc-parameter-annotation-sep">:</span>'
+                        f' <span class="doc-parameter-annotation">{type_str}</span></code>'
+                    )
+                else:
+                    lines.append(f'<code><span class="doc-parameter-name">{display}</span></code>')
+                req = "Required." if arg.get("required", True) else "Optional."
+                lines.append(f":   {req}")
+                lines.append("")
+            lines.append(":::")
+            lines.append("")
+
+        # --- Options section ---
+        if options:
+            lines.append("## Options {.doc-parameters}")
+            lines.append("")
+            lines.append("::: {.doc-definition-items}")
+            for opt in options:
+                if opt.get("hidden"):
+                    continue
+                name_display = opt.get("name_display", "")
+                type_str = opt.get("type")
+
+                # Build the <code> element with HTML spans
+                code_parts = [f'<span class="doc-parameter-name">{name_display}</span>']
+                if type_str and not opt.get("is_flag"):
+                    code_parts.append(
+                        f'<span class="doc-parameter-annotation-sep">:</span>'
+                        f' <span class="doc-parameter-annotation">{type_str}</span>'
+                    )
+                if opt.get("default") is not None and not opt.get("is_flag"):
+                    default_val = opt["default"]
+                    code_parts.append(
+                        f' <span class="doc-parameter-default-sep op">=</span>'
+                        f' <span class="doc-parameter-default">{default_val}</span>'
+                    )
+
+                lines.append(f"<code>{''.join(code_parts)}</code>")
+
+                # Description line
+                help_str = opt.get("help", "")
+                if opt.get("required"):
+                    help_str = f"**Required.** {help_str}" if help_str else "**Required.**"
+                if opt.get("envvar"):
+                    envvar = opt["envvar"]
+                    if isinstance(envvar, (list, tuple)):
+                        envvar = ", ".join(envvar)
+                    help_str += f" Environment variable: `{envvar}`."
+                help_str = self._backtick_cli_prose(help_str.strip(), option_names)
+
+                lines.append(f":   {help_str}")
+                lines.append("")
+
+            lines.append(":::")
+            lines.append("")
+
+        # --- Subcommands section ---
+        commands = cmd_info.get("commands", [])
+        if commands:
+            lines.append("## Commands {.doc-parameters}")
+            lines.append("")
+            lines.append("::: {.doc-definition-items}")
+            for subcmd in commands:
+                subcmd_name = subcmd["name"]
+                safe_name = subcmd_name.replace("-", "_")
+                # Link to the subcommand page
+                short_help = subcmd.get("short_help", "") or ""
+                # For the main page, subcommands are at cli/<name>.qmd
+                # For group pages, subcommands are at <group>/<name>.qmd
+                if is_main:
+                    href = f"{safe_name}.qmd"
+                else:
+                    parent_safe = cmd_info["name"].replace("-", "_")
+                    href = f"{parent_safe}/{safe_name}.qmd"
+                lines.append(f"<code>[{subcmd_name}]{{.doc-parameter-name}}</code>")
+                link_text = f"[{short_help}]({href})" if short_help else f"[Details]({href})"
+                lines.append(f":   {link_text}")
+                lines.append("")
+            lines.append(":::")
+            lines.append("")
+
+        # --- Examples section ---
+        examples = cmd_info.get("examples", [])
+        if examples:
+            lines.append("## Examples {.doc-examples}")
+            lines.append("")
+            lines.append("```bash")
+            for ex in examples:
+                lines.append(ex)
+            lines.append("```")
+            lines.append("")
 
         return "\n".join(lines)
 
@@ -10495,9 +10872,7 @@ body-classes: "gd-homepage"
                 for item in config["format"]["html"]["include-after-body"]
             )
             if not has_on_this_page:
-                config["format"]["html"]["include-after-body"].append(
-                    on_this_page_entry
-                )
+                config["format"]["html"]["include-after-body"].append(on_this_page_entry)
 
         # Add keyboard navigation script (if enabled)
         if metadata.get("keyboard_nav_enabled", True):

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -11204,6 +11204,14 @@ def test_extract_click_command_simple():
         assert result["help"] == "Say hello."
         assert result["is_group"] is False
         assert result["commands"] == []
+        # New structured fields
+        assert isinstance(result["options"], list)
+        assert len(result["options"]) == 1
+        assert result["options"][0]["names"] == ["--name"]
+        assert result["options"][0]["help"] == "Your name"
+        assert result["arguments"] == []
+        assert result["description"] == "Say hello."
+        assert result["examples"] == []
 
 
 def test_extract_click_command_group():
@@ -11269,6 +11277,111 @@ def test_extract_click_command_with_parent_path():
         assert result["full_path"] == "tool sub"
 
 
+def test_extract_click_option():
+    """_extract_click_option extracts option metadata."""
+    pytest.importorskip("click")
+
+    @click.command()
+    @click.option("--name", "-n", help="Your name", required=True)
+    @click.option("--verbose", is_flag=True, help="Be verbose")
+    @click.option("--count", type=int, default=5, show_default=True, help="Repeat count")
+    def cmd(name, verbose, count):
+        pass
+
+    options = [GreatDocs._extract_click_option(p) for p in cmd.params if hasattr(p, "opts")]
+    options = [o for o in options if o is not None]
+
+    # --name
+    name_opt = next(o for o in options if "--name" in o["names"])
+    assert name_opt["required"] is True
+    assert "-n" in name_opt["names"]
+    assert name_opt["help"] == "Your name"
+    assert name_opt["is_flag"] is False
+
+    # --verbose (flag)
+    verbose_opt = next(o for o in options if "--verbose" in o["names"])
+    assert verbose_opt["is_flag"] is True
+
+    # --count (with default)
+    count_opt = next(o for o in options if "--count" in o["names"])
+    assert count_opt["default"] == 5
+    assert count_opt["type"] == "INTEGER"
+
+
+def test_extract_click_option_skips_help():
+    """_extract_click_option returns None for --help."""
+    pytest.importorskip("click")
+
+    @click.command(add_help_option=True)
+    @click.option("--name", help="Your name")
+    def cmd(name):
+        pass
+
+    # The help param is automatically added; filter to find it
+    help_param = next(
+        (p for p in cmd.params if getattr(p, "name", None) == "help"),
+        None,
+    )
+    if help_param is not None:
+        assert GreatDocs._extract_click_option(help_param) is None
+    else:
+        # Click version may not expose help as a param; just verify
+        # that --name is extracted and help is not in the result
+        options = [GreatDocs._extract_click_option(p) for p in cmd.params if hasattr(p, "opts")]
+        options = [o for o in options if o is not None]
+        names = [n for o in options for n in o["names"]]
+        assert "--help" not in names
+
+
+def test_extract_click_argument():
+    """_extract_click_argument extracts argument metadata."""
+    pytest.importorskip("click")
+
+    @click.command()
+    @click.argument("source", required=False)
+    def cmd(source):
+        pass
+
+    arg_param = next(p for p in cmd.params if isinstance(p, click.Argument))
+    result = GreatDocs._extract_click_argument(arg_param)
+
+    assert result["name"] == "source"
+    assert result["required"] is False
+
+
+def test_parse_click_help_parts_no_examples():
+    """_parse_click_help_parts with no examples section."""
+    desc, examples = GreatDocs._parse_click_help_parts("Build the documentation site.")
+
+    assert desc == "Build the documentation site."
+    assert examples == []
+
+
+def test_parse_click_help_parts_with_examples():
+    """_parse_click_help_parts splits description from examples."""
+    help_text = (
+        "Build the documentation site.\n\n"
+        "\\b\n"
+        "Examples:\n"
+        "  great-docs build\n"
+        "  great-docs build --watch\n"
+    )
+    desc, examples = GreatDocs._parse_click_help_parts(help_text)
+
+    assert "Build the documentation" in desc
+    assert len(examples) == 2
+    assert "great-docs build" in examples[0]
+    assert "--watch" in examples[1]
+
+
+def test_parse_click_help_parts_empty():
+    """_parse_click_help_parts handles empty string."""
+    desc, examples = GreatDocs._parse_click_help_parts("")
+
+    assert desc == ""
+    assert examples == []
+
+
 def test_get_click_help_text():
     """_get_click_help_text returns formatted --help output."""
     pytest.importorskip("click")
@@ -11288,20 +11401,30 @@ def test_get_click_help_text():
 
 
 def test_generate_cli_command_page_main():
-    """_generate_cli_command_page generates main CLI page."""
+    """_generate_cli_command_page generates structured main CLI page."""
     with tempfile.TemporaryDirectory() as tmp_dir:
         docs = GreatDocs(project_path=tmp_dir)
         cmd_info = {
             "name": "my-tool",
             "full_path": "my-tool",
+            "help": "My tool help.",
             "help_text": "Usage: my-tool [OPTIONS]\n\n  My tool help.\n",
+            "description": "My tool help.",
+            "examples": [],
+            "options": [],
+            "arguments": [],
+            "commands": [],
+            "is_group": False,
         }
         result = docs._generate_cli_command_page(cmd_info, is_main=True)
 
-        assert 'title: "my-tool"' in result
+        assert "my-tool" in result
         assert "sidebar: cli-reference" in result
-        assert "Usage: my-tool" in result
         assert ".cli-manpage" in result
+        assert '.details summary="Full --help output"' in result
+        assert "doc-api-page" in result
+        assert ".doc-signature" in result
+        assert ".doc-subject" in result
 
 
 def test_generate_cli_command_page_subcommand():
@@ -11311,11 +11434,98 @@ def test_generate_cli_command_page_subcommand():
         cmd_info = {
             "name": "build",
             "full_path": "my-tool build",
+            "help": "Build the site.",
             "help_text": "Usage: my-tool build [OPTIONS]\n",
+            "description": "Build the site.",
+            "examples": [],
+            "options": [
+                {
+                    "names": ["--watch"],
+                    "name_display": "--watch",
+                    "help": "Watch for changes.",
+                    "type": None,
+                    "default": None,
+                    "required": False,
+                    "is_flag": True,
+                    "multiple": False,
+                    "envvar": None,
+                    "show_default": False,
+                    "is_eager": False,
+                    "hidden": False,
+                },
+            ],
+            "arguments": [],
+            "commands": [],
+            "is_group": False,
         }
         result = docs._generate_cli_command_page(cmd_info, is_main=False)
 
-        assert 'title: "my-tool build"' in result
+        assert "my-tool build" in result
+        assert "## Options" in result
+        assert "--watch" in result
+        assert "Watch for changes." in result
+
+
+def test_generate_cli_command_page_with_arguments():
+    """_generate_cli_command_page renders arguments section."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        docs = GreatDocs(project_path=tmp_dir)
+        cmd_info = {
+            "name": "install",
+            "full_path": "my-tool install",
+            "help": "Install a package.",
+            "help_text": "Usage: my-tool install [SOURCE]\n",
+            "description": "Install a package.",
+            "examples": ["my-tool install foo", "my-tool install bar"],
+            "options": [],
+            "arguments": [
+                {
+                    "name": "source",
+                    "name_display": "SOURCE",
+                    "type": None,
+                    "required": False,
+                    "nargs": 1,
+                },
+            ],
+            "commands": [],
+            "is_group": False,
+        }
+        result = docs._generate_cli_command_page(cmd_info, is_main=False)
+
+        assert "## Arguments" in result
+        assert "SOURCE" in result
+        assert "## Examples" in result
+        assert "my-tool install foo" in result
+
+
+def test_generate_cli_command_page_group_with_subcommands():
+    """_generate_cli_command_page renders subcommands section for groups."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        docs = GreatDocs(project_path=tmp_dir)
+        cmd_info = {
+            "name": "my-tool",
+            "full_path": "my-tool",
+            "help": "My CLI.",
+            "help_text": "Usage: my-tool COMMAND\n",
+            "description": "My CLI.",
+            "examples": [],
+            "options": [],
+            "arguments": [],
+            "is_group": True,
+            "commands": [
+                {
+                    "name": "build",
+                    "full_path": "my-tool build",
+                    "short_help": "Build stuff.",
+                },
+            ],
+        }
+        result = docs._generate_cli_command_page(cmd_info, is_main=True)
+
+        assert "## Commands" in result
+        assert "build" in result
+        assert "Build stuff." in result
+        assert "cli-group" in result
 
 
 def test_generate_cli_reference_pages_empty():

--- a/user_guide/07-cli-documentation.qmd
+++ b/user_guide/07-cli-documentation.qmd
@@ -9,9 +9,10 @@ tags: [CLI, Content]
 
 If your Python package includes a command-line interface built with
 [Click](https://click.palletsprojects.com/), Great Docs can generate reference pages for it
-automatically. Each command and subcommand gets its own page showing the full `--help` output in a
-terminal-style format. This means your CLI documentation stays perfectly in sync with your code,
-because the help text is captured directly from Click at build time.
+automatically. Each command and subcommand gets its own structured page showing the usage signature,
+description, typed options, and examples, all using the same layout as API reference pages. This means
+your CLI documentation stays perfectly in sync with your code, because everything is extracted
+directly from Click at build time.
 
 This page covers how to enable CLI documentation, how Great Docs discovers your commands, what the
 generated pages look like, and how to write CLI help text that produces clear, useful reference
@@ -37,8 +38,10 @@ documentation: discover, extract, generate, and integrate. Here's what happens d
 
 1. **Finds your CLI**: looks for Click commands in common locations
 2. **Discovers entry point**: reads `[project.scripts]` from `pyproject.toml`
-3. **Extracts help text**: captures `--help` output for each command and subcommand
-4. **Generates pages**: creates `.qmd` files in `reference/cli/`
+3. **Extracts metadata**: introspects each command for its description, options, arguments,
+   subcommands, and examples
+4. **Generates structured pages**: creates `.qmd` files in `reference/cli/` with the same layout
+   as API reference pages
 5. **Updates navigation**: adds a CLI section to the sidebar
 
 The pipeline runs as part of `great-docs build`, so CLI pages are always regenerated from the
@@ -106,43 +109,45 @@ Reference
 
 ### Page Format
 
-Each CLI page displays the `--help` output in a terminal-style format:
+Each CLI page uses the same structured layout as API reference pages, making the site feel cohesive.
+A generated page contains these sections in order:
 
-```
-Usage: my-cli build [OPTIONS] PATH
+1. **Title** with a colored label badge (`cli` or `cli-group`)
+2. **Subject**: the first paragraph of your docstring (the short description)
+3. **Usage signature**: a `bash` code block showing the invocation pattern
+4. **Extended description**: remaining paragraphs from your docstring, formatted as prose
+5. **Collapsible `--help` output**: the full raw `--help` text, tucked inside a disclosure widget
+6. **Arguments**: if the command takes positional arguments
+7. **Options**: a definition list with name, type, default, and help text
+8. **Subcommands**: for groups, each subcommand links to its own page
+9. **Examples**: if your docstring includes an `Examples:` section
 
-  Build the project at PATH.
+This structured layout gives readers quick access to what they need (usage, options, examples)
+while preserving the full `--help` output for those who want the raw reference.
 
-  This command compiles all source files and generates output
-  in the specified directory.
+#### Text enhancements
 
-Options:
-  --output DIR    Output directory (default: ./dist)
-  --verbose       Enable verbose output
-  --help          Show this message and exit.
-```
+Within the description and option help text, Great Docs automatically applies two enhancements:
 
-The styling mimics a terminal with:
+- **Single-quoted text → code**: `'great-docs build'` in your docstring renders as
+  `great-docs build` in inline code
+- **Option names → code**: references to options like `--watch` or `--from-repo` are rendered as
+  inline code automatically
 
-- Dark background
-- Monospace font
-- Proper spacing for readability
-
-The result is a set of browsable reference pages that feel familiar to anyone who has used `--help`
-in a terminal, but with the convenience of being searchable and navigable within your documentation
-site.
+These enhancements are applied automatically during page generation. You don't need to use
+backticks or any special markup in your Click docstrings or `help=` strings.
 
 ## Writing Good CLI Help
 
-The quality of your CLI documentation depends entirely on the help text you write in your Click
-decorators and docstrings. Great Docs displays this text as-is, so investing in clear, descriptive
-help strings pays off directly in the generated pages.
+The quality of your CLI documentation depends on the help text you write in your Click decorators
+and docstrings. Great Docs parses your docstrings into structured sections, so following a few
+conventions produces the best results.
 
 ### Use Descriptive Help Text
 
-Every Click command should have a docstring that explains what it does. The first line becomes the
-short description shown in `--help` listings, and the full text appears on the command's dedicated
-reference page:
+Every Click command should have a docstring that explains what it does. The first paragraph becomes
+the **subject** (displayed prominently at the top of the page), and remaining paragraphs form the
+**extended description**:
 
 ```{.python filename="cli.py"}
 @click.command()
@@ -150,8 +155,7 @@ reference page:
 @click.option("--output", "-o", help="Output directory for generated files")
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose logging")
 def build(path, output, verbose):
-    """
-    Build the project at PATH.
+    """Build the project at PATH.
 
     This command compiles all source files and generates output
     in the specified directory. Use --verbose to see detailed
@@ -160,10 +164,14 @@ def build(path, output, verbose):
     ...
 ```
 
+The first paragraph is especially important because it also appears as the short description in
+the parent group's **Commands** list and in search results.
+
 ### Document All Options
 
 Every `@click.option()` should include a `help=` string. Options without help text appear in the
-reference page but give readers no indication of what they do:
+reference page but give readers no indication of what they do. Use single quotes around file names
+or values to have them rendered as inline code:
 
 ```{.python filename="cli.py"}
 @click.option(
@@ -172,7 +180,14 @@ reference page but give readers no indication of what they do:
     default="json",
     help="Output format (default: json)"
 )
+@click.option(
+    "--config",
+    help="Path to config file (default: 'pyproject.toml')"
+)
 ```
+
+In the generated page, `'pyproject.toml'` in the second option's help text becomes inline code
+automatically, so the rendered description reads "Path to config file (default: `pyproject.toml`)".
 
 ### Use Click Groups for Subcommands
 
@@ -199,61 +214,92 @@ def build():
 Well-structured Click groups produce the clearest documentation. Each subcommand becomes its own
 page, and the group's docstring serves as the overview for the CLI section.
 
+### Include Examples
+
+If your docstring contains a paragraph starting with `Examples:`, Great Docs extracts it into a
+dedicated **Examples** section rendered as a `bash` code block. Use Click's `\b` marker to prevent
+paragraph rewrapping:
+
+```{.python filename="cli.py"}
+@click.command()
+def deploy():
+    """Deploy the built site.
+
+    Uploads the contents of _site/ to your configured host.
+
+    \b
+    Examples:
+      my-cli deploy                  # Deploy to production
+      my-cli deploy --dry-run        # Preview what would happen
+      my-cli deploy --target staging # Deploy to staging
+    """
+    ...
+```
+
+Without the `\b` marker, Click joins continuation lines into a single paragraph, which would
+collapse the example lines together. Always place `\b` on its own line before `Examples:` to
+preserve the formatting.
+
 ## Example: Great Docs CLI
 
-Great Docs uses this feature to document its own CLI. The generated pages show how the main command
-and its subcommands appear in the reference section:
+Great Docs uses this feature to document its own CLI. Here's what the generated page for
+`great-docs build` looks like (simplified):
 
-**Main command (`great-docs`):**
+**Subject and usage:**
 
-```
-Usage: great-docs [OPTIONS] COMMAND [ARGS]...
+> Build your documentation site.
 
-  Great Docs - Beautiful documentation for Python packages.
-
-  Generate professional documentation sites with auto-discovered API
-  references, CLI documentation, and smart navigation.
-
-Commands:
-  init              Initialize great-docs in your project
-  build             Build documentation site
-  preview           Build and preview locally
-  scan              Scan package exports
-  setup-github-pages  Create GitHub Pages workflow
-  uninstall         Remove great-docs from project
+```bash
+great-docs build [OPTIONS]
 ```
 
-**Subcommand (`great-docs build`):**
+**Extended description (formatted as prose):**
 
+> Requires `great-docs.yml` to exist (run `great-docs init` first). This is the only command you
+> need day-to-day and in CI.
+
+**Collapsible `--help` output:**
+
+The full raw terminal output is available inside a disclosure widget labeled "Full --help output".
+Readers can expand it when they want the complete reference, but it doesn't dominate the page.
+
+**Options (structured definition list):**
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--watch` | flag | Watch for changes and rebuild automatically |
+| `--no-refresh` | flag | Skip re-discovering package exports |
+| `--versions` | TEXT | Build only specific versions (comma-separated) |
+| `--from-repo` | TEXT | Clone a remote Git repository and build its docs |
+
+**Examples (bash code block):**
+
+```bash
+great-docs build                      # Full build with API refresh
+great-docs build --no-refresh         # Fast rebuild (skip API discovery)
+great-docs build --watch              # Rebuild on file changes
 ```
-Usage: great-docs build [OPTIONS]
 
-  Build your documentation site.
-
-  Generates API reference pages and runs quarto render
-  to build the HTML site.
-
-Options:
-  --no-refresh  Skip API discovery refresh (faster rebuild)
-  --watch       Watch for changes and rebuild
-  --help        Show this message and exit.
-```
-
-You can see these pages live in the Great Docs reference section. They are regenerated on every
-build from the actual Click commands, so they always reflect the current set of options and
-subcommands.
+The main group page (`great-docs`) additionally includes a **Commands** section that links to each
+subcommand's dedicated page. You can see these pages live in the Great Docs reference section.
+All of these sections are generated from the same Click decorators and docstrings shown earlier
+in this guide.
 
 ## Styling
 
-CLI reference pages use a distinct visual treatment that sets them apart from API reference pages:
+CLI reference pages share the same visual system as API reference pages:
 
-- disables the sidebar filter (CLIs are usually small)
-- removes breadcrumb navigation
-- uses a wider content area on large screens
-- maintains responsive design on mobile
+- **Colored label badges**: `cli` (blue) and `cli-group` (teal) distinguish commands from groups
+- **Structured definition lists**: options are displayed with the same parameter styling used for
+  function signatures in API docs
+- **Consistent layout**: subject, signature, description, and parameters mirror the API page
+  structure
+- **Responsive design**: pages adapt to mobile and desktop viewports
+- **Collapsible details**: the raw `--help` output is available but doesn't clutter the page
 
-These styling choices keep CLI pages clean and focused, matching the terminal-centric nature of the
-content.
+This shared design language means readers moving between API docs and CLI docs see the same
+patterns: a short subject at the top, a signature block, extended prose, and a structured parameter
+list.
 
 ## Troubleshooting
 
@@ -276,6 +322,9 @@ cli:
   name: cli   # The Click command object name
 ```
 
+If auto-discovery finds a Click command but it's the wrong one, explicit configuration lets you
+point to the correct object directly.
+
 ### Help Text Missing
 
 If commands show minimal help:
@@ -283,6 +332,9 @@ If commands show minimal help:
 1. add docstrings to your Click functions
 2. add `help=` to all options
 3. use `@click.argument()` with proper names
+
+The generated page will still show the command's usage signature and options, but the subject and
+extended description sections will be empty without a docstring.
 
 ## Next Steps
 


### PR DESCRIPTION
This PR adds enhanced rendering for CLI documentation (right now, just for Click-based CLIs). Previously, CLI documentation was rendered, but it only presented the `--help` text of every command/subcommand. Now, the docs look more in line with the Python API documentation, with separate sections for the Description (including the summary line, set in italicized text), Options, Arguments and Examples (we now include the  `--help` text in a details view after the description).