### PR TITLE
fix: support FastMCP for generation of MCP reference pages

### DIFF
--- a/great_docs/_mcp_docs.py
+++ b/great_docs/_mcp_docs.py
@@ -47,18 +47,22 @@ def discover_mcp_server(
     if server_var:
         server = getattr(module, server_var, None)
     else:
-        # Auto-detect: look for mcp.server.Server instances
+        # Auto-detect: look for mcp.server.Server or FastMCP instances
         for attr_name in dir(module):
             obj = getattr(module, attr_name)
             type_name = type(obj).__name__
             module_name = type(obj).__module__ or ""
-            if type_name == "Server" and "mcp" in module_name:
+            if "mcp" in module_name and type_name in ("Server", "FastMCP"):
                 server = obj
                 break
 
     if server is None:
         print(f"No MCP Server instance found in {module_path}")
         return None
+
+    # Unwrap FastMCP to get the underlying low-level server with request_handlers
+    if hasattr(server, "_mcp_server"):
+        server = server._mcp_server
 
     # Extract server name
     server_name = getattr(server, "name", None) or module_path.split(".")[-1]


### PR DESCRIPTION
This PR enhances the server discovery logic to support both `Server` and `FastMCP` instances, and ensures that if a `FastMCP` instance is found, it unwraps it to access the underlying server. This makes the server detection more robust and compatible with different server types.