### PR TITLE
fix: termshow player fixes

### DIFF
--- a/great_docs/_term_player/manifest.py
+++ b/great_docs/_term_player/manifest.py
@@ -55,6 +55,7 @@ class Manifest:
     deltas: list[DeltaEntry] = field(default_factory=list)
     annotations: list[Annotation] = field(default_factory=list)
     highlights: list[Highlight] = field(default_factory=list)
+    window_chrome: str = "none"
 
     def to_json(self) -> str:
         """Serialize manifest to JSON string."""
@@ -96,6 +97,8 @@ class Manifest:
                 for h in self.highlights
             ],
         }
+        if self.window_chrome != "none":
+            data["window_chrome"] = self.window_chrome
         return json.dumps(data, indent=2)
 
 
@@ -234,6 +237,7 @@ def generate_manifest(
         deltas=deltas,
         annotations=script.annotations if script else [],
         highlights=script.highlights if script else [],
+        window_chrome=window_chrome,
     )
 
     if out_path:

--- a/great_docs/_term_player/renderer.py
+++ b/great_docs/_term_player/renderer.py
@@ -53,7 +53,7 @@ def render_frame(
     cell_h = font_size * DEFAULT_LINE_HEIGHT
 
     pad = DEFAULT_PADDING
-    chrome_h = _chrome_height(window_chrome)
+    chrome_h = 0.0  # Chrome is rendered as CSS overlay, not in SVG
 
     content_w = state.cols * cell_w
     content_h = state.rows * cell_h
@@ -90,9 +90,8 @@ def render_frame(
         f'<rect width="{svg_w:.1f}" height="{svg_h:.1f}" fill="{theme.bg}" rx="8" ry="8"/>'
     )
 
-    # Window chrome
-    if window_chrome != "none":
-        parts.append(_render_chrome(window_chrome, svg_w, theme))
+    # Window chrome is now rendered as CSS overlay by the player
+    # (kept as parameter for API compatibility)
 
     # Terminal content group
     content_y = pad + chrome_h

--- a/great_docs/assets/termshow.css
+++ b/great_docs/assets/termshow.css
@@ -19,6 +19,7 @@
   max-width: 100%;
   margin: 1.5em 0;
   background: var(--gd-tp-bg);
+  container-type: inline-size;
 }
 
 /* Viewport */
@@ -66,10 +67,10 @@
 
 .gd-tp-annotation {
   position: absolute;
-  max-width: 280px;
-  padding: 8px 12px;
+  max-width: 40%;
+  padding: clamp(4px, 1.2cqi, 10px) clamp(6px, 1.8cqi, 14px);
   border-radius: 6px;
-  font-size: 13px;
+  font-size: clamp(10px, 2cqi, 14px);
   line-height: 1.4;
   color: var(--gd-tp-fg);
   transition: opacity 0.3s ease;
@@ -83,7 +84,7 @@
 
 .gd-tp-ann-subtle {
   background: rgba(30, 30, 46, 0.7);
-  font-size: 12px;
+  font-size: clamp(9px, 1.8cqi, 12px);
   backdrop-filter: blur(4px);
 }
 
@@ -96,23 +97,23 @@
 
 /* Annotation positions */
 .gd-tp-ann-top-left {
-  top: 12px;
-  left: 12px;
+  top: clamp(6px, 1.8cqi, 14px);
+  left: clamp(6px, 1.8cqi, 14px);
 }
 
 .gd-tp-ann-top-right {
-  top: 12px;
-  right: 12px;
+  top: clamp(6px, 1.8cqi, 14px);
+  right: clamp(6px, 1.8cqi, 14px);
 }
 
 .gd-tp-ann-bottom-left {
-  bottom: 12px;
-  left: 12px;
+  bottom: clamp(6px, 1.8cqi, 14px);
+  left: clamp(6px, 1.8cqi, 14px);
 }
 
 .gd-tp-ann-bottom-right {
-  bottom: 12px;
-  right: 12px;
+  bottom: clamp(6px, 1.8cqi, 14px);
+  right: clamp(6px, 1.8cqi, 14px);
 }
 
 /* Controls bar */
@@ -284,29 +285,63 @@
   }
 }
 
