### PR TITLE
fix: have metadata margin sidebar placed after the body

### DIFF
--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -5747,9 +5747,15 @@ class GreatDocs:
 
 """
 
-        # Reassemble with margin content inserted after frontmatter
+        # Reassemble with the metadata margin sidebar placed AFTER the body.
+        # On desktop `.gd-meta-sidebar` is absolutely positioned into the right
+        # margin (see great-docs.scss), so its position in the DOM is
+        # irrelevant there. On mobile it falls back into normal document flow;
+        # emitting it after the body keeps the hero/content first rather than
+        # pushing it below the metadata panel (links/developers/etc.). See
+        # https://github.com/posit-dev/great-docs/issues/220.
         if margin_content:
-            blended_content = f"{frontmatter_block}\n{hero_block}::: {{.gd-meta-sidebar}}\n{margin_content}\n:::\n\n{body}"
+            blended_content = f"{frontmatter_block}\n{hero_block}{body}\n\n::: {{.gd-meta-sidebar}}\n{margin_content}\n:::\n"
         else:
             blended_content = f"{frontmatter_block}\n{hero_block}{body}"
 


### PR DESCRIPTION
On blended homepage mode (`homepage: user_guide`), the `.gd-meta-sidebar` panel (Links / Developers / etc.) was rendering above the page content on mobile. Turns out that the panel was emitted in the DOM before the body. On desktop this is invisible because the panel is position: absolute (pinned to the right margin), but on mobile that absolute positioning is dropped and the panel falls back into normal flow.

The fix here in this PR moves the `.gd-meta-sidebar` block after the body in the generated `index.qmd`. Desktop layout is unchanged (absolute positioning is order-independent); on mobile the content now comes first, with the metadata panel below it.

Addresses: #220