### PR TITLE
enh: header on mobile

### DIFF
--- a/great_docs/assets/great-docs.scss
+++ b/great_docs/assets/great-docs.scss
@@ -1559,23 +1559,75 @@ body.quarto-light .navbar .navbar-toggler-icon {
     flex-wrap: nowrap;
 }
 
-/* Compact widget tray on narrow phones (iPhone portrait) */
-@media (max-width: 430px) {
+/* ----------------------------------------------------------------------
+   Mobile navbar: two centered rows
+   ----------------------------------------------------------------------
+   Below the lg breakpoint Quarto lays the navbar out as a single flex row
+   in which the hamburger toggle pushes the brand around, making it
+   impossible to truly center the logo/title. We force a deliberate
+   two-row layout instead:
+
+     Row 1 — the brand/logo, horizontally centered. The hamburger toggle is
+             taken out of flow (absolutely pinned to the left) so its width
+             never shifts the brand off-center.
+     Row 2 — the widget tray (#gd-navbar-widgets: theme toggle, search,
+             GitHub, version) centered as a group.
+   -------------------------------------------------------------------- */
+@media (max-width: 991.98px) {
     .navbar .container-fluid {
+        display: flex;
         flex-wrap: wrap;
+        align-items: center;
+        justify-content: center;
+        position: relative;
+        row-gap: 8px;
+        padding-top: 8px;
+        padding-bottom: 8px;
     }
-    .navbar-brand.navbar-brand-logo {
-        padding-right: 100%;
+
+    /* Hamburger pinned left and removed from flow so it can't shift the
+       brand off-center. */
+    .navbar .navbar-toggler {
+        position: absolute;
+        left: 10px;
+        top: 12px;
+        margin: 0;
+        z-index: 3;
     }
-    .quarto-navbar-tools {
+
+    /* Row 1: centered brand/logo */
+    .navbar .navbar-brand-container.mx-auto {
+        order: 1;
         flex: 0 0 100%;
+        margin: 0;
+        display: flex;
         justify-content: center;
-        order: 99;
-        padding-top: 4px;
-        padding-bottom: 4px;
     }
-    #gd-navbar-widgets {
+    .navbar .navbar-brand-container.mx-auto .navbar-brand {
+        margin: 0;
+        padding-right: 0;
+    }
+
+    /* Row 2: centered widget tray */
+    .navbar .quarto-navbar-tools {
+        order: 2;
+        flex: 0 0 100%;
+        display: flex;
         justify-content: center;
+        margin: 0;
+        padding: 0;
+    }
+    .navbar #gd-navbar-widgets {
+        justify-content: center;
+        flex: 0 1 auto;
+        width: auto;
+        margin: 0;
+    }
+
+    /* If the collapse menu is ever expanded it drops to its own row */
+    .navbar #navbarCollapse {
+        order: 3;
+        flex: 0 0 100%;
     }
 }
 

--- a/great_docs/assets/great-docs.scss
+++ b/great_docs/assets/great-docs.scss
@@ -1574,23 +1574,33 @@ body.quarto-light .navbar .navbar-toggler-icon {
              GitHub, version) centered as a group.
    -------------------------------------------------------------------- */
 @media (max-width: 991.98px) {
+    /* Drop the navbar's own vertical padding (Bootstrap defaults to a tall
+       ~17px top/bottom) so the two rows sit snug against the header edges
+       and page content rides higher on load. */
+    .navbar {
+        padding-top: 0;
+        padding-bottom: 0;
+    }
+
     .navbar .container-fluid {
         display: flex;
         flex-wrap: wrap;
         align-items: center;
         justify-content: center;
         position: relative;
-        row-gap: 8px;
-        padding-top: 8px;
-        padding-bottom: 8px;
+        row-gap: 6px;
+        padding-top: 6px;
+        padding-bottom: 6px;
     }
 
     /* Hamburger pinned left and removed from flow so it can't shift the
-       brand off-center. */
+       brand off-center. `top` is the midpoint between a short text title
+       (~44px row) and a max-height logo (~56px row) so it stays vertically
+       centered against the brand in both cases. */
     .navbar .navbar-toggler {
         position: absolute;
         left: 10px;
-        top: 12px;
+        top: 15px;
         margin: 0;
         z-index: 3;
     }
@@ -1602,10 +1612,41 @@ body.quarto-light .navbar .navbar-toggler-icon {
         margin: 0;
         display: flex;
         justify-content: center;
+        /* Quarto reserves `calc(100% - 115px)` here for the toggler/tools in
+           its single-row layout. Our brand has its own full-width row, so
+           reclaim that space (the title's own max-width below still keeps it
+           clear of the absolutely-positioned hamburger). */
+        max-width: 100%;
     }
     .navbar .navbar-brand-container.mx-auto .navbar-brand {
         margin: 0;
+        /* Drop the brand link's own vertical padding: with the title set to
+           `display: block` below its pill padding now counts toward layout
+           height, so this keeps the header as tight as the logo/short-name
+           cases (no extra ~11px). */
+        padding-top: 0;
+        padding-bottom: 0;
         padding-right: 0;
+        max-width: 100%;
+        min-width: 0;
+    }
+
+    /* Long text display names: navbar-widgets.js first steps the font size
+       down to fit; this is the width cap it fits against and the final
+       ellipsis fallback when even the smallest step overflows. `display:
+       block` keeps the truncation inside the title pill (clipping at the
+       brand link instead would slice the pill's border). The 132px cap
+       reserves ~66px each side so the (centered) title clears the
+       absolutely-positioned hamburger button (~59px wide incl. padding).
+       The "…" is a visible nudge that a shorter `display_name` belongs in
+       great-docs.yml. Logo brands have no .navbar-title, so they are
+       unaffected. */
+    .navbar .navbar-title {
+        display: block;
+        max-width: calc(100vw - 132px);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 
     /* Row 2: centered widget tray */

--- a/great_docs/assets/navbar-widgets.js
+++ b/great_docs/assets/navbar-widgets.js
@@ -194,3 +194,62 @@
     attach();
   }
 })();
