### PR TITLE
fix: forward project-level bibliography

### DIFF
--- a/great_docs/assets/great-docs.scss
+++ b/great_docs/assets/great-docs.scss
@@ -893,6 +893,108 @@ li a {
     text-underline-offset: 4px;
 }
 
+/* ==========================================================================
+   Citations & Bibliography (Quarto citeproc output)
+   Theme-aware via --gd-* tokens, so light/dark stay consistent. Without these
+   rules, inline citations fall through to the generic link color (black in
+   light mode, so they don't read as links) and the reference list inherits
+   Bootstrap defaults with no spacing between entries.
+   ========================================================================== */
+
+/* Inline citations, e.g. (Knuth 1984): distinct accent color with a dotted
+   underline in both modes so they're clearly navigable cross-references. */
+.citation a[role="doc-biblioref"] {
+    color: var(--gd-citation-color);
+    text-decoration: underline dotted;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+}
+
+.citation a[role="doc-biblioref"]:hover {
+    color: var(--gd-citation-color);
+    text-decoration-style: solid;
+}
+
+/* Separate a manually-placed reference list from the body. When an author puts
+   `::: {#refs}` under their own heading, #refs sits in a content section
+   (.level1); border that section so the rule lands above the heading. Scoped to
+   .level1 so it does NOT double up with the appendix border below. The metrics
+   mirror Quarto's #quarto-appendix (2rem above the rule, 1.5rem below) so the
+   manual and auto-generated paths look identical. */
+section.level1:has(> #refs) {
+    margin-top: 2rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--gd-border-color);
+}
+
+/* Zero the heading's own top margin so the gap below the rule equals the
+   section padding (otherwise the heading's default margin makes the whitespace
+   above and below the rule uneven). Matches the appendix heading (margin-top:0). */
+section.level1:has(> #refs) > :first-child {
+    margin-top: 0;
+}
+
+/* Fallback when citeproc appends a bare #refs with no section wrapper. */
+#refs:not(section > #refs) {
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--gd-border-color);
+}
+
+/* Auto-generated bibliographies render in Quarto's #quarto-appendix block,
+   which already supplies a top border for separation. Quarto's default theme
+   gives it a light background and border that don't adapt to dark mode, so the
+   reference list shows up as a white card with low-contrast text. Re-theme it. */
+html.quarto-dark #quarto-appendix.default,
+body.quarto-dark #quarto-appendix.default {
+    background-color: transparent;
+    border-top-color: var(--gd-border-color);
+}
+
+/* Quarto renders the appendix bibliography title at body-text size, which looks
+   inconsistent next to a manually-authored "## References" section heading (a
+   full-size section heading). Promote it to the section-heading scale so the
+   References section looks the same whether the heading is auto-generated or
+   authored by hand. Two ids + !important override Quarto's own
+   `.quarto-appendix-heading { font-size: 1em !important }`. */
+#quarto-appendix #quarto-bibliography > .quarto-appendix-heading {
+    font-size: 1.85rem !important;
+    font-weight: 500;
+    margin-bottom: 1rem;
+}
+
+/* Reference list: slightly smaller and softened for hierarchy, with breathing
+   room between entries (Bootstrap leaves them flush against each other). Use
+   0.9em to match Quarto's own appendix rule
+   (`#quarto-appendix .quarto-appendix-contents > *:not(h2) { font-size: .9em }`)
+   so a manually-placed #refs is the same size as the auto-generated one. */
+#refs {
+    font-size: 0.9em;
+    color: var(--gd-text-secondary);
+}
+
+#refs .csl-entry {
+    margin-bottom: 0.6rem;
+}
+
+#refs .csl-entry:last-child {
+    margin-bottom: 0;
+}
+
+/* Unify the hanging indent across both paths. Quarto's appendix applies the
+   hanging indent per-entry (body flush left, wrapped lines indented 1em), but a
+   manually-placed #refs gets the default `div.hanging-indent` rule that shifts
+   the whole list by 1.5em. Force the per-entry form everywhere so every citation
+   starts hard left with consistent wrap indentation. */
+#refs.hanging-indent {
+    margin-left: 0;
+}
+
+#refs.hanging-indent .csl-entry {
+    margin-left: 1em;
+    text-indent: -1em;
+}
+
 /* Author/funder icon links in the landing page margin sidebar */
 .column-margin a:has(.bi),
 .column-margin a:has(.fa-brands),
