### PR TITLE
fix: CLI docs don't show double-dashes in parameter names

### DIFF
--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -4207,8 +4207,12 @@ class GreatDocs:
                 name_display = opt.get("name_display", "")
                 type_str = opt.get("type")
 
+                # Escape double-dashes as HTML entities to prevent Pandoc's smart
+                # extension from converting "--" to an en-dash inside inline HTML.
+                name_display_html = name_display.replace("--", "&#45;&#45;")
+
                 # Build the <code> element with HTML spans
-                code_parts = [f'<span class="doc-parameter-name">{name_display}</span>']
+                code_parts = [f'<span class="doc-parameter-name">{name_display_html}</span>']
                 if type_str and not opt.get("is_flag"):
                     code_parts.append(
                         f'<span class="doc-parameter-annotation-sep">:</span>'

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -11462,7 +11462,7 @@ def test_generate_cli_command_page_subcommand():
 
         assert "my-tool build" in result
         assert "## Options" in result
-        assert "--watch" in result
+        assert "&#45;&#45;watch" in result
         assert "Watch for changes." in result
 
 


### PR DESCRIPTION
This PR makes a small but important fix to the CLI documentation generation that ensures that double-dashes in option names are properly escaped as HTML entities. This prevents Pandoc from converting them to en-dashes when rendering inline HTML.