### PR TITLE
fix: copying section files

### DIFF
--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -2869,7 +2869,18 @@ class GreatDocs:
 
             # Strip numeric prefix from filename (e.g., 01-intro.qmd -> intro.qmd)
             clean_name = self._strip_numeric_prefix(rel.name)
-            dest_file = dest_dir / rel.parent / clean_name
+
+            # Strip numeric prefixes from subdirectory parts too (e.g.,
+            # 02-topic-b/page.qmd -> topic-b/page.qmd), mirroring the user-guide
+            # copy. This keeps on-disk paths in sync with the link rewriting done
+            # by _fix_numeric_prefix_links, which strips prefixes from every path
+            # component.
+            clean_parent = (
+                Path(*[self._strip_numeric_prefix(p) for p in rel.parent.parts])
+                if rel.parent.parts
+                else rel.parent
+            )
+            dest_file = dest_dir / clean_parent / clean_name
 
             # Ensure subdirectories exist
             dest_file.parent.mkdir(parents=True, exist_ok=True)
@@ -2909,8 +2920,8 @@ class GreatDocs:
 
             copied.append(
                 {
-                    "filename": str(rel.parent / clean_name)
-                    if rel.parent != Path(".")
+                    "filename": str(clean_parent / clean_name)
+                    if clean_parent != Path(".")
                     else clean_name,
                     "title": title,
                     "description": description,

--- a/test-packages/synthetic/catalog.py
+++ b/test-packages/synthetic/catalog.py
@@ -386,10 +386,12 @@ ALL_PACKAGES: list[str] = [
     "gdtest_termshow",  # 192
     # 193: Lightbox extension showcase
     "gdtest_lightbox",  # 193
-    # 194: Hero name suppressed (hero.name: false) — regression for #218
+    # 194: Hero name suppressed (hero.name: false)
     "gdtest_hero_no_name",  # 194
-    # 195: Tags in a custom section with a nested dir — regression for #213
+    # 195: Tags in a custom section with a nested dir
     "gdtest_sec_nested_tags",  # 195
+    # 196: Cross-refs into numeric-prefix section subdirs
+    "gdtest_sec_xref_subdirs",  # 196
 ]
 
 
@@ -576,6 +578,7 @@ DIMENSIONS: dict[str, dict[str, str]] = {
     "N9": {"axis": "sections", "label": "Single-page sidebar hide"},
     "N10": {"axis": "sections", "label": "Section index hero cards"},
     "N11": {"axis": "sections", "label": "dir_titles + numeric prefix subdirs"},
+    "N12": {"axis": "sections", "label": "Cross-refs into numeric-prefix subdirs"},
     # Reference axes
     "P1": {"axis": "reference", "label": "Explicit reference"},
     "P2": {"axis": "reference", "label": "members: false"},
@@ -2165,13 +2168,12 @@ PACKAGE_DESCRIPTIONS: dict[str, str] = {
         "explicit dark= attribute), gallery grouping with filmstrip navigation, "
         "captions and credits, .nolightbox opt-out, and deep-linking."
     ),
-    # ── 194: Hero name suppressed (regression for #218) ──────────────
+    # ── 194: Hero name suppressed ────────────────────────────────────
     "gdtest_hero_no_name": (
         "Hero with the name suppressed via hero.name: false plus a "
         "hero-specific logo override. Tests that setting hero.name: false "
         "removes the name entirely instead of falling back to the package "
-        "or display name, while the hero still renders the overridden logo. "
-        "Regression coverage for issue #218."
+        "or display name, while the hero still renders the overridden logo."
     ),
     "gdtest_sec_nested_tags": (
         "A custom section titled 'Examples' published from a nested directory "
@@ -2180,7 +2182,17 @@ PACKAGE_DESCRIPTIONS: dict[str, str] = {
         "scanning resolves the same build directory used to copy the section "
         "(great-docs/docs/examples/) rather than the wrong title-slug path, so "
         "tagged pages in the section appear in tags/index.qmd and in the "
-        "client-side tag data. Regression coverage for issue #213."
+        "client-side tag data."
+    ),
+    "gdtest_sec_xref_subdirs": (
+        "A custom 'Examples' section whose pages live in numerically-prefixed "
+        "subdirectories (01-topic-a/, 02-topic-b/) and cross-reference one "
+        "another, plus an auto-discovery user-guide page that links into the "
+        "section. Link rewriting strips numeric prefixes from every path "
+        "component, so the section copy must strip prefixes from subdirectory "
+        "names too — otherwise files land at examples/02-topic-b/ while links "
+        "point at examples/topic-b/, producing dead cross-references. Verifies "
+        "the on-disk section paths and the rewritten links agree."
     ),
 }
 

--- a/test-packages/synthetic/specs/gdtest_sec_xref_subdirs.py
+++ b/test-packages/synthetic/specs/gdtest_sec_xref_subdirs.py
@@ -1,0 +1,135 @@
+"""
+gdtest_sec_xref_subdirs — Cross-references into numeric-prefix section subdirs.
+
+Dimensions: N12
+Focus: Regression for #215. A custom section whose pages live in
+       numerically-prefixed subdirectories (``01-topic-a/``, ``02-topic-b/``)
+       and contain cross-references to one another, plus a user-guide page that
+       links into the section. ``_fix_numeric_prefix_links`` rewrites those
+       links to strip prefixes from every path component (``02-topic-b`` ->
+       ``topic-b``), so the section copy must also strip prefixes from
+       subdirectory names — otherwise the on-disk file lands at
+       ``examples/02-topic-b/widget_demo.qmd`` while the rewritten link points at
+       ``examples/topic-b/widget_demo.qmd`` and resolves to a dead link.
+"""
+
+SPEC = {
+    "name": "gdtest_sec_xref_subdirs",
+    "description": "Cross-refs into numeric-prefix section subdirs (#215)",
+    "dimensions": ["N12"],
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-sec-xref-subdirs",
+            "version": "0.1.0",
+            "description": "Cross-references into numeric-prefix custom section subdirectories",
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    },
+    "config": {
+        "display_name": "Section Cross-Ref Subdirs Demo",
+        # Custom section whose pages live in numerically-prefixed subdirectories.
+        "sections": [
+            {"title": "Examples", "dir": "examples", "index": True},
+        ],
+        # Auto-discovery user guide (a string, not a list) so numeric prefixes
+        # are stripped and intra-doc links are rewritten.
+        "user_guide": "user_guide",
+    },
+    "files": {
+        "gdtest_sec_xref_subdirs/__init__.py": '''\
+            """A test package for cross-references into prefixed section subdirs."""
+
+            __version__ = "0.1.0"
+            __all__ = ["render", "compose"]
+
+
+            def render(template: str) -> str:
+                """
+                Render a template string.
+
+                Parameters
+                ----------
+                template
+                    The template to render.
+
+                Returns
+                -------
+                str
+                    The rendered output.
+                """
+                return template
+
+
+            def compose(parts: list) -> str:
+                """
+                Compose parts into a single string.
+
+                Parameters
+                ----------
+                parts
+                    The parts to compose.
+
+                Returns
+                -------
+                str
+                    The composed result.
+                """
+                return "".join(parts)
+        ''',
+        # Section page in a prefixed subdir that links to a sibling page in a
+        # DIFFERENT prefixed subdir. The link uses the authored (prefixed) path.
+        "examples/01-topic-a/intro.qmd": """\
+            ---
+            title: Intro
+            description: Introduction to topic A.
+            ---
+
+            ## Introduction
+
+            This is topic A. For a hands-on demo, see the
+            [widget demo](../02-topic-b/widget_demo.qmd) in topic B.
+        """,
+        "examples/02-topic-b/widget_demo.qmd": """\
+            ---
+            title: Widget Demo
+            description: A hands-on widget demonstration.
+            ---
+
+            ## Widget Demo
+
+            This is topic B. Return to the [intro](../01-topic-a/intro.qmd) for
+            background.
+        """,
+        # User-guide page (auto-discovery) that links INTO the prefixed section
+        # subdir. Numeric prefixes are stripped from the user-guide filename and
+        # the link is rewritten to the unprefixed section path.
+        "user_guide/10-concepts.qmd": """\
+            ---
+            title: Concepts
+            ---
+
+            ## Concepts
+
+            For a concrete example, see the
+            [widget demo](../examples/02-topic-b/widget_demo.qmd).
+        """,
+        "README.md": """\
+            # gdtest-sec-xref-subdirs
+
+            A test package demonstrating cross-references into numerically
+            prefixed custom section subdirectories (`examples/02-topic-b/`).
+        """,
+    },
+    "expected": {
+        "detected_name": "gdtest-sec-xref-subdirs",
+        "detected_module": "gdtest_sec_xref_subdirs",
+        "detected_parser": "numpy",
+        "export_names": ["render", "compose"],
+        "num_exports": 2,
+        "section_titles": ["Functions"],
+        "coverage_exclude": ['nodoc', 'bigcl', 'ug', 'supp', 'sechdg', 'sbsec', 'hdg'],
+    },
+}

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -4851,6 +4851,50 @@ def test_process_sections_discovers_and_copies():
         assert "examples" in sidebar_ids
 
 
+def test_copy_section_files_strips_numeric_directory_prefixes():
+    """Section files in numerically-prefixed subdirs are copied to unprefixed paths."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        source_dir = project_path / "examples"
+        topic_a = source_dir / "01-topic-a"
+        topic_b = source_dir / "02-topic-b"
+        topic_a.mkdir(parents=True)
+        topic_b.mkdir(parents=True)
+
+        intro = topic_a / "intro.qmd"
+        intro.write_text(
+            "---\ntitle: Intro\n---\n\nSee [demo](../02-topic-b/widget_demo.qmd) for details.\n"
+        )
+        widget = topic_b / "widget_demo.qmd"
+        widget.write_text("---\ntitle: Widget Demo\n---\n\nDemo content\n")
+
+        dest_dir = project_path / "great-docs" / "examples"
+        dest_dir.mkdir(parents=True)
+
+        docs = GreatDocs(project_path=tmp_dir)
+        copied = docs._copy_section_files([intro, widget], source_dir, dest_dir)
+
+        # Files land at unprefixed directory paths
+        assert (dest_dir / "topic-a" / "intro.qmd").exists()
+        assert (dest_dir / "topic-b" / "widget_demo.qmd").exists()
+
+        # The prefixed directory paths must NOT exist
+        assert not (dest_dir / "01-topic-a").exists()
+        assert not (dest_dir / "02-topic-b").exists()
+
+        # Reported filenames use the cleaned directory parts
+        filenames = {entry["filename"] for entry in copied}
+
+        assert "topic-a/intro.qmd" in filenames
+        assert "topic-b/widget_demo.qmd" in filenames
+
+        # The cross-reference was rewritten to the unprefixed (and now-correct) path
+        intro_content = (dest_dir / "topic-a" / "intro.qmd").read_text()
+
+        assert "../topic-b/widget_demo.qmd" in intro_content
+        assert "02-topic-b" not in intro_content
+
+
 def test_process_sections_no_index_by_default():
     """Test that sections do NOT generate an index page by default."""
     with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
This PR fixes the issue concerning the copying of custom `sections:` content into the build tree. `_copy_section_files` stripped numeric ordering prefixes from filenames but not from subdirectory names, so a page authored at `examples/02-topic-b/widget_demo.qmd` landed on disk at that same prefixed path. Meanwhile `_fix_numeric_prefix_links` rewrites relative `.qmd` cross-references by stripping prefixes from every path component, leaving links that point at `examples/topic-b/widget_demo.qmd`.

Fixes: #215 