### PR TITLE
fix: version expression comparison

### DIFF
--- a/great_docs/_versioning.py
+++ b/great_docs/_versioning.py
@@ -195,6 +195,17 @@ def _parse_version_tuple(tag: str) -> tuple[int, ...] | None:
         return None
 
 
+def _normalize_version_tuples(
+    a: tuple[int, ...], b: tuple[int, ...]
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Pad version tuples with trailing zeros so they have equal length.
+
+    This ensures `(0, 11)` and `(0, 11, 0)` are treated as equal when compared.
+    """
+    max_len = max(len(a), len(b))
+    return (a + (0,) * (max_len - len(a)), b + (0,) * (max_len - len(b)))
+
+
 def _resolve_version_str(tag: str, versions: list[VersionEntry]) -> str:
     """Return the best semantic version string for *tag*.
 
@@ -279,6 +290,7 @@ def evaluate_version_expr(
             ref_tup = _parse_version_tuple(ref_tag)
             if target_tup is None or ref_tup is None:
                 return False
+            target_tup, ref_tup = _normalize_version_tuples(target_tup, ref_tup)
             if op == "" or op == "=":
                 if target_tup != ref_tup:
                     return False

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -315,6 +315,22 @@ class TestEvaluateVersionExpr:
         # >=0.5,<0.9 should NOT match 0.9
         assert evaluate_version_expr(">=0.5,<0.9", "0.9", vers) is False
 
+    def test_three_part_version_in_expr(self):
+        """>=0.11.0 should work the same as >=0.11 when target is 0.11."""
+        vers = parse_versions_config(
+            [
+                {"tag": "dev", "version": "0.12", "prerelease": True},
+                {"tag": "0.11", "latest": True},
+                {"tag": "0.10"},
+            ]
+        )
+        assert evaluate_version_expr(">=0.11.0", "0.11", vers) is True
+        assert evaluate_version_expr(">=0.11.0", "dev", vers) is True
+        assert evaluate_version_expr(">=0.11.0", "0.10", vers) is False
+        # Equality with different segment counts
+        assert evaluate_version_expr("=0.11.0", "0.11", vers) is True
+        assert evaluate_version_expr(">=0.10.0", "0.11", vers) is True
+
 
 # ---------------------------------------------------------------------------
 # process_version_fences


### PR DESCRIPTION
This PR improves version comparison logic to ensure that version tuples with different numbers of segments (like `(0, 11)` and `(0, 11, 0)`) are treated as equivalent. It does this by introducing a normalization step before comparing versions.