### PR TITLE
Decode subprocess pipes as UTF-8 on Windows

### DIFF
--- a/great_docs/_api_diff.py
+++ b/great_docs/_api_diff.py
@@ -7,6 +7,7 @@ import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from great_docs._subprocess import TEXT_MODE_KWARGS
 from great_docs._translations import get_translation
 
 # ---------------------------------------------------------------------------
@@ -622,7 +623,7 @@ def list_version_tags(project_root: Path) -> list[str]:
             ["git", "tag", "--sort=creatordate"],
             cwd=project_root,
             capture_output=True,
-            text=True,
+            **TEXT_MODE_KWARGS,
             timeout=10,
         )
         if result.returncode != 0:
@@ -647,7 +648,7 @@ def _get_tag_date(project_root: Path, tag: str) -> str | None:
             ["git", "log", "-1", "--format=%ai", tag],
             cwd=project_root,
             capture_output=True,
-            text=True,
+            **TEXT_MODE_KWARGS,
             timeout=10,
         )
         if result.returncode == 0 and result.stdout.strip():
@@ -682,7 +683,7 @@ def _extract_package_at_tag(
                 ["git", "ls-tree", "--name-only", tag, candidate + "/"],
                 cwd=project_root,
                 capture_output=True,
-                text=True,
+                **TEXT_MODE_KWARGS,
                 timeout=10,
             )
             if check.returncode != 0 or not check.stdout.strip():
@@ -743,7 +744,7 @@ def _read_cli_module_at_tag(
                 ["git", "show", f"{tag}:{cfg_file}"],
                 cwd=project_root,
                 capture_output=True,
-                text=True,
+                **TEXT_MODE_KWARGS,
                 timeout=10,
             )
             if result.returncode != 0:
@@ -782,7 +783,7 @@ def _read_cli_module_at_tag(
                 ["git", "cat-file", "-t", f"{tag}:{mod_path}"],
                 cwd=project_root,
                 capture_output=True,
-                text=True,
+                **TEXT_MODE_KWARGS,
                 timeout=5,
             )
             if check.returncode == 0:

--- a/great_docs/_git.py
+++ b/great_docs/_git.py
@@ -12,6 +12,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from ._subprocess import TEXT_MODE_KWARGS
+
 if TYPE_CHECKING:
     pass
 
@@ -76,7 +78,7 @@ def get_file_created_date(
             ],
             cwd=project_root,
             capture_output=True,
-            text=True,
+            **TEXT_MODE_KWARGS,
             timeout=10,
         )
 
@@ -160,7 +162,7 @@ def get_file_modified_date(
             ],
             cwd=project_root,
             capture_output=True,
-            text=True,
+            **TEXT_MODE_KWARGS,
             timeout=10,
         )
 
@@ -228,7 +230,7 @@ def get_file_contributors(
             ],
             cwd=project_root,
             capture_output=True,
-            text=True,
+            **TEXT_MODE_KWARGS,
             timeout=10,
         )
 
@@ -268,7 +270,7 @@ def is_git_repository(path: Path) -> bool:
             ["git", "rev-parse", "--git-dir"],
             cwd=path,
             capture_output=True,
-            text=True,
+            **TEXT_MODE_KWARGS,
             timeout=5,
         )
         return result.returncode == 0

--- a/great_docs/_harper.py
+++ b/great_docs/_harper.py
@@ -18,6 +18,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from great_docs._subprocess import TEXT_MODE_KWARGS
+
 if TYPE_CHECKING:
     pass
 
@@ -551,7 +553,7 @@ def get_harper_version(harper_path: str | None = None) -> str | None:
         result = subprocess.run(
             [harper_path, "--version"],
             capture_output=True,
-            text=True,
+            **TEXT_MODE_KWARGS,
             timeout=5,
         )
         if result.returncode == 0:
@@ -649,7 +651,7 @@ def run_harper(
         result = subprocess.run(
             cmd,
             capture_output=True,
-            text=True,
+            **TEXT_MODE_KWARGS,
             timeout=timeout,
         )
     except subprocess.TimeoutExpired as e:
@@ -794,7 +796,7 @@ def run_harper_on_text(
             cmd,
             input=text,
             capture_output=True,
-            text=True,
+            **TEXT_MODE_KWARGS,
             timeout=timeout,
         )
     except subprocess.TimeoutExpired as e:

--- a/great_docs/_renderer/_format.py
+++ b/great_docs/_renderer/_format.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING, cast
 
 import griffe as gf
 
+from great_docs._subprocess import TEXT_MODE_KWARGS
+
 from .pandoc.components import Attr
 from .pandoc.inlines import InterLink, Span
 
@@ -311,7 +313,7 @@ def format_str(source: str) -> str:
             "-",
         ],
         input=source,
