### PR TITLE
enh: add new annotation position and size options to termshow

### DIFF
--- a/great_docs/_term_player/editor.py
+++ b/great_docs/_term_player/editor.py
@@ -49,6 +49,7 @@ def _build_editor_data(recording: Recording, script: Script | None) -> dict[str,
                     "duration": ann.duration,
                     "text": ann.text,
                     "position": ann.position,
+                    "width": ann.width,
                     "style": ann.style,
                 }
                 for ann in (script.annotations if script else [])
@@ -97,6 +98,9 @@ def _serialize_script(script_data: dict[str, Any], source_path: str) -> str:
             lines.append(f"    duration: {ann['duration']}")
             lines.append(f'    text: "{ann["text"]}"')
             lines.append(f"    position: {ann['position']}")
+            width = ann.get("width", "medium")
+            if width != "medium":
+                lines.append(f"    width: {width}")
             lines.append(f"    style: {ann['style']}")
         lines.append("")
 
@@ -494,6 +498,13 @@ body {
 .annotation-bubble.pos-top-right { top: 10px; right: 10px; }
 .annotation-bubble.pos-bottom-left { bottom: 10px; left: 10px; }
 .annotation-bubble.pos-bottom-right { bottom: 10px; right: 10px; }
+.annotation-bubble.pos-top { top: 10px; left: 50%; transform: translateX(-50%); }
+.annotation-bubble.pos-bottom { bottom: 10px; left: 50%; transform: translateX(-50%); }
+.annotation-bubble.pos-left { top: 50%; left: 10px; transform: translateY(-50%); }
+.annotation-bubble.pos-right { top: 50%; right: 10px; transform: translateY(-50%); }
+.annotation-bubble.width-small { max-width: 25%; }
+.annotation-bubble.width-medium { max-width: 50%; }
+.annotation-bubble.width-large { max-width: 75%; }
 
 @keyframes ann-fade-in {
   from { opacity: 0; transform: translateY(-4px); }
@@ -1865,7 +1876,8 @@ body {
       const bubble = document.createElement('div');
       bubble.className = 'annotation-bubble'
         + ' style-' + (ann.style || 'callout')
-        + ' pos-' + (ann.position || 'top-right');
+        + ' pos-' + (ann.position || 'top-right')
+        + ' width-' + (ann.width || 'medium');
       bubble.textContent = ann.text;
       overlay.appendChild(bubble);
     }
@@ -2104,6 +2116,7 @@ body {
     const annEls = trackAnnotations.querySelectorAll('.track-item-annotation');
     if (annEls[idx]) annEls[idx].classList.add('selected');
     const ann = data.script.annotations[idx];
+    if (!ann.width) ann.width = 'medium';
     propsPanel.innerHTML = `
       <div class="prop-title">Annotation</div>
       <div class="prop-field">
@@ -2121,10 +2134,22 @@ body {
       <div class="prop-field">
         <div class="prop-label">Position</div>
         <select class="prop-select" id="prop-position">
+          <option value="top" ${ann.position==='top'?'selected':''}>Top</option>
+          <option value="bottom" ${ann.position==='bottom'?'selected':''}>Bottom</option>
+          <option value="left" ${ann.position==='left'?'selected':''}>Left</option>
+          <option value="right" ${ann.position==='right'?'selected':''}>Right</option>
           <option value="top-left" ${ann.position==='top-left'?'selected':''}>Top Left</option>
           <option value="top-right" ${ann.position==='top-right'?'selected':''}>Top Right</option>
           <option value="bottom-left" ${ann.position==='bottom-left'?'selected':''}>Bottom Left</option>
           <option value="bottom-right" ${ann.position==='bottom-right'?'selected':''}>Bottom Right</option>
+        </select>
+      </div>
+      <div class="prop-field">
+        <div class="prop-label">Width</div>
+        <select class="prop-select" id="prop-width">
+          <option value="small" ${ann.width==='small'?'selected':''}>Small</option>
+          <option value="medium" ${ann.width==='medium'?'selected':''}>Medium</option>
+          <option value="large" ${ann.width==='large'?'selected':''}>Large</option>
         </select>
       </div>
       <div class="prop-field">
@@ -2253,6 +2278,7 @@ body {
       data.script.annotations[index].duration = parseFloat(document.getElementById('prop-duration').value) || 1;
       data.script.annotations[index].text = document.getElementById('prop-text').value;
       data.script.annotations[index].position = document.getElementById('prop-position').value;
+      data.script.annotations[index].width = document.getElementById('prop-width').value;
       data.script.annotations[index].style = document.getElementById('prop-style').value;
     } else if (type === 'cut') {
       data.script.cuts[index].start = parseFloat(document.getElementById('prop-start').value) || 0;
@@ -2752,7 +2778,7 @@ body {
     const start = roundTime(time);
     const end = roundTime(Math.min(time + 1, data.recording.duration));
     if (end > start) {
-      data.script.annotations.push({ time: start, duration: roundTime(end - start), text: 'Annotation', position: 'top-right', style: 'callout' });
+      data.script.annotations.push({ time: start, duration: roundTime(end - start), text: 'Annotation', position: 'top-right', width: 'medium', style: 'callout' });
       renderTracks();
       updatePlayhead();
       markDirty();

--- a/great_docs/_term_player/manifest.py
+++ b/great_docs/_term_player/manifest.py
@@ -81,6 +81,7 @@ class Manifest:
                     "text": a.text,
                     "position": a.position,
                     "style": a.style,
+                    "width": a.width,
                 }
                 for a in self.annotations
             ],

--- a/great_docs/_term_player/script.py
+++ b/great_docs/_term_player/script.py
@@ -35,6 +35,7 @@ class Annotation:
     text: str
     position: str = "bottom-right"
     style: str = "callout"
+    width: str = "medium"
     row: int | None = None
     col: int | None = None
 
@@ -150,6 +151,7 @@ def _parse_script_data(data: dict[str, Any]) -> Script:
                     text=ann.get("text", ""),
                     position=ann.get("position", "bottom-right"),
                     style=ann.get("style", "callout"),
+                    width=ann.get("width", "medium"),
                     row=ann.get("row"),
                     col=ann.get("col"),
                 )

--- a/great_docs/assets/termshow.css
+++ b/great_docs/assets/termshow.css
@@ -20,6 +20,12 @@
   margin: 1.5em 0;
   background: var(--gd-tp-bg);
   container-type: inline-size;
+  overflow-anchor: none;
+}
+
+/* Prevent any player internals from being used as scroll anchors */
+.gd-termshow * {
+  overflow-anchor: none;
 }
 
 /* Viewport */
@@ -61,13 +67,11 @@
   inset: 0;
   pointer-events: none;
   padding: 12px;
-  display: flex;
-  flex-direction: column;
+  contain: layout style;
 }
 
 .gd-tp-annotation {
   position: absolute;
-  max-width: 40%;
   padding: clamp(4px, 1.2cqi, 10px) clamp(6px, 1.8cqi, 14px);
   border-radius: 6px;
   font-size: clamp(10px, 2cqi, 14px);
@@ -106,6 +110,14 @@
   right: clamp(6px, 1.8cqi, 14px);
 }
 
+.gd-tp-ann-top {
+  top: clamp(6px, 1.8cqi, 14px);
+  left: 0;
+  right: 0;
+  margin-inline: auto;
+  width: fit-content;
+}
+
 .gd-tp-ann-bottom-left {
   bottom: clamp(6px, 1.8cqi, 14px);
   left: clamp(6px, 1.8cqi, 14px);
@@ -115,6 +127,35 @@
   bottom: clamp(6px, 1.8cqi, 14px);
   right: clamp(6px, 1.8cqi, 14px);
 }
+
+.gd-tp-ann-bottom {
+  bottom: clamp(6px, 1.8cqi, 14px);
+  left: 0;
+  right: 0;
+  margin-inline: auto;
+  width: fit-content;
+}
+
+.gd-tp-ann-left {
+  top: 0;
+  bottom: 0;
+  left: clamp(6px, 1.8cqi, 14px);
+  margin-block: auto;
+  height: fit-content;
+}
+
+.gd-tp-ann-right {
+  top: 0;
+  bottom: 0;
+  right: clamp(6px, 1.8cqi, 14px);
+  margin-block: auto;
+  height: fit-content;
+}
+
+/* Annotation widths */
+.gd-tp-annotation { max-width: 50%; }
+.gd-tp-ann-w-small { max-width: 25%; }
+.gd-tp-ann-w-large { max-width: 75%; }
 
 /* Controls bar */
 .gd-tp-controls {

--- a/great_docs/assets/termshow.js
+++ b/great_docs/assets/termshow.js
@@ -96,7 +96,11 @@
     // Build player DOM
     const viewport = document.createElement('div');
     viewport.className = 'gd-tp-viewport';
-    viewport.setAttribute('tabindex', '0');
+    // Defer tabindex until user interaction to prevent Safari from treating
+    // auto-playing players as scroll-restoration targets.
+    if (!options.autoplay) {
+      viewport.setAttribute('tabindex', '0');
+    }
     viewport.setAttribute('role', 'application');
     viewport.setAttribute('aria-label', 'Terminal recording player');
 
@@ -178,8 +182,16 @@
         });
     }
 
+    // Restore tabindex on first user interaction (for keyboard nav)
+    function ensureTabindex() {
+      if (!viewport.hasAttribute('tabindex')) {
+        viewport.setAttribute('tabindex', '0');
+      }
+    }
+
     // Event listeners
     controls.playBtn.addEventListener('click', () => {
+      ensureTabindex();
       if (state.playing) {
         pause(state, controls, container, centerOverlay);
       } else if (state.ended) {
@@ -199,6 +211,7 @@
     });
 
     centerOverlay.addEventListener('click', () => {
+      ensureTabindex();
       if (state.ended) {
         // Return to initial state (don't autoplay)
         state.ended = false;
@@ -438,6 +451,18 @@
     const manifest = state.manifest;
     if (!manifest || idx < 0 || idx >= manifest.keyframes.length) return;
 
+    // Pin height before replacing innerHTML to prevent layout collapse.
+    // All frames in a recording share the same dimensions, so we pin once
+    // and keep it for the lifetime of playback. This prevents Safari's
+    // scroll-preservation heuristic from firing on the last player where
+    // even a sub-frame height flicker affects scrollHeight.
+    if (!svgContainer.style.minHeight) {
+      var pinHeight = svgContainer.offsetHeight;
+      if (pinHeight > 0) {
+        svgContainer.style.minHeight = pinHeight + 'px';
+      }
+    }
+
     // Use inline frames if available (no fetch needed)
     if (state.frames && state.frames[idx]) {
       svgContainer.innerHTML = state.frames[idx];
@@ -452,9 +477,7 @@
       .then((svg) => {
         svgContainer.innerHTML = svg;
       })
-      .catch(() => {
-        // Keep current frame if load fails
-      });
+      .catch(() => {});
   }
 
   function findKeyframeIndex(keyframes, time) {
@@ -470,24 +493,43 @@
   }
 
   function updateAnnotations(layer, annotations, time) {
-    // Clear stale annotations
-    layer.innerHTML = '';
+    if (!annotations || annotations.length === 0) {
+      for (var i = 0; i < layer.children.length; i++) {
+        layer.children[i].style.opacity = '0';
+      }
+      return;
+    }
 
-    if (!annotations || annotations.length === 0) return;
-
-    for (const ann of annotations) {
-      if (time >= ann.time && time <= ann.time + ann.duration) {
-        const el = document.createElement('div');
-        el.className = `gd-tp-annotation gd-tp-ann-${ann.position} gd-tp-ann-${ann.style}`;
-        el.textContent = ann.text;
-
-        // Fade progress (for smooth entry/exit)
-        const elapsed = time - ann.time;
-        const fadeIn = Math.min(1, elapsed / 0.3);
-        const fadeOut = Math.min(1, (ann.duration - elapsed) / 0.3);
-        el.style.opacity = Math.min(fadeIn, fadeOut);
-
+    // Pre-create elements with full styling at init time. Once created, ONLY
+    // opacity is mutated per-frame. This prevents Safari from re-evaluating
+    // position styles (top/bottom/margin-block) during playback, which triggers
+    // its scroll-position recalculation bug.
+    if (!layer._annEls) {
+      layer._annEls = [];
+      for (var j = 0; j < annotations.length; j++) {
+        var ann0 = annotations[j];
+        var el = document.createElement('div');
+        var wCls = ann0.width && ann0.width !== 'medium' ? ' gd-tp-ann-w-' + ann0.width : '';
+        el.className = 'gd-tp-annotation gd-tp-ann-' + ann0.position + ' gd-tp-ann-' + ann0.style + wCls;
+        el.textContent = ann0.text;
+        el.style.opacity = '0';
+        el.setAttribute('aria-hidden', 'true');
         layer.appendChild(el);
+        layer._annEls.push(el);
+      }
+    }
+
+    for (var k = 0; k < annotations.length; k++) {
+      var ann = annotations[k];
+      var node = layer._annEls[k];
+      if (time >= ann.time && time <= ann.time + ann.duration) {
+        // Fade progress (for smooth entry/exit)
+        var elapsed = time - ann.time;
+        var fadeIn = Math.min(1, elapsed / 0.3);
+        var fadeOut = Math.min(1, (ann.duration - elapsed) / 0.3);
+        node.style.opacity = Math.min(fadeIn, fadeOut);
+      } else {
+        if (node.style.opacity !== '0') node.style.opacity = '0';
       }
     }
   }

--- a/test-packages/synthetic/specs/gdtest_termshow.py
+++ b/test-packages/synthetic/specs/gdtest_termshow.py
@@ -740,7 +740,10 @@ SPEC = {
             "| `subtle` | Lighter, smaller text — less intrusive |\n"
             "| `highlight` | Amber-tinted with warm border — draws attention |\n"
             "\n"
-            "Positions: `top-left`, `top-right`, `bottom-left`, `bottom-right`.\n"
+            "Positions: `top-left`, `top`, `top-right`, `left`, `right`,\n"
+            "`bottom-left`, `bottom`, `bottom-right`.\n"
+            "\n"
+            "Widths: `small` (25%), `medium` (50%, default), `large` (75%).\n"
             "\n"
             "## Embedding in Pages\n"
             "\n"
@@ -955,6 +958,656 @@ SPEC = {
             "- Works with `file://` protocol (offline docs)\n"
             "- No CORS or fetch issues\n"
             "- SVGs scale perfectly at any zoom level\n"
+        ),
+        # ── Annotation gallery recordings ─────────────────────────────
+        #
+        # A compact base recording used for all annotation position/width
+        # demos. Shows a simple command + output so annotations are visible
+        # against real terminal content.
+        #
+        # --- Position demos ---
+        "demos/ann-pos-top-left.termshow": (
+            '{"version": 1, "format": "termshow", "term": {"cols": 80, "rows": 20, "type": "xterm-256color"}, "title": "Annotation Position Demo"}\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "c"]\n'
+            '[0.07, "o", "h"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.1, "o", " "]\n'
+            '[0.07, "o", "\\""]\n'
+            '[0.06, "o", "H"]\n'
+            '[0.07, "o", "e"]\n'
+            '[0.06, "o", "l"]\n'
+            '[0.08, "o", "l"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", " "]\n'
+            '[0.06, "o", "f"]\n'
+            '[0.07, "o", "r"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", "m"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.07, "o", "G"]\n'
+            '[0.06, "o", "r"]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "a"]\n'
+            '[0.07, "o", "t"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.08, "o", "D"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.07, "o", "c"]\n'
+            '[0.06, "o", "s"]\n'
+            '[0.08, "o", "\\""]\n'
+            '[0.5, "o", "\\r\\n"]\n'
+            '[0.2, "o", "Hello from Great Docs\\r\\n"]\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[5.0, "o", ""]\n'
+        ),
+        "demos/ann-pos-top-left.termshow.yml": (
+            "source: demos/ann-pos-top-left.termshow\n"
+            "\n"
+            "settings:\n"
+            "  idle_time_limit: 2\n"
+            "  window_chrome: colorful\n"
+            "\n"
+            "annotations:\n"
+            "  - at: 1.0\n"
+            "    duration: 5.0\n"
+            '    text: "Annotation at top-left"\n'
+            "    position: top-left\n"
+            "    style: callout\n"
+        ),
+        "demos/ann-pos-top.termshow": (
+            '{"version": 1, "format": "termshow", "term": {"cols": 80, "rows": 20, "type": "xterm-256color"}, "title": "Annotation Position Demo"}\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "c"]\n'
+            '[0.07, "o", "h"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.1, "o", " "]\n'
+            '[0.07, "o", "\\""]\n'
+            '[0.06, "o", "H"]\n'
+            '[0.07, "o", "e"]\n'
+            '[0.06, "o", "l"]\n'
+            '[0.08, "o", "l"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", " "]\n'
+            '[0.06, "o", "f"]\n'
+            '[0.07, "o", "r"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", "m"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.07, "o", "G"]\n'
+            '[0.06, "o", "r"]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "a"]\n'
+            '[0.07, "o", "t"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.08, "o", "D"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.07, "o", "c"]\n'
+            '[0.06, "o", "s"]\n'
+            '[0.08, "o", "\\""]\n'
+            '[0.5, "o", "\\r\\n"]\n'
+            '[0.2, "o", "Hello from Great Docs\\r\\n"]\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[5.0, "o", ""]\n'
+        ),
+        "demos/ann-pos-top.termshow.yml": (
+            "source: demos/ann-pos-top.termshow\n"
+            "\n"
+            "settings:\n"
+            "  idle_time_limit: 2\n"
+            "  window_chrome: colorful\n"
+            "\n"
+            "annotations:\n"
+            "  - at: 1.0\n"
+            "    duration: 5.0\n"
+            '    text: "Annotation at top"\n'
+            "    position: top\n"
+            "    style: callout\n"
+        ),
+        "demos/ann-pos-top-right.termshow": (
+            '{"version": 1, "format": "termshow", "term": {"cols": 80, "rows": 20, "type": "xterm-256color"}, "title": "Annotation Position Demo"}\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "c"]\n'
+            '[0.07, "o", "h"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.1, "o", " "]\n'
+            '[0.07, "o", "\\""]\n'
+            '[0.06, "o", "H"]\n'
+            '[0.07, "o", "e"]\n'
+            '[0.06, "o", "l"]\n'
+            '[0.08, "o", "l"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", " "]\n'
+            '[0.06, "o", "f"]\n'
+            '[0.07, "o", "r"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", "m"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.07, "o", "G"]\n'
+            '[0.06, "o", "r"]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "a"]\n'
+            '[0.07, "o", "t"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.08, "o", "D"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.07, "o", "c"]\n'
+            '[0.06, "o", "s"]\n'
+            '[0.08, "o", "\\""]\n'
+            '[0.5, "o", "\\r\\n"]\n'
+            '[0.2, "o", "Hello from Great Docs\\r\\n"]\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[5.0, "o", ""]\n'
+        ),
+        "demos/ann-pos-top-right.termshow.yml": (
+            "source: demos/ann-pos-top-right.termshow\n"
+            "\n"
+            "settings:\n"
+            "  idle_time_limit: 2\n"
+            "  window_chrome: colorful\n"
+            "\n"
+            "annotations:\n"
+            "  - at: 1.0\n"
+            "    duration: 5.0\n"
+            '    text: "Annotation at top-right"\n'
+            "    position: top-right\n"
+            "    style: callout\n"
+        ),
+        "demos/ann-pos-left.termshow": (
+            '{"version": 1, "format": "termshow", "term": {"cols": 80, "rows": 20, "type": "xterm-256color"}, "title": "Annotation Position Demo"}\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "c"]\n'
+            '[0.07, "o", "h"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.1, "o", " "]\n'
+            '[0.07, "o", "\\""]\n'
+            '[0.06, "o", "H"]\n'
+            '[0.07, "o", "e"]\n'
+            '[0.06, "o", "l"]\n'
+            '[0.08, "o", "l"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", " "]\n'
+            '[0.06, "o", "f"]\n'
+            '[0.07, "o", "r"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", "m"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.07, "o", "G"]\n'
+            '[0.06, "o", "r"]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "a"]\n'
+            '[0.07, "o", "t"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.08, "o", "D"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.07, "o", "c"]\n'
+            '[0.06, "o", "s"]\n'
+            '[0.08, "o", "\\""]\n'
+            '[0.5, "o", "\\r\\n"]\n'
+            '[0.2, "o", "Hello from Great Docs\\r\\n"]\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[5.0, "o", ""]\n'
+        ),
+        "demos/ann-pos-left.termshow.yml": (
+            "source: demos/ann-pos-left.termshow\n"
+            "\n"
+            "settings:\n"
+            "  idle_time_limit: 2\n"
+            "  window_chrome: colorful\n"
+            "\n"
+            "annotations:\n"
+            "  - at: 1.0\n"
+            "    duration: 5.0\n"
+            '    text: "Annotation at left"\n'
+            "    position: left\n"
+            "    style: callout\n"
+        ),
+        "demos/ann-pos-right.termshow": (
+            '{"version": 1, "format": "termshow", "term": {"cols": 80, "rows": 20, "type": "xterm-256color"}, "title": "Annotation Position Demo"}\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "c"]\n'
+            '[0.07, "o", "h"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.1, "o", " "]\n'
+            '[0.07, "o", "\\""]\n'
+            '[0.06, "o", "H"]\n'
+            '[0.07, "o", "e"]\n'
+            '[0.06, "o", "l"]\n'
+            '[0.08, "o", "l"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", " "]\n'
+            '[0.06, "o", "f"]\n'
+            '[0.07, "o", "r"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", "m"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.07, "o", "G"]\n'
+            '[0.06, "o", "r"]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "a"]\n'
+            '[0.07, "o", "t"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.08, "o", "D"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.07, "o", "c"]\n'
+            '[0.06, "o", "s"]\n'
+            '[0.08, "o", "\\""]\n'
+            '[0.5, "o", "\\r\\n"]\n'
+            '[0.2, "o", "Hello from Great Docs\\r\\n"]\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[5.0, "o", ""]\n'
+        ),
+        "demos/ann-pos-right.termshow.yml": (
+            "source: demos/ann-pos-right.termshow\n"
+            "\n"
+            "settings:\n"
+            "  idle_time_limit: 2\n"
+            "  window_chrome: colorful\n"
+            "\n"
+            "annotations:\n"
+            "  - at: 1.0\n"
+            "    duration: 5.0\n"
+            '    text: "Annotation at right"\n'
+            "    position: right\n"
+            "    style: callout\n"
+        ),
+        "demos/ann-pos-bottom-left.termshow": (
+            '{"version": 1, "format": "termshow", "term": {"cols": 80, "rows": 20, "type": "xterm-256color"}, "title": "Annotation Position Demo"}\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "c"]\n'
+            '[0.07, "o", "h"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.1, "o", " "]\n'
+            '[0.07, "o", "\\""]\n'
+            '[0.06, "o", "H"]\n'
+            '[0.07, "o", "e"]\n'
+            '[0.06, "o", "l"]\n'
+            '[0.08, "o", "l"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", " "]\n'
+            '[0.06, "o", "f"]\n'
+            '[0.07, "o", "r"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", "m"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.07, "o", "G"]\n'
+            '[0.06, "o", "r"]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "a"]\n'
+            '[0.07, "o", "t"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.08, "o", "D"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.07, "o", "c"]\n'
+            '[0.06, "o", "s"]\n'
+            '[0.08, "o", "\\""]\n'
+            '[0.5, "o", "\\r\\n"]\n'
+            '[0.2, "o", "Hello from Great Docs\\r\\n"]\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[5.0, "o", ""]\n'
+        ),
+        "demos/ann-pos-bottom-left.termshow.yml": (
+            "source: demos/ann-pos-bottom-left.termshow\n"
+            "\n"
+            "settings:\n"
+            "  idle_time_limit: 2\n"
+            "  window_chrome: colorful\n"
+            "\n"
+            "annotations:\n"
+            "  - at: 1.0\n"
+            "    duration: 5.0\n"
+            '    text: "Annotation at bottom-left"\n'
+            "    position: bottom-left\n"
+            "    style: callout\n"
+        ),
+        "demos/ann-pos-bottom.termshow": (
+            '{"version": 1, "format": "termshow", "term": {"cols": 80, "rows": 20, "type": "xterm-256color"}, "title": "Annotation Position Demo"}\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "c"]\n'
+            '[0.07, "o", "h"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.1, "o", " "]\n'
+            '[0.07, "o", "\\""]\n'
+            '[0.06, "o", "H"]\n'
+            '[0.07, "o", "e"]\n'
+            '[0.06, "o", "l"]\n'
+            '[0.08, "o", "l"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", " "]\n'
+            '[0.06, "o", "f"]\n'
+            '[0.07, "o", "r"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", "m"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.07, "o", "G"]\n'
+            '[0.06, "o", "r"]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "a"]\n'
+            '[0.07, "o", "t"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.08, "o", "D"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.07, "o", "c"]\n'
+            '[0.06, "o", "s"]\n'
+            '[0.08, "o", "\\""]\n'
+            '[0.5, "o", "\\r\\n"]\n'
+            '[0.2, "o", "Hello from Great Docs\\r\\n"]\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[5.0, "o", ""]\n'
+        ),
+        "demos/ann-pos-bottom.termshow.yml": (
+            "source: demos/ann-pos-bottom.termshow\n"
+            "\n"
+            "settings:\n"
+            "  idle_time_limit: 2\n"
+            "  window_chrome: colorful\n"
+            "\n"
+            "annotations:\n"
+            "  - at: 1.0\n"
+            "    duration: 5.0\n"
+            '    text: "Annotation at bottom"\n'
+            "    position: bottom\n"
+            "    style: callout\n"
+        ),
+        "demos/ann-pos-bottom-right.termshow": (
+            '{"version": 1, "format": "termshow", "term": {"cols": 80, "rows": 20, "type": "xterm-256color"}, "title": "Annotation Position Demo"}\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "c"]\n'
+            '[0.07, "o", "h"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.1, "o", " "]\n'
+            '[0.07, "o", "\\""]\n'
+            '[0.06, "o", "H"]\n'
+            '[0.07, "o", "e"]\n'
+            '[0.06, "o", "l"]\n'
+            '[0.08, "o", "l"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", " "]\n'
+            '[0.06, "o", "f"]\n'
+            '[0.07, "o", "r"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", "m"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.07, "o", "G"]\n'
+            '[0.06, "o", "r"]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "a"]\n'
+            '[0.07, "o", "t"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.08, "o", "D"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.07, "o", "c"]\n'
+            '[0.06, "o", "s"]\n'
+            '[0.08, "o", "\\""]\n'
+            '[0.5, "o", "\\r\\n"]\n'
+            '[0.2, "o", "Hello from Great Docs\\r\\n"]\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[5.0, "o", ""]\n'
+        ),
+        "demos/ann-pos-bottom-right.termshow.yml": (
+            "source: demos/ann-pos-bottom-right.termshow\n"
+            "\n"
+            "settings:\n"
+            "  idle_time_limit: 2\n"
+            "  window_chrome: colorful\n"
+            "\n"
+            "annotations:\n"
+            "  - at: 1.0\n"
+            "    duration: 5.0\n"
+            '    text: "Annotation at bottom-right"\n'
+            "    position: bottom-right\n"
+            "    style: callout\n"
+        ),
+        # --- Width demos (all at top-right) ---
+        "demos/ann-width-small.termshow": (
+            '{"version": 1, "format": "termshow", "term": {"cols": 80, "rows": 20, "type": "xterm-256color"}, "title": "Annotation Width Demo"}\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "c"]\n'
+            '[0.07, "o", "h"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.1, "o", " "]\n'
+            '[0.07, "o", "\\""]\n'
+            '[0.06, "o", "H"]\n'
+            '[0.07, "o", "e"]\n'
+            '[0.06, "o", "l"]\n'
+            '[0.08, "o", "l"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", " "]\n'
+            '[0.06, "o", "f"]\n'
+            '[0.07, "o", "r"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", "m"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.07, "o", "G"]\n'
+            '[0.06, "o", "r"]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "a"]\n'
+            '[0.07, "o", "t"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.08, "o", "D"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.07, "o", "c"]\n'
+            '[0.06, "o", "s"]\n'
+            '[0.08, "o", "\\""]\n'
+            '[0.5, "o", "\\r\\n"]\n'
+            '[0.2, "o", "Hello from Great Docs\\r\\n"]\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[5.0, "o", ""]\n'
+        ),
+        "demos/ann-width-small.termshow.yml": (
+            "source: demos/ann-width-small.termshow\n"
+            "\n"
+            "settings:\n"
+            "  idle_time_limit: 2\n"
+            "  window_chrome: colorful\n"
+            "\n"
+            "annotations:\n"
+            "  - at: 1.0\n"
+            "    duration: 5.0\n"
+            '    text: "Small"\n'
+            "    position: top-right\n"
+            "    style: callout\n"
+            "    width: small\n"
+        ),
+        "demos/ann-width-medium.termshow": (
+            '{"version": 1, "format": "termshow", "term": {"cols": 80, "rows": 20, "type": "xterm-256color"}, "title": "Annotation Width Demo"}\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "c"]\n'
+            '[0.07, "o", "h"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.1, "o", " "]\n'
+            '[0.07, "o", "\\""]\n'
+            '[0.06, "o", "H"]\n'
+            '[0.07, "o", "e"]\n'
+            '[0.06, "o", "l"]\n'
+            '[0.08, "o", "l"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", " "]\n'
+            '[0.06, "o", "f"]\n'
+            '[0.07, "o", "r"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", "m"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.07, "o", "G"]\n'
+            '[0.06, "o", "r"]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "a"]\n'
+            '[0.07, "o", "t"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.08, "o", "D"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.07, "o", "c"]\n'
+            '[0.06, "o", "s"]\n'
+            '[0.08, "o", "\\""]\n'
+            '[0.5, "o", "\\r\\n"]\n'
+            '[0.2, "o", "Hello from Great Docs\\r\\n"]\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[5.0, "o", ""]\n'
+        ),
+        "demos/ann-width-medium.termshow.yml": (
+            "source: demos/ann-width-medium.termshow\n"
+            "\n"
+            "settings:\n"
+            "  idle_time_limit: 2\n"
+            "  window_chrome: colorful\n"
+            "\n"
+            "annotations:\n"
+            "  - at: 1.0\n"
+            "    duration: 5.0\n"
+            '    text: "Medium width annotation with more text content"\n'
+            "    position: top-right\n"
+            "    style: callout\n"
+            "    width: medium\n"
+        ),
+        "demos/ann-width-large.termshow": (
+            '{"version": 1, "format": "termshow", "term": {"cols": 80, "rows": 20, "type": "xterm-256color"}, "title": "Annotation Width Demo"}\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "c"]\n'
+            '[0.07, "o", "h"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.1, "o", " "]\n'
+            '[0.07, "o", "\\""]\n'
+            '[0.06, "o", "H"]\n'
+            '[0.07, "o", "e"]\n'
+            '[0.06, "o", "l"]\n'
+            '[0.08, "o", "l"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", " "]\n'
+            '[0.06, "o", "f"]\n'
+            '[0.07, "o", "r"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.08, "o", "m"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.07, "o", "G"]\n'
+            '[0.06, "o", "r"]\n'
+            '[0.08, "o", "e"]\n'
+            '[0.06, "o", "a"]\n'
+            '[0.07, "o", "t"]\n'
+            '[0.06, "o", " "]\n'
+            '[0.08, "o", "D"]\n'
+            '[0.06, "o", "o"]\n'
+            '[0.07, "o", "c"]\n'
+            '[0.06, "o", "s"]\n'
+            '[0.08, "o", "\\""]\n'
+            '[0.5, "o", "\\r\\n"]\n'
+            '[0.2, "o", "Hello from Great Docs\\r\\n"]\n'
+            '[0.5, "o", "\\u001b[32m\\u001b[1m$\\u001b[0m "]\n'
+            '[5.0, "o", ""]\n'
+        ),
+        "demos/ann-width-large.termshow.yml": (
+            "source: demos/ann-width-large.termshow\n"
+            "\n"
+            "settings:\n"
+            "  idle_time_limit: 2\n"
+            "  window_chrome: colorful\n"
+            "\n"
+            "annotations:\n"
+            "  - at: 1.0\n"
+            "    duration: 5.0\n"
+            '    text: "Large width annotation that takes up more horizontal space for longer explanations"\n'
+            "    position: top-right\n"
+            "    style: callout\n"
+            "    width: large\n"
+        ),
+        # ── Annotation gallery page ──────────────────────────────────
+        "user_guide/05-annotation-gallery.qmd": (
+            "---\n"
+            "title: Annotation Gallery\n"
+            "---\n"
+            "\n"
+            "## Annotation Positions\n"
+            "\n"
+            "Annotations can be placed at any edge or corner of the terminal\n"
+            "viewport. All examples below use the default `medium` width\n"
+            "and `callout` style.\n"
+            "\n"
+            "### Position: Top-Left\n"
+            "\n"
+            '{{< termshow file="demos/ann-pos-top-left" autoplay="true" loop="true" >}}\n'
+            "\n"
+            "### Position: Top\n"
+            "\n"
+            '{{< termshow file="demos/ann-pos-top" autoplay="true" loop="true" >}}\n'
+            "\n"
+            "### Position: Top-Right\n"
+            "\n"
+            '{{< termshow file="demos/ann-pos-top-right" autoplay="true" loop="true" >}}\n'
+            "\n"
+            "### Position: Left\n"
+            "\n"
+            '{{< termshow file="demos/ann-pos-left" autoplay="true" loop="true" >}}\n'
+            "\n"
+            "### Position: Right\n"
+            "\n"
+            '{{< termshow file="demos/ann-pos-right" autoplay="true" loop="true" >}}\n'
+            "\n"
+            "### Position: Bottom-Left\n"
+            "\n"
+            '{{< termshow file="demos/ann-pos-bottom-left" autoplay="true" loop="true" >}}\n'
+            "\n"
+            "### Position: Bottom\n"
+            "\n"
+            '{{< termshow file="demos/ann-pos-bottom" autoplay="true" loop="true" >}}\n'
+            "\n"
+            "### Position: Bottom-Right\n"
+            "\n"
+            '{{< termshow file="demos/ann-pos-bottom-right" autoplay="true" loop="true" >}}\n'
+            "\n"
+            "## Annotation Widths\n"
+            "\n"
+            "The `width` field controls how wide an annotation can grow as\n"
+            "a fraction of the player viewport. All examples below use\n"
+            "`top-right` position and `callout` style.\n"
+            "\n"
+            "### Small (25%)\n"
+            "\n"
+            '{{< termshow file="demos/ann-width-small" autoplay="true" loop="true" >}}\n'
+            "\n"
+            "### Medium (50%) — Default\n"
+            "\n"
+            '{{< termshow file="demos/ann-width-medium" autoplay="true" loop="true" >}}\n'
+            "\n"
+            "### Large (75%)\n"
+            "\n"
+            '{{< termshow file="demos/ann-width-large" autoplay="true" loop="true" >}}\n'
+            "\n"
+            "## Choosing Settings\n"
+            "\n"
+            "| Goal | Recommended |\n"
+            "|------|-------------|\n"
+            "| Brief label next to code | `position: right`, `width: small` |\n"
+            "| Step explanation avoiding left-aligned output | `position: top-right`, `width: medium` |\n"
+            "| Long description with room to breathe | `position: top`, `width: large` |\n"
+            "| Warning banner across the top | `position: top`, `width: large`, `style: highlight` |\n"
+            "| Subtle aside | `position: bottom-right`, `width: small`, `style: subtle` |\n"
+            "\n"
+            "## YAML Example\n"
+            "\n"
+            "```yaml\n"
+            "annotations:\n"
+            "  - at: 2.0\n"
+            "    duration: 3.0\n"
+            "    text: This step installs all dependencies\n"
+            "    position: top-right\n"
+            "    style: callout\n"
+            "    width: large\n"
+            "```\n"
+            "\n"
+            "Available positions: `top-left`, `top`, `top-right`, `left`, `right`,\n"
+            "`bottom-left`, `bottom`, `bottom-right`.\n"
+            "\n"
+            "Available widths: `small` (25%), `medium` (50%, default), `large` (75%).\n"
         ),
     },
     "config": {

--- a/user_guide/41-terminal-recordings.qmd
+++ b/user_guide/41-terminal-recordings.qmd
@@ -338,6 +338,7 @@ annotations:
     text: This installs all dependencies from requirements.txt
     position: top-right
     style: callout
+    width: medium
 ```
 
 Annotations are purely presentational: they don't affect timing or terminal output, and you can
@@ -358,12 +359,33 @@ and `subtle`; reserve `highlight` for critical warnings or pivotal steps.
 
 ### Positions
 
-Annotations can be placed in any corner of the terminal viewport:
+Annotations can be placed at any edge or corner of the terminal viewport:
 
-`top-left`, `top-right`, `bottom-left`, `bottom-right`
+| Position | Placement |
+|----------|-----------|
+| `top-left` | Top-left corner |
+| `top` | Top center |
+| `top-right` | Top-right corner |
+| `left` | Vertically centered, left edge |
+| `right` | Vertically centered, right edge |
+| `bottom-left` | Bottom-left corner |
+| `bottom` | Bottom center |
+| `bottom-right` | Bottom-right corner (default) |
 
 Place annotations where they won't cover the terminal text you're explaining. `top-right` is a
 good default because most CLI output scrolls along the left edge.
+
+### Width
+
+Control how wide an annotation can grow with the `width` field:
+
+| Width | Max width |
+|-------|-----------|
+| `small` | 25% of the viewport |
+| `medium` | 50% of the viewport (default) |
+| `large` | 75% of the viewport |
+
+Use `small` for brief one-word labels, `large` for longer explanations that need breathing room.
 
 **Tips:**
 


### PR DESCRIPTION
This PR adds new options for positioning and sizing annotation bubbles in the terminal player. We also generally improve annotation rendering performance, and address scroll anchoring issues in Safari.