### PR TITLE
fix: update navbar background default color

### DIFF
--- a/great_docs/assets/great-docs.scss
+++ b/great_docs/assets/great-docs.scss
@@ -3005,7 +3005,7 @@ body.quarto-dark .gd-keyboard-btn {
     --gd-code-color: rgb(18, 18, 18);
     --gd-blockquote-bg: #E8E8E8;
     --gd-sidebar-bg: #FAFAFD;
-    --gd-navbar-bg: #e3f2fd;
+    --gd-navbar-bg: #f0f0f0;
     --gd-navbar-text: #2d2d2d;
     --gd-footer-text: rgb(48, 48, 48);
     --gd-highlight-color: rgba(255, 243, 205, 0.5);


### PR DESCRIPTION
This PR makes a minor visual update to the light theme of the docs site by adjusting the background color of the navigation bar for improved consistency. Moves from light blue to light gray.