-        text=True,
+        **TEXT_MODE_KWARGS,
         capture_output=True,
     )
 

--- a/great_docs/_subprocess.py
+++ b/great_docs/_subprocess.py
@@ -1,0 +1,12 @@
+"""Subprocess helpers for consistent UTF-8 text-mode I/O."""
+
+from __future__ import annotations
+
+# Windows text-mode pipes default to the locale codec (e.g. cp1252). Quarto and
+# Python post-render hooks emit UTF-8, so parent readers must not rely on
+# locale.getpreferredencoding(False).
+TEXT_MODE_KWARGS: dict[str, str | bool] = {
+    "text": True,
+    "encoding": "utf-8",
+    "errors": "replace",
+}

--- a/great_docs/_term_player/editor.py
+++ b/great_docs/_term_player/editor.py
@@ -13,6 +13,8 @@ from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
 from typing import Any
 
+from great_docs._subprocess import TEXT_MODE_KWARGS
+
 from .manifest import generate_manifest
 from .parser import Event, Recording, TermInfo, parse_termshow
 from .script import (
@@ -504,7 +506,7 @@ def _generate_preview_html(editor_data: dict, script_data: dict) -> str:
             ["quarto", "render", "preview.qmd", "--quiet"],
             cwd=str(tmp_dir),
             capture_output=True,
-            text=True,
+            **TEXT_MODE_KWARGS,
             timeout=30,
         )
         if result.returncode != 0:

--- a/great_docs/_versioned_build.py
+++ b/great_docs/_versioned_build.py
@@ -11,6 +11,7 @@ from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_compl
 from pathlib import Path
 from typing import Any, Callable
 
+from great_docs._subprocess import TEXT_MODE_KWARGS
 from great_docs._versioning import (
     VersionEntry,
     build_version_map,
@@ -974,7 +975,7 @@ def _validate_git_ref_is_tag(project_root: Path, git_ref: str) -> bool:
             ["git", "tag", "--list", git_ref],
             cwd=project_root,
             capture_output=True,
-            text=True,
+            **TEXT_MODE_KWARGS,
             timeout=10,
         )
         return result.returncode == 0 and git_ref in result.stdout.strip().split("\n")
@@ -1339,7 +1340,7 @@ def _render_single_version(
                 ["quarto", "render"],
                 cwd=build_dir,
                 capture_output=True,
-                text=True,
+                **TEXT_MODE_KWARGS,
                 env=env,
                 timeout=600,
             )
@@ -1383,7 +1384,7 @@ def _render_single_version_streaming(
             cwd=build_dir,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True,
+            **TEXT_MODE_KWARGS,
             env=env,
             bufsize=1,
         )
@@ -1439,7 +1440,7 @@ def _render_single_version_streaming(
                 cwd=build_dir,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                text=True,
+                **TEXT_MODE_KWARGS,
                 env=env,
                 bufsize=1,
             )

--- a/great_docs/assets/post-render.py
+++ b/great_docs/assets/post-render.py
@@ -25,6 +25,11 @@ def _configure_stdio_for_unicode() -> None:
 
 _configure_stdio_for_unicode()
 
+try:
+    from great_docs._subprocess import TEXT_MODE_KWARGS as _SUBPROCESS_TEXT_KWARGS
+except ImportError:
+    _SUBPROCESS_TEXT_KWARGS = {"text": True, "encoding": "utf-8", "errors": "replace"}
+
 # Skip post-render processing during freeze-only renders
 if os.environ.get("GD_FREEZE_ONLY"):
     print("Skipping post-render (freeze-only mode)")
@@ -4035,7 +4040,7 @@ def inject_page_metadata():
                             ["git", "log", "-1", "--format=%aI", "--", source_file],
                             cwd=project_root,
                             capture_output=True,
-                            text=True,
+                            **_SUBPROCESS_TEXT_KWARGS,
                             timeout=5,
                         )
                         if result.returncode == 0 and result.stdout.strip():
@@ -4055,7 +4060,7 @@ def inject_page_metadata():
                             ],
                             cwd=project_root,
                             capture_output=True,
-                            text=True,
+                            **_SUBPROCESS_TEXT_KWARGS,
                             timeout=5,
                         )
                         if result.returncode == 0 and result.stdout.strip():
