### PR TITLE
Fix lint issue: Use def instead of lambda for default argument

### DIFF
--- a/great_docs/_renderer/inventory.py
+++ b/great_docs/_renderer/inventory.py
@@ -68,7 +68,8 @@ def create_inventory(
         Inventory dictionary with project, version, count, and items.
     """
     if uri is None:
-        uri = lambda s: f"{s.canonical_path}.html"
+        def uri(s):
+            return f"{s.canonical_path}.html"
     if dispname is None:
         dispname = "-"
 


### PR DESCRIPTION
## Problem Background
This change addresses a lint warning related to the use of lambda expressions assigned to variables. In Python, assigning a lambda to a variable (e.g., `uri = lambda s: ...`) is generally discouraged by style guides and linters because it reduces code clarity and can lead to confusion. The `def` statement is preferred for defining named functions, as it explicitly declares the function's intent and improves readability.

## Changes
- Replaced the lambda expression assigned to `uri` in the `create_inventory` function with a `def` statement. This aligns with lint best practices and enhances code maintainability without altering functionality.

## Verification
- Run lint checks (e.g., using `flake8`, `pylint`, or the project's configured linter) to confirm no related warnings remain.
- Ensure all existing tests pass, as the change should not affect the external behavior or API of the code.