-/* Chapter name bar */
+/* Title bar */
 .gd-tp-chapter-bar {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  padding: 6px 12px;
+  position: relative;
+  padding: clamp(4px, 1cqi, 8px) clamp(8px, 1.8cqi, 14px);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  font-size: 14px;
+  font-size: clamp(10px, 2.2cqi, 14px);
   font-weight: 500;
   color: rgba(255, 255, 255, 0.85);
-  background: linear-gradient(to bottom, rgba(0,0,0,0.45) 0%, transparent 100%);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
-  pointer-events: none;
-  z-index: 4;
-  min-height: 28px;
+  background: var(--gd-tp-bg);
+  border-bottom: 1px solid var(--gd-tp-border);
+  min-height: clamp(22px, 5cqi, 36px);
   text-align: center;
-  opacity: 1;
-  transition: opacity 0.3s;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.gd-tp-chapter-bar:empty {
-  opacity: 0;
+.gd-tp-chapter-bar:empty:not(.gd-tp-has-chrome) {
+  display: none;
+}
+
+.gd-tp-chapter-text {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Traffic light decorations */
+.gd-tp-traffic-lights {
+  position: absolute;
+  left: clamp(8px, 1.8cqi, 16px);
+  top: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  gap: clamp(4px, 0.9cqi, 8px);
+}
+
+.gd-tp-traffic-dot {
+  width: clamp(7px, 1.6cqi, 12px);
+  height: clamp(7px, 1.6cqi, 12px);
+  border-radius: 50%;
+}
+
+.gd-tp-dot-close { background: #f38ba8; }
+.gd-tp-dot-minimize { background: #f9e2af; }
+.gd-tp-dot-maximize { background: #a6e3a1; }
+
+/* Minimal chrome: muted dots */
+.gd-tp-traffic-lights.gd-tp-chrome-minimal .gd-tp-dot-close,
+.gd-tp-traffic-lights.gd-tp-chrome-minimal .gd-tp-dot-minimize,
+.gd-tp-traffic-lights.gd-tp-chrome-minimal .gd-tp-dot-maximize {
+  background: #585b70;
 }
 
 /* Light theme overrides (Quarto body[data-bs-theme="light"]) */

--- a/great_docs/assets/termshow.js
+++ b/great_docs/assets/termshow.js
@@ -89,6 +89,10 @@
       try { inlineFrames = JSON.parse(framesEl.textContent); } catch (e) {}
     }
 
+    // Title bar (separate from viewport, above it)
+    const chapterBar = document.createElement('div');
+    chapterBar.className = 'gd-tp-chapter-bar';
+
     // Build player DOM
     const viewport = document.createElement('div');
     viewport.className = 'gd-tp-viewport';
@@ -114,15 +118,11 @@
     centerOverlay.appendChild(centerBtn);
     viewport.appendChild(centerOverlay);
 
-    // Chapter name bar (top of viewport)
-    const chapterBar = document.createElement('div');
-    chapterBar.className = 'gd-tp-chapter-bar';
-    viewport.appendChild(chapterBar);
-
     const controls = buildControls();
 
     // Replace container content with player structure
     container.innerHTML = '';
+    container.appendChild(chapterBar);
     container.appendChild(viewport);
     container.appendChild(controls.root);
 
@@ -132,6 +132,28 @@
       state.frames = frames;
       controls.duration.textContent = formatTime(manifest.duration);
       renderChapterMarkers(controls.timeline, manifest);
+
+      // Add traffic light decorations if window_chrome is set
+      var chrome = manifest.window_chrome || 'none';
+      var hasChapters = manifest.chapters && manifest.chapters.length > 0;
+      if (chrome === 'none' && !hasChapters) {
+        chapterBar.style.display = 'none';
+      } else if (chrome !== 'none') {
+        chapterBar.classList.add('gd-tp-has-chrome');
+        var lights = document.createElement('div');
+        lights.className = 'gd-tp-traffic-lights' + (chrome === 'minimal' ? ' gd-tp-chrome-minimal' : '');
+        lights.innerHTML = '<span class="gd-tp-traffic-dot gd-tp-dot-close"></span>' +
+          '<span class="gd-tp-traffic-dot gd-tp-dot-minimize"></span>' +
+          '<span class="gd-tp-traffic-dot gd-tp-dot-maximize"></span>';
+        chapterBar.appendChild(lights);
+      }
+
+      // Add a span for chapter text (so traffic lights aren't overwritten)
+      var chapterText = document.createElement('span');
+      chapterText.className = 'gd-tp-chapter-text';
+      chapterBar.appendChild(chapterText);
+      state.chapterText = chapterText;
+
       updateChapterBar(chapterBar, manifest, 0);
       // Show initial frame
       showFrame(state, svgContainer, 0);
@@ -395,8 +417,10 @@
   }
 
   function updateChapterBar(chapterBar, manifest, time) {
+    var textEl = chapterBar.querySelector('.gd-tp-chapter-text');
+    if (!textEl) return;
     if (!manifest || !manifest.chapters || manifest.chapters.length === 0) {
-      chapterBar.textContent = '';
+      textEl.textContent = '';
       return;
     }
     // Find the current chapter (last one at or before current time)
@@ -407,7 +431,7 @@
         break;
       }
     }
-    chapterBar.textContent = label;
+    textEl.textContent = label;
   }
 
   function showFrame(state, svgContainer, idx) {

--- a/tests/test_term_manifest.py
+++ b/tests/test_term_manifest.py
@@ -253,10 +253,19 @@ class TestGenerateManifest:
         out = tmp_path / "render"
         generate_manifest(rec, script, output_dir=out)
 
-        # First frame SVG should use the script settings
+        # First frame SVG should use the script font settings
         svg = (out / "frame-000.svg").read_text()
+
         assert "Courier" in svg
-        assert "circle" in svg  # colorful chrome has circles
+
+        # Chrome is rendered by the CSS player, not in the SVG
+        assert "circle" not in svg
+
+        # But window_chrome should be in the manifest
+        manifest_text = (out / "manifest.json").read_text()
+        data = json.loads(manifest_text)
+
+        assert data["window_chrome"] == "colorful"
 
     def test_manifest_json_valid(self, tmp_path: Path):
         rec = _minimal_recording(3.0)

--- a/tests/test_term_renderer.py
+++ b/tests/test_term_renderer.py
@@ -257,14 +257,15 @@ class TestRenderFrame:
     def test_window_chrome_colorful(self):
         state = _simple_screen(10, 3, "X")
         svg = render_frame(state, window_chrome="colorful")
-        assert "circle" in svg
-        assert "#f38ba8" in svg  # Close button color
+
+        # SVG should not contain chrome circles (in the CSS overlay)
+        assert "circle" not in svg
 
     def test_window_chrome_minimal(self):
         state = _simple_screen(10, 3, "X")
         svg = render_frame(state, window_chrome="minimal")
-        assert "circle" in svg
-        assert "#585b70" in svg  # Grey dots
+
+        assert "circle" not in svg
 
     def test_xml_escapes_special_chars(self):
         state = _simple_screen(20, 3, "<script>&alert</script>")


### PR DESCRIPTION
This PR refactors how the terminal player displays window chrome (the title bar at the top of terminal windows). This rendering is now handled by the CSS/JS player overlay instead of being drawn into the SVG frames. The manifest and player logic are updated to support this, and the CSS is improved for responsiveness and clarity.