### PR TITLE
fix: tags on custom pages

### DIFF
--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -1943,6 +1943,32 @@ class GreatDocs:
     # Page Tags Methods
     # =========================================================================
 
+    def _section_build_dir(self, section_cfg: dict[str, object]) -> Path | None:
+        """
+        Resolve the build-time destination directory for a custom section.
+
+        Mirrors the slug logic in `_process_sections` so that tag and status
+        scanning look at the same directory the section files were copied into.
+        The build directory is derived from `section_cfg["dir"]` (not the title),
+        which is what `_process_sections` uses as the copy destination.
+
+        Parameters
+        ----------
+        section_cfg
+            A single entry from the `sections` config.
+
+        Returns
+        -------
+        Path | None
+            The build directory under `project_path`, or `None` if the section
+            has no `dir`.
+        """
+        src_dir = section_cfg.get("dir")
+        if not src_dir or not isinstance(src_dir, str):
+            return None
+        slug = src_dir.replace("_", "-").replace(" ", "-").lower()
+        return self.project_path / slug
+
     def _collect_page_tags(self) -> dict[str, list[dict[str, str]]]:
         """
         Scan all built .qmd files for tags in frontmatter.
@@ -1972,9 +1998,12 @@ class GreatDocs:
         # Also scan custom sections (skip if already covered above)
         for section_cfg in self._config.sections:
             title = section_cfg.get("title", "")
-            slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-") if title else ""
-            section_dir = self.project_path / slug
-            if section_dir.is_dir() and section_dir.resolve() not in seen_dirs:
+            section_dir = self._section_build_dir(section_cfg)
+            if (
+                section_dir is not None
+                and section_dir.is_dir()
+                and section_dir.resolve() not in seen_dirs
+            ):
                 scan_dirs.append((section_dir, title))
                 seen_dirs.add(section_dir.resolve())
 
@@ -2213,15 +2242,15 @@ class GreatDocs:
         # and per-page tag_location overrides from frontmatter
         # Re-scan tagged directories
         page_tag_locations: dict[str, str] = {}
-        scan_dir_names = ["user-guide", "recipes"]
+        scan_dirs: list[Path] = [self.project_path / "user-guide", self.project_path / "recipes"]
+        seen_dirs: set[Path] = {d.resolve() for d in scan_dirs}
         # Include custom section directories
         for section_cfg in self._config.sections:
-            title = section_cfg.get("title", "")
-            slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-") if title else ""
-            if slug and slug not in scan_dir_names:
-                scan_dir_names.append(slug)
-        for scan_dir_name in scan_dir_names:
-            scan_dir = self.project_path / scan_dir_name
+            section_dir = self._section_build_dir(section_cfg)
+            if section_dir is not None and section_dir.resolve() not in seen_dirs:
+                scan_dirs.append(section_dir)
+                seen_dirs.add(section_dir.resolve())
+        for scan_dir in scan_dirs:
             if not scan_dir.is_dir():
                 continue
             for qmd_file in sorted(scan_dir.rglob("*.qmd")):
@@ -2497,10 +2526,12 @@ class GreatDocs:
                 scan_dirs.append(d)
                 seen_dirs.add(d.resolve())
         for section_cfg in self._config.sections:
-            title = section_cfg.get("title", "")
-            slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-") if title else ""
-            section_dir = self.project_path / slug
-            if section_dir.is_dir() and section_dir.resolve() not in seen_dirs:
+            section_dir = self._section_build_dir(section_cfg)
+            if (
+                section_dir is not None
+                and section_dir.is_dir()
+                and section_dir.resolve() not in seen_dirs
+            ):
                 scan_dirs.append(section_dir)
                 seen_dirs.add(section_dir.resolve())
 
@@ -2709,7 +2740,9 @@ class GreatDocs:
                 print(f"   ⚠️  Section '{title}' directory '{src_dir}' has no .qmd/.md files")
                 continue
 
-            # Determine the slug for the build directory (lowercase, hyphenated)
+            # Determine the slug for the build directory (lowercase, hyphenated).
+            # `_section_build_dir` mirrors this formula so tag/status scanning
+            # resolves the same destination directory.
             slug = src_dir.replace("_", "-").replace(" ", "-").lower()
             dest_dir = self.project_path / slug
             dest_dir.mkdir(parents=True, exist_ok=True)

--- a/test-packages/synthetic/catalog.py
+++ b/test-packages/synthetic/catalog.py
@@ -388,6 +388,8 @@ ALL_PACKAGES: list[str] = [
     "gdtest_lightbox",  # 193
     # 194: Hero name suppressed (hero.name: false) — regression for #218
     "gdtest_hero_no_name",  # 194
+    # 195: Tags in a custom section with a nested dir — regression for #213
+    "gdtest_sec_nested_tags",  # 195
 ]
 
 
@@ -612,6 +614,7 @@ DIMENSIONS: dict[str, dict[str, str]] = {
     # Page tags axes
     "T1": {"axis": "tags", "label": "Page tags with hierarchy + shadow"},
     "T3": {"axis": "tags", "label": "Tag location top vs. bottom with per-page overrides"},
+    "T4": {"axis": "tags", "label": "Tags in a custom section with a nested dir"},
     # Page status axes
     "T2": {"axis": "status", "label": "Page status badges in sidebar + pages"},
 }
@@ -2169,6 +2172,15 @@ PACKAGE_DESCRIPTIONS: dict[str, str] = {
         "removes the name entirely instead of falling back to the package "
         "or display name, while the hero still renders the overridden logo. "
         "Regression coverage for issue #218."
+    ),
+    "gdtest_sec_nested_tags": (
+        "A custom section titled 'Examples' published from a nested directory "
+        "(dir: docs/examples) whose path does not match the title-derived slug. "
+        "Two of its pages carry flat and hierarchical tags. Tests that page tag "
+        "scanning resolves the same build directory used to copy the section "
+        "(great-docs/docs/examples/) rather than the wrong title-slug path, so "
+        "tagged pages in the section appear in tags/index.qmd and in the "
+        "client-side tag data. Regression coverage for issue #213."
     ),
 }
 

--- a/test-packages/synthetic/specs/gdtest_sec_nested_tags.py
+++ b/test-packages/synthetic/specs/gdtest_sec_nested_tags.py
@@ -1,0 +1,132 @@
+"""
+gdtest_sec_nested_tags — Page tags inside a custom section with a nested dir.
+
+Dimensions: T4
+Focus: Regression for #213. A custom section whose ``dir`` is a nested path
+       (``docs/examples``) that does NOT match the title-derived slug
+       (``examples``). Tagged pages live under the build path
+       ``great-docs/docs/examples/`` and must be discovered by tag scanning,
+       which previously looked at the wrong title-slug directory.
+"""
+
+SPEC = {
+    "name": "gdtest_sec_nested_tags",
+    "description": "Page tags in a custom section with a nested dir (#213)",
+    "dimensions": ["T4"],
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-sec-nested-tags",
+            "version": "0.1.0",
+            "description": "Tags in a custom section published from a nested dir",
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    },
+    "config": {
+        "display_name": "Nested Section Tags Demo",
+        # The section dir is nested and intentionally differs from the
+        # title-derived slug ("Examples" -> "examples"). The build copies it to
+        # great-docs/docs/examples/, which is where tag scanning must look.
+        "sections": [
+            {"title": "Examples", "dir": "docs/examples"},
+        ],
+        "tags": {
+            "enabled": True,
+            "index_page": True,
+            "show_on_pages": True,
+            "hierarchical": True,
+            "icons": {
+                "Python": "code",
+                "Tutorial": "book-open",
+            },
+        },
+    },
+    "files": {
+        "gdtest_sec_nested_tags/__init__.py": '''\
+            """A test package for tags in a nested custom section."""
+
+            __version__ = "0.1.0"
+            __all__ = ["transform", "validate"]
+
+
+            def transform(data: list) -> list:
+                """
+                Transform a list of data items.
+
+                Parameters
+                ----------
+                data
+                    The input data to transform.
+
+                Returns
+                -------
+                list
+                    The transformed data.
+                """
+                return data
+
+
+            def validate(data: list) -> bool:
+                """
+                Validate a list of data items.
+
+                Parameters
+                ----------
+                data
+                    The input data to validate.
+
+                Returns
+                -------
+                bool
+                    True if the data is valid.
+                """
+                return True
+        ''',
+        # Tagged pages under a NESTED section dir. With #213 unfixed, tag
+        # scanning looks at great-docs/examples/ and finds nothing here.
+        "docs/examples/basic-usage.qmd": """\
+            ---
+            title: Basic Usage
+            tags: [Tutorial, Python]
+            ---
+
+            ## Getting Started
+
+            This example shows basic usage of the library and carries tags.
+        """,
+        "docs/examples/advanced-patterns.qmd": """\
+            ---
+            title: Advanced Patterns
+            tags: [Python/Advanced, Tutorial]
+            ---
+
+            ## Advanced Usage
+
+            This example demonstrates advanced patterns and a hierarchical tag.
+        """,
+        "docs/examples/no-tags.qmd": """\
+            ---
+            title: Untagged Example
+            ---
+
+            This page has no tags and should not appear in the tag index.
+        """,
+        "README.md": """\
+            # gdtest-sec-nested-tags
+
+            A test package demonstrating page tags inside a custom section
+            published from a nested directory (`docs/examples`).
+        """,
+    },
+    "expected": {
+        "detected_name": "gdtest-sec-nested-tags",
+        "detected_module": "gdtest_sec_nested_tags",
+        "detected_parser": "numpy",
+        "export_names": ["transform", "validate"],
+        "num_exports": 2,
+        "section_titles": ["Functions"],
+        "coverage_exclude": ['nodoc', 'bigcl', 'ug', 'supp', 'sechdg', 'sbsec', 'hdg'],
+    },
+}

--- a/tests/test_page_status.py
+++ b/tests/test_page_status.py
@@ -194,6 +194,19 @@ class TestCollectPageStatuses:
 
         assert result["tutorials/first.qmd"] == "new"
 
+    def test_custom_section_nested_dir_scanned(self, tmp_path: Path):
+        """A custom section with a nested `dir` is scanned at its build path, not its title slug."""
+        gd = _bootstrap_project(
+            tmp_path,
+            "page_status:\n  enabled: true\nsections:\n  - title: Examples\n    dir: docs/examples\n",
+        )
+        section_dir = gd.project_path / "docs" / "examples"
+        _make_qmd(section_dir / "ex.qmd", "Example", status="new")
+
+        result = gd._collect_page_statuses()
+
+        assert result["docs/examples/ex.qmd"] == "new"
+
 
 # ── JSON Generation Tests ───────────────────────────────────────────────────
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -214,6 +214,36 @@ class TestCollectPageTags:
             "overlaps the built-in recipes directory"
         )
 
+    def test_custom_section_nested_dir(self, tmp_path: Path):
+        """A custom section with a nested `dir` is scanned at its build path, not its title slug."""
+        gd = _bootstrap_project(
+            tmp_path,
+            "tags:\n  enabled: true\nsections:\n  - title: Examples\n    dir: docs/examples\n",
+        )
+        # _process_sections copies to project_path / "docs/examples" (slug from dir)
+        section_dir = gd.project_path / "docs" / "examples"
+        _make_qmd(section_dir / "example1.qmd", "Example One", tags=["Demo"])
+
+        result = gd._collect_page_tags()
+
+        assert "Demo" in result
+        assert len(result["Demo"]) == 1
+        assert result["Demo"][0]["href"] == "docs/examples/example1.qmd"
+        assert result["Demo"][0]["section"] == "Examples"
+
+    def test_section_build_dir_uses_dir_not_title(self, tmp_path: Path):
+        """`_section_build_dir` derives the path from `dir`, with the title ignored."""
+        gd = _bootstrap_project(tmp_path)
+        assert gd._section_build_dir({"title": "Examples", "dir": "docs/examples"}) == (
+            gd.project_path / "docs" / "examples"
+        )
+        # Underscores and spaces are normalized to hyphens and lowercased
+        assert gd._section_build_dir({"title": "Foo", "dir": "My_Cool Dir"}) == (
+            gd.project_path / "my-cool-dir"
+        )
+        # No `dir` → None
+        assert gd._section_build_dir({"title": "Examples"}) is None
+
 
 # ── Tag Hierarchy Tests ──────────────────────────────────────────────────────
 
@@ -409,6 +439,24 @@ class TestGenerateTagsJson:
 
         data = json.loads((gd.project_path / "_tags.json").read_text())
         assert "user-guide/page.qmd" not in data["page_tag_locations"]
+
+    def test_nested_section_rescan_picks_up_tag_location(self, tmp_path: Path):
+        """The re-scan in `_generate_tags_json` uses the section build dir, not the title slug."""
+        gd = _bootstrap_project(
+            tmp_path,
+            "tags:\n  enabled: true\nsections:\n  - title: Examples\n    dir: docs/examples\n",
+        )
+        section_dir = gd.project_path / "docs" / "examples"
+        _make_qmd(
+            section_dir / "ex.qmd", "Example", tags=["Demo"], extra="tag-location: bottom"
+        )
+
+        tag_index = gd._collect_page_tags()
+        gd._generate_tags_json(tag_index)
+
+        data = json.loads((gd.project_path / "_tags.json").read_text())
+        assert "docs/examples/ex.qmd" in data["page_tags"]
+        assert data["page_tag_locations"]["docs/examples/ex.qmd"] == "bottom"
 
 
 # ── Tag Slug Tests ───────────────────────────────────────────────────────────


### PR DESCRIPTION
This PR fixes an issue where Page Tags (and page status) failed to discover tagged pages in custom sections whose `dir` is a nested path that doesn't match the title-derived slug.

Fixes: #213 