### PR TITLE
fix: `navbar_color:` CSS leaking onto the root element (issue on Firefox)

### DIFF
--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -12368,87 +12368,87 @@ body-classes: "gd-homepage"
                     toggler_stroke = "rgba(0,0,0,0.65)"
 
                 if mode == "light":
-                    selector = "html.quarto-light, :root[data-bs-theme='light']"
+                    prefixes = ("html.quarto-light", ":root[data-bs-theme='light']")
                 else:
-                    selector = "html.quarto-dark, :root[data-bs-theme='dark']"
+                    prefixes = ("html.quarto-dark", ":root[data-bs-theme='dark']")
 
-                css_parts.append(f"""{selector} {{
+                # Distribute each suffix across both theme prefixes.  Writing
+                # this as a comma-joined `selector` and then appending
+                # ` .navbar` is a trap: `html.quarto-dark, :root[...] .navbar`
+                # parses as two selectors — `html.quarto-dark` (the bare root
+                # element) and `:root[...] .navbar` — so the navbar styling
+                # leaks onto <html>.  Firefox then paints that leaked
+                # background/border in the transparent regions of the blended
+                # homepage as gray bars behind the content (issue #230).
+                def sel(*suffixes: str) -> str:
+                    return ",\n".join(p + suffix for suffix in suffixes for p in prefixes)
+
+                css_parts.append(f"""{sel("")} {{
     --gd-navbar-bg: {bg_hex};
     --gd-navbar-text: {text_hex};
 }}
-{selector} .navbar {{
+{sel(" .navbar")} {{
     background: {bg_hex} !important;
     border-bottom: 1px solid {border_col};
 }}
-{selector} .navbar .navbar-title,
-{selector} .navbar .nav-link {{
+{sel(" .navbar .navbar-title", " .navbar .nav-link")} {{
     color: {text_hex} !important;
 }}
-{selector} .navbar .nav-link:hover {{
+{sel(" .navbar .nav-link:hover")} {{
     background-color: {hover_bg} !important;
     color: {text_hex} !important;
 }}
-{selector} .navbar .nav-item:has(#github-widget) .nav-link:hover {{
+{sel(" .navbar .nav-item:has(#github-widget) .nav-link:hover")} {{
     background-color: transparent !important;
 }}
-{selector} .navbar .nav-link.active {{
+{sel(" .navbar .nav-link.active")} {{
     text-decoration-color: {active_underline} !important;
 }}
-{selector} .navbar .dark-mode-toggle,
-{selector} #quarto-search .aa-DetachedSearchButton {{
+{sel(" .navbar .dark-mode-toggle", " #quarto-search .aa-DetachedSearchButton")} {{
     background: {btn_bg};
     border-color: {btn_border};
     color: {text_hex};
 }}
-{selector} .navbar .dark-mode-toggle:hover,
-{selector} #quarto-search .aa-DetachedSearchButton:hover {{
+{sel(" .navbar .dark-mode-toggle:hover", " #quarto-search .aa-DetachedSearchButton:hover")} {{
     background: {btn_hover_bg};
     border-color: {btn_hover_border};
 }}
-{selector} .navbar .gh-widget-trigger {{
+{sel(" .navbar .gh-widget-trigger")} {{
     background: {btn_bg};
     border-color: {btn_border};
     color: {text_hex};
 }}
-{selector} .navbar .gh-widget-trigger:hover {{
+{sel(" .navbar .gh-widget-trigger:hover")} {{
     background: {btn_hover_bg};
     border-color: {btn_hover_border};
 }}
-{selector} .navbar .quarto-navbar-tools button,
-{selector} .navbar .quarto-navbar-tools .quarto-navigation-tool {{
+{sel(" .navbar .quarto-navbar-tools button", " .navbar .quarto-navbar-tools .quarto-navigation-tool")} {{
     background: {btn_bg};
     border-color: {btn_border};
     color: {text_hex};
 }}
-{selector} .navbar .quarto-navbar-tools button:hover,
-{selector} .navbar .quarto-navbar-tools .quarto-navigation-tool:hover {{
+{sel(" .navbar .quarto-navbar-tools button:hover", " .navbar .quarto-navbar-tools .quarto-navigation-tool:hover")} {{
     background: {btn_hover_bg};
     border-color: {btn_hover_border};
 }}
-{selector} .navbar .nav-item.compact .nav-link,
-{selector} .navbar .gd-navbar-icon {{
+{sel(" .navbar .nav-item.compact .nav-link", " .navbar .gd-navbar-icon")} {{
     background: {btn_bg};
     border: 1px solid {btn_border};
     border-radius: 6px;
     color: {text_hex};
 }}
-{selector} .navbar .nav-item.compact .nav-link:hover,
-{selector} .navbar .gd-navbar-icon:hover {{
+{sel(" .navbar .nav-item.compact .nav-link:hover", " .navbar .gd-navbar-icon:hover")} {{
     background: {btn_hover_bg};
     border-color: {btn_hover_border};
 }}
-{selector} .navbar .navbar-toggler-icon {{
+{sel(" .navbar .navbar-toggler-icon")} {{
     background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='{toggler_stroke}' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e") !important;
 }}
-{selector} .navbar .bi,
-{selector} .navbar .aa-SubmitIcon,
-{selector} .navbar .aa-SearchIcon,
-{selector} .navbar .aa-DetachedSearchButtonIcon,
-{selector} .navbar .aa-DetachedSearchButtonIcon svg {{
+{sel(" .navbar .bi", " .navbar .aa-SubmitIcon", " .navbar .aa-SearchIcon", " .navbar .aa-DetachedSearchButtonIcon", " .navbar .aa-DetachedSearchButtonIcon svg")} {{
     color: {text_hex} !important;
     fill: {text_hex} !important;
 }}
-{selector} .navbar .version-badge {{
+{sel(" .navbar .version-badge")} {{
     color: {text_hex};
     opacity: 0.75;
     background-color: {btn_bg};

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -15414,6 +15414,58 @@ def test_update_quarto_config_navbar_color_light_only():
         assert "quarto-light" in css_items[0]
 
 
+def test_update_quarto_config_navbar_color_does_not_leak_onto_root():
+    """`navbar_color` CSS must scope every rule to `.navbar`, never the bare root."""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        docs = GreatDocs(project_path=tmp_dir)
+
+        (Path(tmp_dir) / "pyproject.toml").write_text(
+            '[project]\nname = "mypkg"\n', encoding="utf-8"
+        )
+        (Path(tmp_dir) / "great-docs.yml").write_text(
+            "navbar_color:\n  light: '#c76e00'\n  dark: '#0a2540'\n", encoding="utf-8"
+        )
+        docs._config = Config(Path(tmp_dir))
+
+        quarto_yml = docs.project_path / "_quarto.yml"
+        quarto_yml.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(quarto_yml, "w") as f:
+            write_yaml(
+                {
+                    "project": {"type": "website"},
+                    "website": {"navbar": {"left": []}, "sidebar": []},
+                    "format": {"html": {}},
+                },
+                f,
+            )
+
+        docs._update_quarto_config()
+
+        with open(quarto_yml, "r") as f:
+            result = read_yaml(f)
+
+        after_body = result["format"]["html"].get("include-after-body", [])
+        css = "".join(
+            item["text"] if isinstance(item, dict) else str(item)
+            for item in after_body
+            if "navbar_color overrides" in str(item)
+        )
+
+        # The buggy form leaves a bare root prefix joined by a comma directly
+        # before a descendant — these substrings must never appear.
+        assert "html.quarto-dark, :root[data-bs-theme='dark'] .navbar" not in css
+        assert "html.quarto-light, :root[data-bs-theme='light'] .navbar" not in css
+
+        # Every prefix must be scoped to .navbar (descendant combinator present).
+        assert "html.quarto-dark .navbar" in css
+        assert ":root[data-bs-theme='dark'] .navbar" in css
+
+        # The CSS-variable block on the bare root is intentional and kept.
+        assert "--gd-navbar-bg:" in css
+
+
 def test_update_quarto_config_announcement_banner():
     """Test _update_quarto_config injects announcement banner meta+script."""
 


### PR DESCRIPTION
The `navbar_color` override CSS was generated with a comma-grouped selector (`html.quarto-dark, :root[data-bs-theme='dark']`) concatenated with `.navbar` descendants, which CSS parses as two separate selectors: leaking every navbar background, border, and `border-radius` onto the bare `<html>` element. On the transparent blended homepage, Firefox paints that leaked styling through the content containers as gray bars behind the text. Chrome/Chromium seems to hide it behind the opaque `<body>`. This PR scopes every rule to `.navbar` via a `sel()` helper so no bare root selector is emitted. This keeps only the intentional CSS-variable block on the root, which prevents the visual artifacts on Firefox.

Fixes: #230