@@ -4679,7 +4684,7 @@ def generate_markdown_pages():
                 ["quarto", "pandoc", "-f", "html", "-t", "gfm", "--wrap=none"],
                 input=main_html,
                 capture_output=True,
-                text=True,
+                **_SUBPROCESS_TEXT_KWARGS,
                 timeout=30,
             )
 

--- a/great_docs/cli.py
+++ b/great_docs/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import click
 
 from . import __version__
+from ._subprocess import TEXT_MODE_KWARGS
 from .core import GreatDocs
 
 
@@ -947,7 +948,7 @@ def freeze(
             ["quarto", "render", str(rel_target)],
             cwd=build_dir,
             capture_output=True,
-            text=True,
+            **TEXT_MODE_KWARGS,
             env=freeze_env,
         )
 

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from yaml12 import format_yaml, parse_yaml, read_yaml, write_yaml
 
 from .config import Config
+from ._subprocess import TEXT_MODE_KWARGS
 
 
 def _patch_griffe():
@@ -5880,7 +5881,7 @@ class GreatDocs:
                 ["git", "describe", "--tags", "--exact-match"],
                 cwd=package_root,
                 capture_output=True,
-                text=True,
+                **TEXT_MODE_KWARGS,
             )
             if result.returncode == 0:
                 return result.stdout.strip()
@@ -5890,7 +5891,7 @@ class GreatDocs:
                 ["git", "rev-parse", "--abbrev-ref", "HEAD"],
                 cwd=package_root,
                 capture_output=True,
-                text=True,
+                **TEXT_MODE_KWARGS,
             )
             if result.returncode == 0:
                 branch = result.stdout.strip()
@@ -9356,7 +9357,7 @@ jupyter: python3
             result = subprocess.run(
                 [*pandoc_cmd, str(rst_path), "-f", "rst", "-t", "markdown", "--wrap=none"],
                 capture_output=True,
-                text=True,
+                **TEXT_MODE_KWARGS,
                 timeout=30,
             )
             if result.returncode == 0:
@@ -12085,7 +12086,7 @@ body-classes: "gd-homepage"
                     ["git", "config", "--get", "remote.origin.url"],
                     cwd=gd_source_dir,
                     capture_output=True,
-                    text=True,
+                    **TEXT_MODE_KWARGS,
                     timeout=5,
                 )
                 remote_url = remote_result.stdout.strip() if remote_result.returncode == 0 else ""
@@ -12094,7 +12095,7 @@ body-classes: "gd-homepage"
                         ["git", "rev-parse", "--short", "HEAD"],
                         cwd=gd_source_dir,
                         capture_output=True,
-                        text=True,
+                        **TEXT_MODE_KWARGS,
                         timeout=5,
                     )
                     if result.returncode == 0:
@@ -12587,7 +12588,7 @@ body-classes: "gd-homepage"
                 ["git", "describe", "--tags", "--exact-match", "HEAD"],
                 cwd=self.project_root,
                 capture_output=True,
-                text=True,
+                **TEXT_MODE_KWARGS,
                 timeout=5,
             )
             if result.returncode == 0 and result.stdout.strip():
@@ -14754,7 +14755,7 @@ body-classes: "gd-homepage"
                         ["git", "config", "--get", "remote.origin.url"],
                         cwd=str(self.project_root),
                         capture_output=True,
-                        text=True,
+                        **TEXT_MODE_KWARGS,
                     )
                     if _git_remote.returncode == 0 and _git_remote.stdout.strip():
                         _remote_url = _git_remote.stdout.strip()
@@ -14858,7 +14859,7 @@ body-classes: "gd-homepage"
                 cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                text=True,
+                **TEXT_MODE_KWARGS,
                 env=env,
                 bufsize=1,
             )
@@ -15618,7 +15619,7 @@ body-classes: "gd-homepage"
             if branch:
                 clone_cmd += ["--branch", branch]
             clone_cmd += [repo_url, str(clone_dir)]
-            result = subprocess.run(clone_cmd, capture_output=True, text=True)
+            result = subprocess.run(clone_cmd, capture_output=True, **TEXT_MODE_KWARGS)
             if result.returncode != 0:
                 raise RuntimeError(
                     f"git clone failed (exit {result.returncode}):\n{result.stderr.strip()}"
@@ -15633,13 +15634,13 @@ body-classes: "gd-homepage"
                         ["git", "fetch", "--unshallow"],
                         cwd=str(clone_dir),
                         capture_output=True,
-                        text=True,
+                        **TEXT_MODE_KWARGS,
                     )
                     subprocess.run(
                         ["git", "fetch", "--tags"],
                         cwd=str(clone_dir),
                         capture_output=True,
-                        text=True,
+                        **TEXT_MODE_KWARGS,
                     )
                 elif needs == "tags":
                     print("   Fetching tags for source link detection...")
