### PR TITLE
fix: detect python version from project and use min Python version

### DIFF
--- a/great_docs/cli.py
+++ b/great_docs/cli.py
@@ -1274,8 +1274,16 @@ def setup_github_pages(
         if python_version is None:
             detected_version = _detect_python_version_from_pyproject(project_root)
             if detected_version:
-                python_version = detected_version
-                click.echo(f"📦 Detected Python {python_version} from pyproject.toml")
+                detected_tuple = tuple(int(x) for x in detected_version.split("."))
+                if detected_tuple < min_great_docs_version:
+                    python_version = f"{min_great_docs_version[0]}.{min_great_docs_version[1]}"
+                    click.echo(
+                        f"📦 Project requires Python {detected_version}, "
+                        f"but Great Docs needs >={python_version}; using {python_version}"
+                    )
+                else:
+                    python_version = detected_version
+                    click.echo(f"📦 Detected Python {python_version} from pyproject.toml")
             else:
                 python_version = "3.12"
                 click.echo("📦 Using default Python 3.12 (no requires-python found)")

--- a/great_docs/cli.py
+++ b/great_docs/cli.py
@@ -1269,6 +1269,8 @@ def setup_github_pages(
         project_root = Path(project_path) if project_path else Path.cwd()
 
         # Auto-detect Python version if not specified
+        # Great Docs requires Python 3.11+, so we enforce that as the floor
+        min_great_docs_version = (3, 11)
         if python_version is None:
             detected_version = _detect_python_version_from_pyproject(project_root)
             if detected_version:


### PR DESCRIPTION
This PR updates the `setup_github_pages()` function in `great_docs/cli.py` to enforce a minimum required Python version for Great Docs in CI. If the detected project Python version is below 3.11, the function now automatically upgrades it to 3.11 (min Python version requirement) and notifies the user when using `great-docs setup-github-pages`.

The Python version is only used to fill the `{python_version}` placeholder in the generated GitHub Actions workflow template (i.e., it controls what `actions/setup-python` installs in CI for the docs build job). This determination doesn't affect the user's local environment or their project's own `requires-python` metadata.