### PR TITLE
Fix preview hangs safari browser

### DIFF
--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -15794,7 +15794,6 @@ body-classes: "gd-homepage"
         """
         import functools
         import http.server
-        import socketserver
         import sys
         import threading
         import webbrowser
@@ -15810,10 +15809,15 @@ body-classes: "gd-homepage"
             http.server.SimpleHTTPRequestHandler,
             directory=str(site_path),
         )
-        socketserver.TCPServer.allow_reuse_address = True
+        # Reap half-open sockets (e.g. Safari's idle speculative connections) so a
+        # stalled connection cannot tie up a worker thread indefinitely.
+        http.server.SimpleHTTPRequestHandler.timeout = 10
+        http.server.ThreadingHTTPServer.allow_reuse_address = True
 
         try:
-            httpd = socketserver.TCPServer(("", port), handler)
+            # Use a threading server so one idle/speculative connection (notably from
+            # Safari) cannot block the whole preview. See issue #219.
+            httpd = http.server.ThreadingHTTPServer(("", port), handler)
         except OSError:
             print(f"❌ Port {port} is already in use. Try a different port.")
             sys.exit(1)
@@ -15956,7 +15960,6 @@ body-classes: "gd-homepage"
         """
         import functools
         import http.server
-        import socketserver
         import sys
         import threading
         import webbrowser
@@ -15979,11 +15982,16 @@ body-classes: "gd-homepage"
             http.server.SimpleHTTPRequestHandler,
             directory=str(site_path),
         )
+        # Reap half-open sockets (e.g. Safari's idle speculative connections) so a
+        # stalled connection cannot tie up a worker thread indefinitely.
+        http.server.SimpleHTTPRequestHandler.timeout = 10
         # Allow quick restart after Ctrl-C
-        socketserver.TCPServer.allow_reuse_address = True
+        http.server.ThreadingHTTPServer.allow_reuse_address = True
 
         try:
-            httpd = socketserver.TCPServer(("", port), handler)
+            # Use a threading server so one idle/speculative connection (notably from
+            # Safari) cannot block the whole preview. See issue #219.
+            httpd = http.server.ThreadingHTTPServer(("", port), handler)
         except OSError:
             print(f"❌ Port {port} is already in use. Try a different port.")
             sys.exit(1)

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -25569,7 +25569,10 @@ def test_preview_port_in_use():
         (site_dir / "index.html").write_text("<html></html>", encoding="utf-8")
 
         with (
-            patch("socketserver.TCPServer", side_effect=OSError("Address in use")),
+            patch(
+                "http.server.ThreadingHTTPServer",
+                side_effect=OSError("Address in use"),
+            ),
             pytest.raises(SystemExit),
         ):
             docs.preview(port=9999)
@@ -25577,7 +25580,7 @@ def test_preview_port_in_use():
 
 def test_preview_serves_and_stops():
     """Test preview() starts server and handles KeyboardInterrupt."""
-    import http.server  # noqa: F401  # ensure module is loaded before patching socketserver
+    import http.server  # noqa: F401  # ensure module is loaded before patching the server
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         docs = GreatDocs(project_path=tmp_dir)
@@ -25591,7 +25594,7 @@ def test_preview_serves_and_stops():
         mock_timer = MagicMock()
 
         with (
-            patch("socketserver.TCPServer", return_value=mock_server),
+            patch("http.server.ThreadingHTTPServer", return_value=mock_server),
             patch("threading.Timer", return_value=mock_timer),
             patch("webbrowser.open"),
         ):


### PR DESCRIPTION
This PR improves the performance of 'great-docs preview' on the Safari browser. Previously, that browser would, with the single-threaded server, be blocked reading from it and other requests wouldn't be served until Safari's connection timeout expired. In my testing of this new configuration, there appears to be much better performance than previously.

Addresses: https://github.com/posit-dev/great-docs/issues/219