@@ -3369,6 +3471,7 @@ body.quarto-dark .gd-keyboard-btn {
     --gd-highlight-color: rgba(255, 243, 205, 0.5);
     --gd-active-link: rgb(244, 121, 0);
     --gd-accent-blue: rgba(101, 180, 237, 0.75);
+    --gd-citation-color: #1a6cae;
 
     /* Syntax highlighting - light mode */
     --gd-syn-class: #0e84b5;
@@ -3406,6 +3509,7 @@ body.quarto-dark {
     --gd-highlight-color: rgba(255, 193, 7, 0.2);
     --gd-active-link: #ff9f43;
     --gd-accent-blue: rgba(101, 180, 237, 0.6);
+    --gd-citation-color: #7cb8e8;
 
     /* Syntax highlighting - dark mode (optimized for contrast) */
     --gd-syn-class: #56c8ff;
@@ -6285,6 +6389,47 @@ html[data-bs-theme="dark"] .gd-page-metadata {
         padding: 6px 10px;
         position: relative;
         z-index: 1;
+    }
+}
+
+/* Citation / cross-reference hover popovers.
+   Quarto shows the full reference on hover using a tippy box with
+   theme="quarto", whose default surface is light. In dark mode that flashes a
+   white panel over the page, so give it a dark surface, border, and arrow that
+   track the GD theme tokens. */
+html.quarto-dark .tippy-box[data-theme~="quarto"],
+body.quarto-dark .tippy-box[data-theme~="quarto"] {
+    background-color: var(--gd-bg-secondary);
+    color: var(--gd-text-primary);
+    border: 1px solid var(--gd-border-color);
+
+    .csl-entry {
+        color: var(--gd-text-primary);
+    }
+
+    a {
+        color: var(--gd-citation-color);
+    }
+
+    /* Arrow fill + per-placement borders (tippy colors the arrow via borders) */
+    > .tippy-arrow {
+        color: var(--gd-bg-secondary);
+    }
+
+    &[data-placement^="top"] > .tippy-arrow::before {
+        border-top-color: var(--gd-bg-secondary);
+    }
+
+    &[data-placement^="bottom"] > .tippy-arrow::before {
+        border-bottom-color: var(--gd-bg-secondary);
+    }
+
+    &[data-placement^="left"] > .tippy-arrow::before {
+        border-left-color: var(--gd-bg-secondary);
+    }
+
+    &[data-placement^="right"] > .tippy-arrow::before {
+        border-right-color: var(--gd-bg-secondary);
     }
 }
 

--- a/great_docs/config.py
+++ b/great_docs/config.py
@@ -1281,6 +1281,39 @@ class Config:
         return scripts
 
     @property
+    def bibliography(self) -> list[str]:
+        """Get the normalized list of bibliography file paths.
+
+        Accepts a single path string or a list of paths in `great-docs.yml`. Paths are relative to
+        the project root.
+
+        Returns
+        -------
+        list[str]
+            List of bibliography (`.bib`) file paths, or an empty list if none.
+        """
+        raw = self.get("bibliography")
+        if isinstance(raw, str):
+            return [raw]
+        if isinstance(raw, list):
+            return [s for s in raw if isinstance(s, str)]
+        return []
+
+    @property
+    def csl(self) -> str | None:
+        """Get the citation style language (CSL) file path.
+
+        Returns
+        -------
+        str | None
+            Path to the `.csl` file relative to the project root, or `None`.
+        """
+        raw = self.get("csl")
+        if isinstance(raw, str):
+            return raw
+        return None
+
+    @property
     def nav_icons(self) -> dict[str, dict[str, str]] | None:
         """Get the normalized navigation icons configuration.
 

--- a/great_docs/config.py
+++ b/great_docs/config.py
@@ -1930,6 +1930,17 @@ def create_default_config() -> str:
 # file frontmatter if needed for special cases.
 # jupyter: python3             # Default: python3
 
+# Bibliography & Citations
+# ------------------------
+# Project-level bibliography for [@citation-key] syntax. Paths are relative to
+# the project root; the file(s) are copied into the build directory and wired
+# into _quarto.yml so every page can cite without per-page frontmatter.
+# bibliography: docs/references.bib       # single file
+# bibliography:                           # or multiple files
+#   - docs/references.bib
+#   - docs/software.bib
+# csl: docs/nature.csl                    # optional citation style
+
 # API Reference Structure
 # -----------------------
 # Explicit control over API reference sections. If not provided, sections are

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -11199,6 +11199,23 @@ body-classes: "gd-homepage"
         # Disable Quarto's built-in GLightbox — we supply gd-lightbox instead
         config["lightbox"] = False
 
+        # Forward project-level bibliography/CSL from great-docs.yml. The files
+        # are copied into the build directory (see _prepare_build_directory), so
+        # the _quarto.yml keys reference them by basename.
+        bib_files = self._config.bibliography
+        if bib_files:
+            bib_names = [Path(b).name for b in bib_files]
+            config["bibliography"] = bib_names[0] if len(bib_names) == 1 else bib_names
+            print(f"Using bibliography: {', '.join(bib_names)}")
+            # Note: the auto-generated references heading is localized by Quarto
+            # itself from the document `lang` (set below), e.g. "Les références"
+            # for French. We deliberately do not set `reference-section-title`:
+            # under our `shift-heading-level-by: -1` it would be demoted to a
+            # stray <p> and duplicated alongside Quarto's appendix heading.
+        csl_path = self._config.csl
+        if csl_path:
+            config["csl"] = Path(csl_path).name
+
         # Set document language for Quarto built-in i18n (search widget, etc.)
         if self._config.language and self._config.language != "en":
             config["lang"] = self._config.language  # pragma: no cover

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -259,6 +259,22 @@ class GreatDocs:
             else:
                 print(f"Warning: Pre-render script not found: {script_path}")
 
+        # Copy bibliography and CSL files into the build directory so that
+        # project-level citations resolve (see _update_quarto_config for wiring)
+        for bib_path in self._config.bibliography:
+            src = self.project_root / bib_path
+            if src.is_file():
+                shutil.copy2(src, self.project_path / src.name)
+            else:
+                print(f"Warning: Bibliography file not found: {bib_path}")
+        csl_path = self._config.csl
+        if csl_path:
+            csl_src = self.project_root / csl_path
+            if csl_src.is_file():
+                shutil.copy2(csl_src, self.project_path / csl_src.name)
+            else:
+                print(f"Warning: CSL file not found: {csl_path}")
+
         # Copy qrenderer assets
         renderer_src = self.assets_path / "_renderer.py"
         if renderer_src.exists():

--- a/test-packages/synthetic/catalog.py
+++ b/test-packages/synthetic/catalog.py
@@ -392,6 +392,10 @@ ALL_PACKAGES: list[str] = [
     "gdtest_sec_nested_tags",  # 195
     # 196: Cross-refs into numeric-prefix section subdirs
     "gdtest_sec_xref_subdirs",  # 196
+    # 197: Project-level bibliography forwarded into _quarto.yml
+    "gdtest_bibliography",  # 197
+    # 198: Project-level bibliography with a custom (numeric) CSL style
+    "gdtest_bibliography_csl",  # 198
 ]
 
 
@@ -614,6 +618,8 @@ DIMENSIONS: dict[str, dict[str, str]] = {
     "K54": {"axis": "config", "label": "inline_methods: default (5)"},
     "K55": {"axis": "config", "label": "inline_methods: true (never split)"},
     "K56": {"axis": "config", "label": "inline_methods: false (always split)"},
+    "K57": {"axis": "config", "label": "project-level bibliography"},
+    "K58": {"axis": "config", "label": "citation style (CSL)"},
     # Page tags axes
     "T1": {"axis": "tags", "label": "Page tags with hierarchy + shadow"},
     "T3": {"axis": "tags", "label": "Tag location top vs. bottom with per-page overrides"},
@@ -2193,6 +2199,29 @@ PACKAGE_DESCRIPTIONS: dict[str, str] = {
         "names too — otherwise files land at examples/02-topic-b/ while links "
         "point at examples/topic-b/, producing dead cross-references. Verifies "
         "the on-disk section paths and the rewritten links agree."
+    ),
+    "gdtest_bibliography": (
+        "A package whose great-docs.yml sets a single project-level "
+        "`bibliography: docs/references.bib` key (issue #214) and then cites it "
+        "from four different contexts with no per-page `bibliography:` "
+        "frontmatter: the homepage (README→index.qmd), a top-level user-guide "
+        "page, a user-guide page nested one subdirectory deep, and a function "
+        "docstring on a generated API reference page. One key (knuth1984) is "
+        "shared across pages to prove a single bibliography serves the whole "
+        "project. Great Docs should copy the .bib into the build directory and "
+        "write `bibliography: references.bib` into _quarto.yml, so Quarto's "
+        "citeproc resolves every citation inline and renders a References "
+        "section on each page — regardless of nesting depth. If the wiring is "
+        "missing you'll see raw [@knuth1984] text and no references, exactly the "
+        "bug this verifies is fixed."
+    ),
+    "gdtest_bibliography_csl": (
+        "Like gdtest_bibliography, but great-docs.yml also sets the optional "
+        "`csl: docs/numeric.csl` key. The custom Citation Style Language file is "
+        "copied into the build and wired into _quarto.yml, so citations render as "
+        "bracketed numbers ([1], [2]) and the reference list is numbered, instead "
+        "of the default Chicago author-date style. Confirms CSL selection works "
+        "end to end (issue #214's optional CSL support)."
     ),
 }
 

--- a/test-packages/synthetic/specs/gdtest_bibliography.py
+++ b/test-packages/synthetic/specs/gdtest_bibliography.py
@@ -1,0 +1,203 @@
+"""
+gdtest_bibliography — Project-level bibliography forwarded from great-docs.yml.
+
+Dimensions: A1, B1, C1, D1, E6, F1, G1, H7, K57
+Focus: A single project-level `bibliography:` key in great-docs.yml is copied
+       into the build directory and wired into _quarto.yml so that *every* page
+       can use [@citation-key] syntax without per-page frontmatter. Verifies the
+       fix for issue #214 across multiple contexts:
+         - the homepage (index.qmd, built from README at the project root),
+         - a top-level user-guide page,
+         - a user-guide page nested in a subdirectory (depth-independence),
+       with one citation key (knuth1984) shared across pages to prove a single
+       bibliography genuinely serves the whole project.
+"""
+
+SPEC = {
+    "name": "gdtest_bibliography",
+    "description": "Project-level bibliography forwarded into _quarto.yml",
+    "dimensions": ["A1", "B1", "C1", "D1", "E6", "F1", "G1", "H7", "K57"],
+    # ── Project metadata ─────────────────────────────────────────────
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-bibliography",
+            "version": "0.1.0",
+            "description": "Synthetic test for project-level bibliography wiring",
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    },
+    # ── Source files ──────────────────────────────────────────────────
+    "files": {
+        "gdtest_bibliography/__init__.py": '''\
+            """Package demonstrating project-level citations."""
+
+            __version__ = "0.1.0"
+            __all__ = ["weave", "tangle"]
+
+
+            def weave(source: str) -> str:
+                """
+                Produce documentation from a literate source.
+
+                The literate programming model this implements is due to Knuth
+                [@knuth1984]; this docstring citation probes whether project-level
+                bibliography resolution reaches generated API reference pages.
+
+                Parameters
+                ----------
+                source
+                    The literate program source.
+
+                Returns
+                -------
+                str
+                    The woven documentation.
+                """
+                return source
+
+
+            def tangle(source: str) -> str:
+                """
+                Extract compilable code from a literate source.
+
+                Parameters
+                ----------
+                source
+                    The literate program source.
+
+                Returns
+                -------
+                str
+                    The tangled code.
+                """
+                return source
+        ''',
+        # The bibliography lives outside the build tree, under docs/. The
+        # great-docs.yml `bibliography:` key points here; Great Docs copies it
+        # into the build directory at build time. Three entries: knuth1984 is
+        # shared across multiple pages; lamport1994 and parnas1972 are page-local.
+        "docs/references.bib": """\
+            @article{knuth1984,
+              title = {Literate Programming},
+              author = {Knuth, Donald E.},
+              year = {1984},
+              journal = {The Computer Journal},
+              volume = {27},
+              number = {2},
+              pages = {97--111},
+            }
+
+            @book{lamport1994,
+              title = {LaTeX: A Document Preparation System},
+              author = {Lamport, Leslie},
+              year = {1994},
+              publisher = {Addison-Wesley},
+              edition = {2nd},
+            }
+
+            @article{parnas1972,
+              title = {On the Criteria to Be Used in Decomposing Systems into Modules},
+              author = {Parnas, David L.},
+              year = {1972},
+              journal = {Communications of the ACM},
+              volume = {15},
+              number = {12},
+              pages = {1053--1058},
+            }
+        """,
+        # Homepage: README becomes index.qmd at the project root. Citing here
+        # exercises the root-level build path (distinct from user-guide/ pages).
+        "README.md": """\
+            # gdtest-bibliography
+
+            Synthetic test for project-level `bibliography:` wiring (issue #214).
+            This package follows the literate programming tradition [@knuth1984].
+
+            ## Purpose
+
+            A single `bibliography: docs/references.bib` entry in `great-docs.yml`
+            should:
+
+            - copy `references.bib` into the build directory, and
+            - set `bibliography: references.bib` in the generated `_quarto.yml`,
+
+            so that `[@citation-key]` syntax on *any* page resolves to a formatted
+            citation and a References section, with no per-page frontmatter.
+
+            ## References
+
+            ::: {#refs}
+            :::
+        """,
+        # Top-level user-guide page citing two keys with no per-page
+        # `bibliography:` frontmatter — relying entirely on the project-level key.
+        "user_guide/01-citations.qmd": """\
+            ---
+            title: Citations
+            ---
+
+            Literate programming was introduced by Knuth [@knuth1984], who argued
+            that programs should be written for human readers first. The approach
+            interleaves prose and code, and is often typeset with LaTeX
+            [@lamport1994].
+
+            These citations resolve project-wide because `great-docs.yml` sets a
+            single `bibliography:` key — no per-page frontmatter is needed.
+
+            ## References
+
+            ::: {#refs}
+            :::
+        """,
+        # Nested user-guide page (one subdirectory deep). The single project-level
+        # key must resolve here too, even though the per-page workaround in the
+        # issue required paths that depended on this nesting depth. It reuses
+        # knuth1984 (shared with the homepage and the top-level page) and adds a
+        # page-local key, parnas1972.
+        "user_guide/02-advanced/01-decomposition.qmd": """\
+            ---
+            title: Modular Decomposition
+            ---
+
+            Module boundaries should hide design decisions that are likely to
+            change [@parnas1972]. Combining that principle with literate
+            programming [@knuth1984] yields documentation that tracks the modular
+            structure of the code.
+
+            This page lives one directory deep under `user-guide/`, yet the same
+            project-level `bibliography:` key resolves its citations — no
+            depth-dependent per-page path is required.
+
+            This page deliberately adds *no* manual References heading: Quarto
+            generates the section automatically and titles it from the document
+            language (here, the English "References").
+        """,
+    },
+    # ── great-docs.yml ────────────────────────────────────────────────
+    "config": {
+        "bibliography": "docs/references.bib",
+    },
+    # ── Expected outcomes ─────────────────────────────────────────────
+    "expected": {
+        "detected_name": "gdtest-bibliography",
+        "detected_module": "gdtest_bibliography",
+        "detected_parser": "numpy",
+        "export_names": ["weave", "tangle"],
+        "num_exports": 2,
+        "section_titles": ["Functions"],
+        "has_user_guide": True,
+        # Only top-level user-guide pages are listed here; the nested page is
+        # verified by dedicated tests (the generic UG test globs non-recursively).
+        "user_guide_files": ["01-citations.qmd"],
+        "has_license_page": False,
+        "has_citation_page": False,
+        # Bibliography-specific expectations (consumed by dedicated tests)
+        "has_bibliography": True,
+        "bibliography_file": "references.bib",
+        "citation_keys": ["knuth1984", "lamport1994", "parnas1972"],
+        "coverage_exclude": ['nodoc', 'bigcl', 'supp', 'hdg'],
+},
+}

--- a/test-packages/synthetic/specs/gdtest_bibliography_csl.py
+++ b/test-packages/synthetic/specs/gdtest_bibliography_csl.py
@@ -1,0 +1,143 @@
+"""
+gdtest_bibliography_csl — Project-level bibliography with a custom CSL style.
+
+Dimensions: A1, B1, C1, D1, E6, F1, G1, H7, K58
+Focus: Exercises the optional `csl:` key alongside `bibliography:` in
+       great-docs.yml. A custom numeric Citation Style Language file is copied
+       into the build directory and wired into _quarto.yml, so citations render
+       as bracketed numbers ([1], [2]) instead of the default Chicago
+       author-date style. This proves CSL selection works end to end (issue
+       #214's optional CSL support), distinct from gdtest_bibliography which
+       uses the default style.
+"""
+
+SPEC = {
+    "name": "gdtest_bibliography_csl",
+    "description": "Project-level bibliography with a custom (numeric) CSL style",
+    "dimensions": ["A1", "B1", "C1", "D1", "E6", "F1", "G1", "H7", "K58"],
+    # ── Project metadata ─────────────────────────────────────────────
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-bibliography-csl",
+            "version": "0.1.0",
+            "description": "Synthetic test for project-level bibliography + CSL",
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    },
+    # ── Source files ──────────────────────────────────────────────────
+    "files": {
+        "gdtest_bibliography_csl/__init__.py": '''\
+            """Package demonstrating a custom citation style."""
+
+            __version__ = "0.1.0"
+            __all__ = ["cite"]
+
+
+            def cite(key: str) -> str:
+                """
+                Return a citation key.
+
+                Parameters
+                ----------
+                key
+                    The citation key.
+
+                Returns
+                -------
+                str
+                    The same key.
+                """
+                return key
+        ''',
+        # Bibliography (two entries, cited in order on the page).
+        "docs/references.bib": """\
+            @article{knuth1984,
+              title = {Literate Programming},
+              author = {Knuth, Donald E.},
+              year = {1984},
+              journal = {The Computer Journal},
+            }
+
+            @book{lamport1994,
+              title = {LaTeX: A Document Preparation System},
+              author = {Lamport, Leslie},
+              year = {1994},
+              publisher = {Addison-Wesley},
+            }
+        """,
+        # A minimal numeric CSL style: inline citations become [1], [2] and the
+        # bibliography is a numbered list — visibly different from the default
+        # Chicago author-date style, so a test can confirm the CSL was applied.
+        "docs/numeric.csl": """\
+            <?xml version="1.0" encoding="utf-8"?>
+            <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="en-US">
+              <info>
+                <title>GD Test Numeric</title>
+                <id>gd-test-numeric</id>
+                <updated>2024-01-01T00:00:00+00:00</updated>
+              </info>
+              <citation collapse="citation-number">
+                <layout prefix="[" suffix="]" delimiter=",">
+                  <text variable="citation-number"/>
+                </layout>
+              </citation>
+              <bibliography>
+                <layout>
+                  <text variable="citation-number" prefix="[" suffix="] "/>
+                  <names variable="author" suffix=". "><name/></names>
+                  <text variable="title" suffix="."/>
+                </layout>
+              </bibliography>
+            </style>
+        """,
+        # A page citing both entries; no per-page frontmatter.
+        "user_guide/01-citations.qmd": """\
+            ---
+            title: Numbered Citations
+            ---
+
+            Literate programming was introduced by Knuth [@knuth1984], and LaTeX
+            by Lamport [@lamport1994]. With a numeric CSL, these render as
+            bracketed numbers rather than author-year text.
+
+            ## References
+
+            ::: {#refs}
+            :::
+        """,
+        "README.md": """\
+            # gdtest-bibliography-csl
+
+            Synthetic test for the optional `csl:` key (issue #214). A custom
+            numeric Citation Style Language file selects bracketed-number
+            citations instead of the default author-date style.
+        """,
+    },
+    # ── great-docs.yml ────────────────────────────────────────────────
+    "config": {
+        "bibliography": "docs/references.bib",
+        "csl": "docs/numeric.csl",
+    },
+    # ── Expected outcomes ─────────────────────────────────────────────
+    "expected": {
+        "detected_name": "gdtest-bibliography-csl",
+        "detected_module": "gdtest_bibliography_csl",
+        "detected_parser": "numpy",
+        "export_names": ["cite"],
+        "num_exports": 1,
+        "section_titles": ["Functions"],
+        "has_user_guide": True,
+        "user_guide_files": ["01-citations.qmd"],
+        "has_license_page": False,
+        "has_citation_page": False,
+        # Bibliography + CSL expectations (consumed by dedicated tests)
+        "has_bibliography": True,
+        "bibliography_file": "references.bib",
+        "csl_file": "numeric.csl",
+        "citation_keys": ["knuth1984", "lamport1994"],
+        "coverage_exclude": ['nodoc', 'bigcl', 'supp', 'hdg'],
+},
+}

--- a/test-packages/synthetic/specs/gdtest_i18n_french.py
+++ b/test-packages/synthetic/specs/gdtest_i18n_french.py
@@ -339,7 +339,9 @@ SPEC = {
             "valider",
         ],
         "num_exports": 4,
-        "section_titles": ["Classes", "Functions"],
+        # A French site localizes the auto-generated API section titles, so
+        # "Functions" renders as "Fonctions" ("Classes" is identical in French).
+        "section_titles": ["Classes", "Fonctions"],
         "has_user_guide": True,
         "user_guide_files": [
             "01-demarrage-rapide.qmd",

--- a/test-packages/synthetic/specs/gdtest_i18n_french.py
+++ b/test-packages/synthetic/specs/gdtest_i18n_french.py
@@ -43,6 +43,9 @@ SPEC = {
         "copy_code": True,
         "page_metadata": True,
         "funding": {"name": "Fondation pour la Recherche"},
+        # Project-level bibliography; the auto-generated references heading must
+        # be localized to French ("R\u00e9f\u00e9rences") via reference-section-title.
+        "bibliography": "docs/references.bib",
     },
     "files": {
         "gdtest_i18n_french/__init__.py": '''\
@@ -232,6 +235,13 @@ SPEC = {
             | CSV      | .csv      | Oui          |
             | JSON     | .json     | Non          |
             | Parquet  | .parquet  | Oui          |
+
+            ## Fondements
+
+            Cette approche s'appuie sur les travaux fondateurs en programmation
+            lettrée [@knuth1984]. Aucune en-tête de bibliographie n'est ajoutée
+            à la main : Great Docs génère automatiquement la section, dont le
+            titre est traduit en français.
         """,
         "user_guide/02-configuration.qmd": """\
             ---
@@ -303,6 +313,20 @@ SPEC = {
 
             MIT
         """,
+        # Project-level bibliography (outside the build tree). The citing page
+        # adds no manual heading, so Quarto generates the references section and
+        # Great Docs localizes its title to French.
+        "docs/references.bib": """\
+            @article{knuth1984,
+              title = {Literate Programming},
+              author = {Knuth, Donald E.},
+              year = {1984},
+              journal = {The Computer Journal},
+              volume = {27},
+              number = {2},
+              pages = {97--111},
+            }
+        """,
     },
     "expected": {
         "detected_name": "gdtest-i18n-french",
@@ -322,6 +346,13 @@ SPEC = {
             "02-configuration.qmd",
             "03-table-explorer.qmd",
         ],
+        # Bibliography with an auto-generated, French-localized references title.
+        # The heading is localized by Quarto itself from `lang: fr` — its
+        # built-in French string is "Les références".
+        "has_bibliography": True,
+        "bibliography_file": "references.bib",
+        "references_heading_i18n": "Les références",
+        "references_page": "user-guide/demarrage-rapide.html",
         "coverage_exclude": ['nodoc', 'bigcl', 'supp', 'hdg'],
 },
 }

--- a/tests/test_gdg_rendered.py
+++ b/tests/test_gdg_rendered.py
@@ -10184,3 +10184,332 @@ def test_DED_tbl_explorer_user_guide():
     assert ug.exists(), "User guide should exist"
     pages = list(ug.glob("*.html"))
     assert len(pages) >= 5, f"Should have several UG pages, got {len(pages)}"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# DED: bibliography — Project-level bibliography forwarded into _quarto.yml
+# ═══════════════════════════════════════════════════════════════════════════════
+
+_BIBLIOGRAPHY_PKG = "gdtest_bibliography"
+
+# Rendered citation pages, by their path under _site/. The single project-level
+# bibliography in great-docs.yml must serve every one of these contexts.
+_BIB_HOMEPAGE = "index.html"  # built from README at the project root
+_BIB_TOPLEVEL_UG = "user-guide/citations.html"
+_BIB_NESTED_UG = "user-guide/advanced/decomposition.html"  # one subdir deep
+_BIB_REFERENCE = "reference/weave.html"  # citation inside an API docstring
+
+
+def _bibliography_page(relpath: str) -> "str | None":
+    """Return a rendered bibliography-site page by its path under _site/.
+
+    Returns None if the page is absent so callers can skip cleanly.
+    """
+    page = _site_dir(_BIBLIOGRAPHY_PKG) / relpath
+    return page.read_text(encoding="utf-8") if page.exists() else None
+
+
+def _bibliography_ug_html() -> "str | None":
+    """Return the rendered top-level citations user-guide page HTML, or None."""
+    return _bibliography_page(_BIB_TOPLEVEL_UG)
+
+
+@pytest.mark.dedicated
+def test_DED_bibliography_file_copied_into_build_dir():
+    """gdtest_bibliography: references.bib is copied into the build directory."""
+    pkg = _BIBLIOGRAPHY_PKG
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+    # _site_dir(pkg).parent is the great-docs/ build directory.
+    build_dir = _site_dir(pkg).parent
+    assert (build_dir / "references.bib").exists(), (
+        "references.bib should be copied into the build directory by basename"
+    )
+
+
+@pytest.mark.dedicated
+def test_DED_bibliography_wired_into_quarto_yml():
+    """gdtest_bibliography: _quarto.yml carries bibliography: references.bib."""
+    pkg = _BIBLIOGRAPHY_PKG
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+    from yaml12 import read_yaml
+
+    quarto_yml = _site_dir(pkg).parent / "_quarto.yml"
+    assert quarto_yml.exists(), "_quarto.yml should exist in the build directory"
+    with open(quarto_yml, encoding="utf-8") as f:
+        config = read_yaml(f)
+    assert config.get("bibliography") == "references.bib", (
+        f"Expected bibliography: references.bib, got {config.get('bibliography')!r}"
+    )
+
+
+@pytest.mark.dedicated
+def test_DED_bibliography_citations_resolve():
+    """gdtest_bibliography: [@key] citations resolve (no raw citation text)."""
+    pkg = _BIBLIOGRAPHY_PKG
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+    html = _bibliography_ug_html()
+    assert html is not None, "Citations user-guide page should have rendered to HTML"
+
+    # The raw citation markup must NOT survive into the output
+    assert "[@knuth1984]" not in html, "Raw [@knuth1984] markup should be resolved"
+    assert "[@lamport1994]" not in html, "Raw [@lamport1994] markup should be resolved"
+
+    # citeproc emits per-entry anchors for each resolved key.
+    assert "ref-knuth1984" in html, "Resolved citation anchor for knuth1984 missing"
+    assert "ref-lamport1994" in html, "Resolved citation anchor for lamport1994 missing"
+
+
+@pytest.mark.dedicated
+@requires_bs4
+def test_DED_bibliography_references_section_rendered():
+    """gdtest_bibliography: a References section with both entries is rendered."""
+    pkg = _BIBLIOGRAPHY_PKG
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+    html = _bibliography_ug_html()
+    assert html is not None, "Citations user-guide page should have rendered to HTML"
+
+    soup = BeautifulSoup(html, "html.parser")
+    refs = soup.find(id="refs")
+    assert refs is not None, "A References section (#refs) should be rendered"
+
+    refs_text = refs.get_text()
+    # Both cited works should appear in the formatted reference list.
+    assert "Knuth" in refs_text, "Knuth reference should appear in the bibliography"
+    assert "Lamport" in refs_text, "Lamport reference should appear in the bibliography"
+
+
+@pytest.mark.dedicated
+@requires_bs4
+def test_DED_bibliography_homepage_citation_resolves():
+    """gdtest_bibliography: the homepage (README→index.qmd) resolves its citation.
+
+    The homepage also contains a source-tree viewer that legitimately displays
+    raw `.qmd`/README source, so we don't assert the absence of raw `[@key]`
+    text here — we check for the *resolved* citation link and the refs list.
+    """
+    pkg = _BIBLIOGRAPHY_PKG
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+    html = _bibliography_page(_BIB_HOMEPAGE)
+    assert html is not None, "Homepage index.html should exist"
+
+    soup = BeautifulSoup(html, "html.parser")
+    # A resolved inline citation links to the bibliography entry.
+    assert soup.select('a[href="#ref-knuth1984"]'), (
+        "Homepage should contain a resolved citation link to #ref-knuth1984"
+    )
+    refs = soup.find(id="refs")
+    assert refs is not None, "Homepage should render a References section"
+    assert "Knuth" in refs.get_text(), "Homepage references should list the Knuth entry"
+
+
+@pytest.mark.dedicated
+def test_DED_bibliography_nested_page_citations_resolve():
+    """gdtest_bibliography: a user-guide page one subdir deep resolves citations."""
+    pkg = _BIBLIOGRAPHY_PKG
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+    html = _bibliography_page(_BIB_NESTED_UG)
+    assert html is not None, (
+        f"Nested user-guide page {_BIB_NESTED_UG!r} should have rendered to HTML"
+    )
+
+    # Authored .qmd pages have no source viewer, so raw markup must be gone.
+    assert "[@parnas1972]" not in html, "Raw [@parnas1972] markup should be resolved"
+    assert "[@knuth1984]" not in html, "Raw [@knuth1984] markup should be resolved"
+    assert "ref-parnas1972" in html, "Resolved anchor for parnas1972 missing"
+    assert "ref-knuth1984" in html, "Resolved anchor for knuth1984 missing"
+
+
+@pytest.mark.dedicated
+def test_DED_bibliography_shared_key_across_pages():
+    """gdtest_bibliography: one key (knuth1984) resolves on every citing page.
+
+    Proves a single bibliography genuinely serves the whole project rather than
+    each page coincidentally resolving its own — the same key is cited on the
+    homepage, a top-level user-guide page, and a nested user-guide page.
+    """
+    pkg = _BIBLIOGRAPHY_PKG
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+    for relpath in (_BIB_HOMEPAGE, _BIB_TOPLEVEL_UG, _BIB_NESTED_UG):
+        html = _bibliography_page(relpath)
+        assert html is not None, f"{relpath!r} should have rendered"
+        assert "ref-knuth1984" in html, f"Shared key knuth1984 should resolve on {relpath!r}"
+
+
+@pytest.mark.dedicated
+@requires_bs4
+def test_DED_bibliography_docstring_citation_resolves():
+    """gdtest_bibliography: a citation inside an API docstring resolves too.
+
+    The weave() docstring cites [@knuth1984]. Generated API reference pages go
+    through a different rendering pipeline than authored .qmd pages, so this
+    confirms the project-level bibliography reaches docstring-sourced content.
+    """
+    pkg = _BIBLIOGRAPHY_PKG
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+    html = _bibliography_page(_BIB_REFERENCE)
+    assert html is not None, f"Reference page {_BIB_REFERENCE!r} should exist"
+
+    assert "[@knuth1984]" not in html, "Raw [@knuth1984] in docstring should be resolved"
+    soup = BeautifulSoup(html, "html.parser")
+    assert soup.select('a[href="#ref-knuth1984"]'), (
+        "Docstring citation should resolve to a #ref-knuth1984 link"
+    )
+    refs = soup.find(id="refs")
+    assert refs is not None, "Reference page should render a References section"
+    assert "Knuth" in refs.get_text(), "Reference page bibliography should list Knuth"
+
+
+@pytest.mark.dedicated
+@requires_bs4
+def test_DED_bibliography_auto_generated_heading():
+    """gdtest_bibliography: the nested page gets an auto-generated References heading.
+
+    The nested page authors no manual References heading, so Quarto generates the
+    section and Great Docs titles it via reference-section-title (English here).
+    This proves the heading-rendering mechanism that i18n localization relies on.
+    """
+    pkg = _BIBLIOGRAPHY_PKG
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+    html = _bibliography_page(_BIB_NESTED_UG)
+    assert html is not None, f"{_BIB_NESTED_UG!r} should have rendered"
+
+    soup = BeautifulSoup(html, "html.parser")
+    headings = [h.get_text().strip() for h in soup.find_all(["h1", "h2", "h3"])]
+    assert "References" in headings, (
+        f"An auto-generated 'References' heading should appear; got {headings}"
+    )
+    assert soup.find(id="refs") is not None, "Auto-generated #refs section should exist"
+
+    # Regression: shift-heading-level-by: -1 demotes the in-body reference title
+    # to a <p>, leaving a duplicate alongside the appendix heading. Post-render
+    # must strip that orphan so "References" appears exactly once.
+    assert "<p>References</p>" not in html, (
+        "Orphaned duplicate <p>References</p> should be removed (post-render)"
+    )
+    block_titles = [
+        el.get_text().strip()
+        for el in soup.find_all(["h1", "h2", "h3", "h4", "p"])
+        if el.get_text().strip() == "References"
+    ]
+    assert len(block_titles) == 1, (
+        f"'References' should appear exactly once as a heading; found {len(block_titles)}"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# DED: i18n bibliography — localized references heading
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.dedicated
+@requires_bs4
+def test_DED_i18n_french_references_heading_localized():
+    """gdtest_i18n_french: the auto-generated references heading is French.
+
+    With site.language: fr and a project-level bibliography, Great Docs sets
+    reference-section-title to the French translation, so Quarto renders
+    'Références' rather than the English 'References'.
+    """
+    pkg = "gdtest_i18n_french"
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+    expected = _get_expected(pkg)
+    page = _site_dir(pkg) / expected["references_page"]
+    if not page.exists():
+        pytest.skip(f"{page} not rendered")
+    html = page.read_text(encoding="utf-8")
+
+    soup = BeautifulSoup(html, "html.parser")
+    headings = [h.get_text().strip() for h in soup.find_all(["h1", "h2", "h3"])]
+    title = expected["references_heading_i18n"]  # "Références"
+    assert title in headings, f"Expected localized heading {title!r}; got {headings}"
+    # The English default must not leak through.
+    assert "References" not in headings, "English 'References' should not appear"
+    assert "ref-knuth1984" in html, "Citation should resolve on the French page"
+
+    # Regression: the localized title must not be duplicated as an orphan <p>.
+    assert f"<p>{title}</p>" not in html, (
+        f"Orphaned duplicate <p>{title}</p> should be removed (post-render)"
+    )
+    block_titles = [
+        el.get_text().strip()
+        for el in soup.find_all(["h1", "h2", "h3", "h4", "p"])
+        if el.get_text().strip() == title
+    ]
+    assert len(block_titles) == 1, (
+        f"{title!r} should appear exactly once; found {len(block_titles)}"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# DED: bibliography_csl — custom CSL style
+# ═══════════════════════════════════════════════════════════════════════════════
+
+_BIBLIOGRAPHY_CSL_PKG = "gdtest_bibliography_csl"
+
+
+@pytest.mark.dedicated
+def test_DED_bibliography_csl_file_copied_and_wired():
+    """gdtest_bibliography_csl: the .csl file is copied and wired into _quarto.yml."""
+    pkg = _BIBLIOGRAPHY_CSL_PKG
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+    from yaml12 import read_yaml
+
+    build_dir = _site_dir(pkg).parent
+    assert (build_dir / "numeric.csl").exists(), (
+        "the .csl file should be copied into the build directory by basename"
+    )
+    with open(build_dir / "_quarto.yml", encoding="utf-8") as f:
+        config = read_yaml(f)
+    assert config.get("csl") == "numeric.csl", (
+        f"Expected csl: numeric.csl in _quarto.yml, got {config.get('csl')!r}"
+    )
+    assert config.get("bibliography") == "references.bib"
+
+
+@pytest.mark.dedicated
+@requires_bs4
+def test_DED_bibliography_csl_applies_numeric_style():
+    """gdtest_bibliography_csl: the custom CSL changes citation formatting.
+
+    The numeric style renders inline citations as bracketed numbers ([1], [2])
+    instead of the default Chicago author-date "(Knuth 1984)". Confirming the
+    numbers appear proves Quarto actually used the configured .csl file.
+    """
+    pkg = _BIBLIOGRAPHY_CSL_PKG
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+    ug = _site_dir(pkg) / "user-guide"
+    page = ug / "citations.html"
+    if not page.exists():
+        pages = list(ug.glob("*.html"))
+        page = pages[0] if pages else None
+    assert page is not None and page.exists(), "citations page should have rendered"
+    html = page.read_text(encoding="utf-8")
+    soup = BeautifulSoup(html, "html.parser")
+
+    cite_links = soup.select('a[role="doc-biblioref"]')
+    assert cite_links, "should have resolved citation links"
+    cite_texts = [a.get_text().strip() for a in cite_links]
+    # Numeric style → every inline citation label is a number.
+    assert all(t.isdigit() for t in cite_texts), (
+        f"Expected numeric citation labels from the custom CSL, got {cite_texts}"
+    )
+    assert {"1", "2"} <= set(cite_texts), (
+        f"Expected numbered citations [1] and [2], got {cite_texts}"
+    )
+    # And NOT the default author-date rendering.
+    assert "Knuth 1984" not in html, "Default author-date style should not appear"
+    # References still resolve.
+    assert soup.find(id="refs") is not None, "References section should render"
+    assert "ref-knuth1984" in html, "Citation anchor should resolve"

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -16696,6 +16696,170 @@ def test_prepare_build_directory_copies_js_files():
         assert (docs.project_path / "responsive-tables.js").exists()
 
 
+def test_config_bibliography_normalization():
+    """Config.bibliography normalizes string, list, and missing values."""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        root = Path(tmp_dir)
+
+        # Single string -> one-element list
+        (root / "great-docs.yml").write_text(
+            "package: mypkg\nbibliography: docs/references.bib\n", encoding="utf-8"
+        )
+        assert Config(root).bibliography == ["docs/references.bib"]
+
+        # List -> filtered list
+        (root / "great-docs.yml").write_text(
+            "package: mypkg\nbibliography:\n  - docs/a.bib\n  - docs/b.bib\n",
+            encoding="utf-8",
+        )
+        assert Config(root).bibliography == ["docs/a.bib", "docs/b.bib"]
+
+        # Missing -> empty list
+        (root / "great-docs.yml").write_text("package: mypkg\n", encoding="utf-8")
+        cfg = Config(root)
+        assert cfg.bibliography == []
+        assert cfg.csl is None
+
+        # CSL string
+        (root / "great-docs.yml").write_text(
+            "package: mypkg\ncsl: docs/nature.csl\n", encoding="utf-8"
+        )
+        assert Config(root).csl == "docs/nature.csl"
+
+
+def test_prepare_build_directory_copies_bibliography():
+    """_prepare_build_directory copies the .bib file and wires _quarto.yml."""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        root = Path(tmp_dir)
+
+        (root / "pyproject.toml").write_text('[project]\nname = "mypkg"\n', encoding="utf-8")
+        (root / "README.md").write_text("# My Pkg\n", encoding="utf-8")
+        (root / "great-docs.yml").write_text(
+            "package: mypkg\nbibliography: docs/references.bib\n", encoding="utf-8"
+        )
+        docs_dir = root / "docs"
+        docs_dir.mkdir()
+        (docs_dir / "references.bib").write_text("@book{key, title={T}}\n", encoding="utf-8")
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        with patch.object(docs, "_add_api_reference_config"):
+            with patch.object(docs, "_update_sidebar_from_sections"):
+                with patch.object(docs, "_update_reference_index_frontmatter"):
+                    docs._prepare_build_directory()
+
+        # .bib copied into build dir by basename
+        assert (docs.project_path / "references.bib").exists()
+
+        # _quarto.yml references it by basename
+        with open(docs.project_path / "_quarto.yml", "r") as f:
+            config = read_yaml(f)
+        assert config["bibliography"] == "references.bib"
+
+
+def test_prepare_build_directory_copies_multiple_bib_and_csl():
+    """_prepare_build_directory handles multiple .bib files plus a CSL file."""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        root = Path(tmp_dir)
+
+        (root / "pyproject.toml").write_text('[project]\nname = "mypkg"\n', encoding="utf-8")
+        (root / "README.md").write_text("# My Pkg\n", encoding="utf-8")
+        (root / "great-docs.yml").write_text(
+            "package: mypkg\n"
+            "bibliography:\n  - docs/refs.bib\n  - docs/software.bib\n"
+            "csl: docs/nature.csl\n",
+            encoding="utf-8",
+        )
+        docs_dir = root / "docs"
+        docs_dir.mkdir()
+        (docs_dir / "refs.bib").write_text("@book{a, title={A}}\n", encoding="utf-8")
+        (docs_dir / "software.bib").write_text("@misc{b, title={B}}\n", encoding="utf-8")
+        (docs_dir / "nature.csl").write_text("<style/>\n", encoding="utf-8")
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        with patch.object(docs, "_add_api_reference_config"):
+            with patch.object(docs, "_update_sidebar_from_sections"):
+                with patch.object(docs, "_update_reference_index_frontmatter"):
+                    docs._prepare_build_directory()
+
+        assert (docs.project_path / "refs.bib").exists()
+        assert (docs.project_path / "software.bib").exists()
+        assert (docs.project_path / "nature.csl").exists()
+
+        with open(docs.project_path / "_quarto.yml", "r") as f:
+            config = read_yaml(f)
+        assert config["bibliography"] == ["refs.bib", "software.bib"]
+        assert config["csl"] == "nature.csl"
+
+
+def test_prepare_build_directory_bibliography_missing_warns(capsys):
+    """A configured but missing .bib/.csl file warns instead of failing the build."""
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        root = Path(tmp_dir)
+
+        (root / "pyproject.toml").write_text('[project]\nname = "mypkg"\n', encoding="utf-8")
+        (root / "README.md").write_text("# My Pkg\n", encoding="utf-8")
+        (root / "great-docs.yml").write_text(
+            "package: mypkg\nbibliography: docs/missing.bib\ncsl: docs/missing.csl\n",
+            encoding="utf-8",
+        )
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        with patch.object(docs, "_add_api_reference_config"):
+            with patch.object(docs, "_update_sidebar_from_sections"):
+                with patch.object(docs, "_update_reference_index_frontmatter"):
+                    docs._prepare_build_directory()
+
+        out = capsys.readouterr().out
+        assert "Bibliography file not found" in out
+        assert "CSL file not found" in out
+        assert not (docs.project_path / "missing.bib").exists()
+
+
+def test_bibliography_does_not_set_reference_section_title():
+    """Great Docs leaves the references heading to Quarto's native localization.
+
+    Under `shift-heading-level-by: -1` an explicit `reference-section-title`
+    is demoted to a stray `<p>` and duplicated next to Quarto's appendix
+    heading, so Great Docs must not set it. Quarto localizes the heading from
+    `lang` (e.g. "Les références" for French).
+    """
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        root = Path(tmp_dir)
+        (root / "pyproject.toml").write_text('[project]\nname = "mypkg"\n', encoding="utf-8")
+        (root / "README.md").write_text("# My Pkg\n", encoding="utf-8")
+        docs_dir = root / "docs"
+        docs_dir.mkdir()
+        (docs_dir / "references.bib").write_text("@book{k, title={T}}\n", encoding="utf-8")
+        (root / "great-docs.yml").write_text(
+            "package: mypkg\nbibliography: docs/references.bib\nsite:\n  language: fr\n",
+            encoding="utf-8",
+        )
+
+        docs = GreatDocs(project_path=tmp_dir)
+        with patch.object(docs, "_add_api_reference_config"):
+            with patch.object(docs, "_update_sidebar_from_sections"):
+                with patch.object(docs, "_update_reference_index_frontmatter"):
+                    docs._prepare_build_directory()
+
+        with open(docs.project_path / "_quarto.yml", encoding="utf-8") as f:
+            config = read_yaml(f)
+
+        # The bibliography is still wired up...
+        assert config.get("bibliography") == "references.bib"
+        assert config.get("lang") == "fr"
+
+        # ...but the references heading is left to Quarto (no explicit override).
+        assert "reference-section-title" not in config
+
+
 def test_prepare_build_directory_optional_js_copy_page():
     """Test _prepare_build_directory copies copy-page.js when markdown_pages_widget is set."""
 

--- a/tests/test_synthetic.py
+++ b/tests/test_synthetic.py
@@ -939,6 +939,42 @@ def _setup_blended_homepage(pkg_dir: Path, spec: dict) -> GreatDocs:
 
 
 @pytest.mark.parametrize("pkg_name", _AVAILABLE_PACKAGES)
+def test_L3_bibliography_wired_into_quarto_config(pkg_name: str, tmp_path: Path):
+    """Project-level bibliography is copied into the build dir and wired into _quarto.yml."""
+    pkg_dir, spec = _make_package(pkg_name, tmp_path)
+    expected = spec.get("expected", {})
+    if not expected.get("has_bibliography"):
+        pytest.skip("No 'has_bibliography' in spec expected outcomes")
+
+    from yaml12 import read_yaml
+
+    docs = GreatDocs(project_path=str(pkg_dir))
+
+    # The generated great-docs.yml already carries the bibliography key, so the
+    # build directory prep alone should copy the file and wire the config.
+    docs._prepare_build_directory()
+
+    bib_file = expected["bibliography_file"]
+
+    # The .bib file is copied into the build directory by basename.
+    assert (docs.project_path / bib_file).exists(), (
+        f"{bib_file!r} should be copied into the build dir {docs.project_path}"
+    )
+
+    # _quarto.yml references the bibliography by basename.
+    quarto_yml = docs.project_path / "_quarto.yml"
+
+    assert quarto_yml.exists(), "_quarto.yml was not created"
+
+    with open(quarto_yml, encoding="utf-8") as f:
+        config = read_yaml(f)
+
+    assert config.get("bibliography") == bib_file, (
+        f"Expected bibliography {bib_file!r} in _quarto.yml, got {config.get('bibliography')!r}"
+    )
+
+
+@pytest.mark.parametrize("pkg_name", _AVAILABLE_PACKAGES)
 def test_L3_blended_homepage_index_content(pkg_name: str, tmp_path: Path):
     """In blended mode, index.qmd contains first UG page content + metadata sidebar."""
     pkg_dir, spec = _make_package(pkg_name, tmp_path)

--- a/user_guide/12-cross-referencing.qmd
+++ b/user_guide/12-cross-referencing.qmd
@@ -2,7 +2,7 @@
 title: "Cross-Referencing"
 guide-section: "Config & Theming"
 bread-crumbs: false
-tags: [Content, Configuration]
+tags: [Content, Configuration, Citations]
 ---
 
 # Cross-Referencing
@@ -10,7 +10,9 @@ tags: [Content, Configuration]
 Documentation becomes much more useful when readers can follow connections between related items.
 Without links, someone reading the `encode()` page has no easy way to discover that `decode()`
 exists, or that a higher-level `Pipeline` class ties everything together. Cross-references turn
-isolated pages into a connected web.
+isolated pages into a connected web. This page covers that internal linking, and ends with
+citations: linking your prose outward to the papers, specifications, and books your work builds
+on.
 
 Great Docs provides a linking system called GDLS (Great Docs Linking System) that automatically
 creates clickable navigation between your API reference pages. GDLS operates at three levels, each
@@ -268,14 +270,108 @@ Code autolinks require no effort on your part, since they happen automatically. 
 common words like `Config` or `Data` might match a symbol unexpectedly. If you notice unwanted links
 in the rendered output, add `{.gd-no-link}` to the specific code span.
 
+## Citations & Bibliography
+
+Cross-references connect the pages *within* your documentation; citations connect your prose to the
+work it builds on (e.g., a paper, a specification, a book, etc.). Great Docs supports academic
+citations and a generated **References** section, driven by a single project-level bibliography.
+
+Point `bibliography:` at a `.bib` file (path relative to the project root):
+
+```{.yaml filename="great-docs.yml"}
+bibliography: docs/references.bib
+```
+
+Then cite by key anywhere (no per-page frontmatter required):
+
+```markdown
+Literate programming was introduced by Knuth [@knuth1984].
+```
+
+That renders as "…by Knuth (Knuth 1984)", linked to a References section. At build time Great Docs
+copies the `.bib` into the build directory and wires it into the generated `_quarto.yml`, so the
+bibliography is available to *every* page: User Guide pages, custom sections, the homepage, and even
+the docstrings that become your API reference.
+
+### Writing citations
+
+Citations use standard [Pandoc citation
+syntax](https://quarto.org/docs/authoring/citations.html#sec-citations). The citation key is the
+identifier from your `.bib` entry (`knuth1984` above), prefixed with `@`.
+
+| You write | Renders as |
+|-----------|------------|
+| `[@knuth1984]` | (Knuth 1984) |
+| `@knuth1984` | Knuth (1984) |
+| `[@knuth1984; @lamport1994]` | (Knuth 1984; Lamport 1994) |
+| `[see @knuth1984, pp. 33-35]` | (see Knuth 1984, 33–35) |
+| `[-@knuth1984]` | (1984) |
+
+Wrap a key in square brackets for a parenthetical citation, drop them for an in-text citation where
+the author becomes part of the sentence, separate multiple keys with semicolons, and add a prefix,
+locator, or leading `-` to suppress the author.
+
+### The references section
+
+When a page contains at least one citation, Great Docs renders a **References** section listing
+every work cited. By default it appears at the end of the page. To place it somewhere specific, add
+an empty `#refs` div where you want it:
+
+```markdown
+## References
+
+::: {#refs}
+:::
+```
+
+Quarto fills that div with the reference list instead of appending one at the end, and uses your
+heading as-is (it won't add a second one).
+
+### Multiple bibliography files
+
+Pass a list to combine several `.bib` files; all entries become citable from any page:
+
+```{.yaml filename="great-docs.yml"}
+bibliography:
+  - docs/references.bib
+  - docs/software.bib
+```
+
+### Citation style
+
+By default citations follow the Chicago author-date style. To use a different
+[CSL](https://citationstyles.org) style, point `csl:` at a `.csl` file (relative to the project
+root); Great Docs copies it into the build alongside the bibliography. Find styles in the
+[Zotero Style Repository](https://www.zotero.org/styles).
+
+```{.yaml filename="great-docs.yml"}
+bibliography: docs/references.bib
+csl: docs/nature.csl
+```
+
+### Localized headings
+
+If your site sets a [language](internationalization.qmd), the auto-generated references heading is
+localized automatically. So a French site (`site.language: fr`) renders **Les références**, with the
+entries themselves formatted for that language too.
+
+::: {.callout-note}
+If citations render as literal `[@key]` text with no References section, the key doesn't match a
+`.bib` entry or the bibliography wasn't found. So check the key spelling and that `bibliography:`
+resolves from the project root. A missing file warns (`"Bibliography file not found"`) and the build
+continues without it.
+:::
+
 ## Next Steps
 
 Cross-references turn a collection of standalone reference pages into a connected web of
-documentation. Use `%seealso` for structured navigation, interlinks for inline mentions, and let
-code autolinks handle the rest automatically.
+documentation. Use `%seealso` for structured navigation, interlinks for inline mentions, code
+autolinks for the rest, and a project-level `bibliography:` to cite external work.
 
 - [Writing Docstrings](writing-docstrings.qmd) covers how to write effective docstrings that work
 well with cross-referencing
 - [API Documentation](api-documentation.qmd) covers how API discovery and page organization work
 - [User Guides](user-guides.qmd) explains how to link from User Guide pages to API reference pages
+- [Internationalization](internationalization.qmd) localizes the References heading and the rest of
+the UI
 - [Linting](linting.qmd) can catch broken cross-references during the build


### PR DESCRIPTION
This PR forwards a project-level `bibliography:` (plus the optional `csl:` and multiple .bib files) from `great-docs.yml` into the generated `_quarto.yml` and copies the files into the build directory. This is all so that `[@key]` citations resolve and a language-localized References section renders on every page with no need for per-page frontmatter. We now also document the citations feature in the Cross-Referencing user guide article.

Fixes: #214 