+
+/**
+ * Responsive mobile brand-title sizing.
+ *
+ * On mobile (< 992px) a text display name shares one centered row. Rather
+ * than truncate as soon as it is a little long, we step the font size down
+ * through a few set sizes until the name fits the available width, and only
+ * fall back to the CSS ellipsis (great-docs.scss) when even the smallest
+ * step overflows. Short names keep the full default size; logo brands have
+ * no .navbar-title and are left untouched. Desktop always uses the default.
+ */
+(function () {
+  "use strict";
+
+  var mql = window.matchMedia("(max-width: 991.98px)");
+  // Largest → smallest; the floor (0.68) keeps the name readable before the
+  // ellipsis takes over.
+  var RATIOS = [1, 0.92, 0.84, 0.76, 0.68];
+
+  function fit() {
+    var title = document.querySelector(".navbar-title");
+    if (!title) return;
+
+    title.style.fontSize = ""; // reset to the CSS default
+    if (!mql.matches) return; // desktop — keep the default size
+    if (title.scrollWidth <= title.clientWidth) return; // fits at full size
+
+    var base = parseFloat(getComputedStyle(title).fontSize);
+    if (!base) return;
+
+    // Step down until it fits; if none do, the smallest size stays and the
+    // CSS `text-overflow: ellipsis` truncates as a last resort.
+    for (var i = 1; i < RATIOS.length; i++) {
+      title.style.fontSize = base * RATIOS[i] + "px";
+      if (title.scrollWidth <= title.clientWidth) return;
+    }
+  }
+
+  var raf;
+  function schedule() {
+    cancelAnimationFrame(raf);
+    raf = requestAnimationFrame(fit);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", fit);
+  } else {
+    fit();
+  }
+  window.addEventListener("load", fit, { once: true });
+  window.addEventListener("resize", schedule);
+  window.addEventListener("orientationchange", schedule);
+  mql.addEventListener("change", schedule);
+
+  // Re-fit once web fonts settle (metrics can change after swap).
+  if (document.fonts && document.fonts.ready) {
+    document.fonts.ready.then(fit);
+  }
+})();

--- a/great_docs/assets/tooltips.js
+++ b/great_docs/assets/tooltips.js
@@ -33,8 +33,11 @@
       placement: "top",
       theme: "gd-material",
       maxWidth: 300,
-      touch: ["hold", 500], // Long press on touch devices
-      // Smart positioning — flip if not enough space
+      // Tooltips are a hover affordance so we suppress them on touch devices
+      // (phones/tablets) where there is no hover and a tap/long-press would
+      // otherwise pop a stray tooltip (e.g., the version badge on the brand).
+      touch: false,
+      // Smart positioning: flip if not enough space
       popperOptions: {
         modifiers: [
           {


### PR DESCRIPTION
This PR reworks the mobile navbar into a cleaner two-row layout where:

1. the package logo/name is centered on the top row with the hamburger pinned left (no longer shifting the title off-center)
2. the widget icons are centered on the second row
3. the header padding is tightened so content sits higher on load
4. long text display names are made robust by progressively shrinking the title font to fit before falling back to an ellipsis (a nudge to set a shorter `display_name`).
5. hover tooltips are suppressed on touch devices

Fixes: https://github.com/posit-dev/great-docs/issues/227