@@ -15647,7 +15648,7 @@ body-classes: "gd-homepage"
                         ["git", "fetch", "--tags"],
                         cwd=str(clone_dir),
                         capture_output=True,
-                        text=True,
+                        **TEXT_MODE_KWARGS,
                     )
             print("   Cloned to temporary directory")
 
@@ -15667,7 +15668,7 @@ body-classes: "gd-homepage"
             result = subprocess.run(
                 [str(venv_pip), "install", "great-docs"],
                 capture_output=True,
-                text=True,
+                **TEXT_MODE_KWARGS,
             )
             if result.returncode != 0:
                 # Fall back to installing from the current source tree if
@@ -15676,7 +15677,7 @@ body-classes: "gd-homepage"
                 result = subprocess.run(
                     [str(venv_pip), "install", str(src_root)],
                     capture_output=True,
-                    text=True,
+                    **TEXT_MODE_KWARGS,
                 )
                 if result.returncode != 0:
                     raise RuntimeError(f"Failed to install great-docs:\n{result.stderr.strip()}")
@@ -15690,13 +15691,13 @@ body-classes: "gd-homepage"
                 install_cmd.append(f"{clone_dir}[{extras}]")
             else:
                 install_cmd.append(str(clone_dir))
-            result = subprocess.run(install_cmd, capture_output=True, text=True)
+            result = subprocess.run(install_cmd, capture_output=True, **TEXT_MODE_KWARGS)
             if result.returncode != 0:
                 # Retry without extras
                 result = subprocess.run(
                     [str(venv_pip), "install", "-e", str(clone_dir)],
                     capture_output=True,
-                    text=True,
+                    **TEXT_MODE_KWARGS,
                 )
                 if result.returncode != 0:
                     raise RuntimeError(

--- a/tests/test_subprocess_encoding.py
+++ b/tests/test_subprocess_encoding.py
@@ -1,0 +1,60 @@
+"""Tests for UTF-8 subprocess text-mode decoding (issue #200 follow-up)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from great_docs._subprocess import TEXT_MODE_KWARGS
+
+
+def test_text_mode_kwargs_decode_utf8_child_output():
+    """Parent must read UTF-8 bytes from children without locale decode errors."""
+    child_code = (
+        "import sys; "
+        "sys.stdout.buffer.write(bytes(["
+        "0x0a, 0xf0, 0x9f, 0x94, 0x8d, 0x20, 0x53, 0x45, 0x4f, 0x0a"
+        "])); "
+        "sys.stdout.flush()"
+    )
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", child_code],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        **TEXT_MODE_KWARGS,
+    )
+    assert proc.stdout is not None
+    output = proc.stdout.read()
+    proc.wait()
+    assert "SEO" in output
+
+
+def test_locale_codec_fails_on_utf8_child_output():
+    """Reproduce the Windows cp1252 parent-decode failure from issue #200."""
+    child_code = (
+        "import sys; "
+        "sys.stdout.buffer.write(bytes(["
+        "0x0a, 0xf0, 0x9f, 0x94, 0x8d, 0x20, 0x53, 0x45, 0x4f, 0x0a"
+        "])); "
+        "sys.stdout.flush()"
+    )
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", child_code],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="cp1252",
+        errors="strict",
+    )
+    assert proc.stdout is not None
+    try:
+        proc.stdout.read()
+        raised = False
+    except UnicodeDecodeError:
+        raised = True
+    finally:
+        proc.wait()
+
+    assert raised


### PR DESCRIPTION
## Summary
- Add `TEXT_MODE_KWARGS` (`encoding="utf-8"`, `errors="replace"`) for text-mode subprocess I/O
- Apply to the streaming Quarto runner (`run_streaming` `Popen`) and other `subprocess.run` / `Popen` call sites that read child output
- Reconfigure post-render subprocess calls with the same UTF-8 decoding (with import fallback when run standalone)

Follow-up to #201: child processes now emit UTF-8 correctly after that PR, but the parent `great-docs build` CLI was still decoding pipes with the Windows locale codec (`cp1252`), causing `UnicodeDecodeError` in `_readerthread` while reading post-render output.

Fixes #200

## Test plan
- [x] `pytest tests/test_subprocess_encoding.py` (MCVE from issue comment + regression guard)
- [ ] Manual: `great-docs build` on Windows without `PYTHONUTF8` after Quarto reaches post-render