### PR TITLE
fix: remove 404s seen with helper scripts

### DIFF
--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -11885,17 +11885,16 @@ body-classes: "gd-homepage"
             config["format"]["html"]["include-after-body"].append(tooltips_script_entry)
 
         # Add color-swatch script (always enabled — loaded after tooltips)
-        # Use inline loader to resolve path relative to site root (Quarto does not
-        # rewrite bare src= paths for scripts appended after its processing pass).
+        # Use an inline loader that resolves the path against the site root via
+        # Quarto's quarto:offset meta tag (always present). Bare src= paths and
+        # canonical-URL stripping both 404 on nested pages; quarto:offset is the
+        # robust pattern shared with termshow.js, on-this-page.js, etc.
         color_swatch_entry = {
             "text": (
-                "<script>"
-                "(function(){var s=document.createElement('script');"
-                "s.src=(document.querySelector('link[rel=\"canonical\"]')||{href:location.href})"
-                ".href.replace(/\\/[^\\/]*$/,'').replace(/\\/[^\\/]*$/,'')+'/color-swatch.js';"
-                "var h=document.currentScript;"
-                "h.parentNode.insertBefore(s,h.nextSibling);})()"
-                "</script>"
+                "<script>(function(){var s=document.createElement('script');"
+                "var m=document.querySelector('meta[name=\"quarto:offset\"]');"
+                "s.src=(m?m.content:'')+'color-swatch.js';"
+                "document.body.appendChild(s);})();</script>"
             )
         }
         # Remove any stale plain <script src="color-swatch.js"> entries so the
@@ -11921,7 +11920,29 @@ body-classes: "gd-homepage"
             config["format"]["html"]["include-after-body"].append(responsive_tables_script_entry)
 
         # Add video embed script (always enabled — lazy loading + YouTube thumbnails)
-        video_embed_script_entry = {"text": '<script src="video-embed.js"></script>'}
+        # Use an inline loader that resolves the path against the site root via
+        # Quarto's quarto:offset meta tag (always present). A bare src= path 404s
+        # on nested pages; quarto:offset is the robust pattern shared with
+        # termshow.js, on-this-page.js, etc.
+        video_embed_script_entry = {
+            "text": (
+                "<script>(function(){var s=document.createElement('script');"
+                "var m=document.querySelector('meta[name=\"quarto:offset\"]');"
+                "s.src=(m?m.content:'')+'video-embed.js';"
+                "document.body.appendChild(s);})();</script>"
+            )
+        }
+        # Remove any stale plain <script src="video-embed.js"> entries so the
+        # dynamic loader below is used instead.
+        config["format"]["html"]["include-after-body"] = [
+            item
+            for item in config["format"]["html"]["include-after-body"]
+            if not (
+                isinstance(item, dict)
+                and "video-embed.js" in item.get("text", "")
+                and "createElement" not in item.get("text", "")
+            )
+        ]
         has_video_embed = any(
             "video-embed.js" in str(item) for item in config["format"]["html"]["include-after-body"]
         )

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -40006,7 +40006,7 @@ def test_update_quarto_config_video_embed_not_duplicated():
 
 
 def test_update_quarto_config_video_embed_script_tag_format():
-    """video-embed.js is included as a proper script tag in include-after-body."""
+    """video-embed.js uses the quarto:offset loader so nested pages resolve it."""
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         docs, quarto_yml = _make_uqc_docs(tmp_dir)
@@ -40024,7 +40024,12 @@ def test_update_quarto_config_video_embed_script_tag_format():
         ]
 
         assert len(video_entries) == 1
-        assert video_entries[0]["text"] == '<script src="video-embed.js"></script>'
+        # Robust path resolution: derive the site root from quarto:offset rather
+        # than a bare relative src= that 404s on nested pages (issue #212).
+        text = video_entries[0]["text"]
+        assert "quarto:offset" in text
+        assert "video-embed.js" in text
+        assert 'src="video-embed.js"' not in text
 
 
 def test_prepare_build_directory_copies_video_embed_js():
@@ -40726,6 +40731,32 @@ def test_on_this_page_script_tag_uses_quarto_offset():
 
         assert len(otp_entries) == 1
         assert "quarto:offset" in str(otp_entries[0])
+
+
+def test_color_swatch_script_tag_uses_quarto_offset():
+    """The color-swatch include-after-body entry uses the quarto:offset pattern.
+
+    The previous loader derived the path from canonical/location.href by stripping
+    two path segments, which produced wrong paths (404s) on nested pages such as
+    /docs/examples/foo.html (issue #212). quarto:offset resolves the site root
+    correctly at any depth.
+    """
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        docs, quarto_yml = _make_uqc_docs(tmp_dir)
+
+        docs._update_quarto_config()
+
+        with open(quarto_yml) as f:
+            result = read_yaml(f)
+
+        after_body = result["format"]["html"]["include-after-body"]
+        swatch_entries = [item for item in after_body if "color-swatch.js" in str(item)]
+
+        assert len(swatch_entries) == 1
+        text = str(swatch_entries[0])
+        assert "quarto:offset" in text
+        assert "canonical" not in text
 
 
 def test_on_this_page_not_duplicated():


### PR DESCRIPTION
This PR fixes the case where some Great Docs helper scripts are emitted with paths that work on root-level pages but 404 on nested pages (e.g., `video-embed.js`).

Fixes: https://github.com/posit-dev/great-docs/issues/212