### PR TITLE
Copy site.css config option to build directory

### DIFF
--- a/great_docs/config.py
+++ b/great_docs/config.py
@@ -1352,6 +1352,25 @@ class Config:
         return None
 
     @property
+    def css(self) -> list[str]:
+        """Get the normalized list of custom CSS file paths.
+
+        Accepts a single path string or a list of paths under `site.css` in
+        `great-docs.yml`. Paths are relative to the project root.
+
+        Returns
+        -------
+        list[str]
+            List of `.css` file paths, or an empty list if none.
+        """
+        raw = self.site.get("css")
+        if isinstance(raw, str):
+            return [raw]
+        if isinstance(raw, list):
+            return [s for s in raw if isinstance(s, str)]
+        return []
+
+    @property
     def nav_icons(self) -> dict[str, dict[str, str]] | None:
         """Get the normalized navigation icons configuration.
 

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -279,6 +279,15 @@ class GreatDocs:
             else:
                 print(f"Warning: CSL file not found: {csl_path}")
 
+        # Copy custom CSS files (site.css) into the build directory
+        # where _quarto.yml will refer to them by basename
+        for css_path in self._config.css:
+            css_src = self.project_root / css_path
+            if css_src.is_file():
+                shutil.copy2(css_src, self.project_path / css_src.name)
+            else:
+                print(f"Warning: CSS file not found: {css_path}")
+
         # Copy qrenderer assets
         renderer_src = self.assets_path / "_renderer.py"
         if renderer_src.exists():
@@ -11558,6 +11567,11 @@ body-classes: "gd-homepage"
             if isinstance(config["format"]["html"]["theme"], str):
                 config["format"]["html"]["theme"] = [config["format"]["html"]["theme"]]
             config["format"]["html"]["theme"].append("great-docs.scss")
+
+        # Add the custom CSS from site.css
+        css_files = self._config.css
+        if css_files:
+            config["format"]["html"]["css"] = [Path(c).name for c in css_files]
 
         if "shift-heading-level-by" not in config["format"]["html"]:
             config["format"]["html"]["shift-heading-level-by"] = -1

--- a/test-packages/synthetic/catalog.py
+++ b/test-packages/synthetic/catalog.py
@@ -398,6 +398,8 @@ ALL_PACKAGES: list[str] = [
     "gdtest_bibliography",  # 197
     # 198: Project-level bibliography with a custom (numeric) CSL style
     "gdtest_bibliography_csl",  # 198
+    # 199: Project-level custom CSS forwarded into _quarto.yml
+    "gdtest_custom_css",  # 199
 ]
 
 
@@ -604,6 +606,7 @@ DIMENSIONS: dict[str, dict[str, str]] = {
     "Q5": {"axis": "theme", "label": "TOC depth 3"},
     "Q6": {"axis": "theme", "label": "Custom TOC title"},
     "Q7": {"axis": "theme", "label": "Site combo"},
+    "Q8": {"axis": "theme", "label": "site.css: custom stylesheet"},
     # Skill axes
     "S1": {"axis": "skill", "label": "Auto-generated skill"},
     "S2": {"axis": "skill", "label": "Curated skill"},
@@ -2233,6 +2236,13 @@ PACKAGE_DESCRIPTIONS: dict[str, str] = {
         "bracketed numbers ([1], [2]) and the reference list is numbered, instead "
         "of the default Chicago author-date style. Confirms CSL selection works "
         "end to end (issue #214's optional CSL support)."
+    ),
+    "gdtest_custom_css": (
+        "A package whose great-docs.yml sets a single project-level "
+        "`site.css: [docs/custom.css]` key. Great Docs should copy "
+        "the stylesheet into the build directory and write it into _quarto.yml's "
+        "format.html.css. If the wiring is missing, the marker rule in custom.css "
+        "never reaches the rendered site."
     ),
 }
 

--- a/test-packages/synthetic/specs/gdtest_custom_css.py
+++ b/test-packages/synthetic/specs/gdtest_custom_css.py
@@ -1,0 +1,94 @@
+"""
+gdtest_custom_css — Project-level custom CSS forwarded from great-docs.yml.
+
+Dimensions: A1, B1, C1, D1, E6, F1, G1, Q8
+Focus: A single project-level `site.css:` key in great-docs.yml (issue #248)
+       is copied into the build directory and wired into _quarto.yml's
+       `format.html.css`, mirroring the working `bibliography`/`csl` pattern.
+"""
+
+SPEC = {
+    "name": "gdtest_custom_css",
+    "description": "Project-level custom CSS forwarded into _quarto.yml",
+    "dimensions": ["A1", "B1", "C1", "D1", "E6", "F1", "G1", "Q8"],
+    # ── Project metadata ─────────────────────────────────────────────
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-custom-css",
+            "version": "0.1.0",
+            "description": "Synthetic test for project-level custom CSS wiring",
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    },
+    # ── Source files ──────────────────────────────────────────────────
+    "files": {
+        "gdtest_custom_css/__init__.py": '''\
+            """Package demonstrating project-level custom CSS."""
+
+            __version__ = "0.1.0"
+            __all__ = ["widget"]
+
+
+            def widget(name: str) -> str:
+                """
+                Build a text widget.
+
+                Parameters
+                ----------
+                name
+                    Label for the widget.
+
+                Returns
+                -------
+                str
+                    The rendered widget.
+                """
+                return f"[{name}]"
+        ''',
+        # The stylesheet lives outside the build tree, under docs/. The
+        # great-docs.yml `site.css:` key points here; Great Docs copies it
+        # into the build directory at build time (issue #248).
+        "docs/custom.css": """\
+            /* gdtest-custom-css marker rule: unique and easily greppable so
+               tests can confirm this exact file was linked, not just any
+               stylesheet. */
+            .gdtest-custom-css-marker {
+              --gdtest-custom-css: applied;
+            }
+        """,
+        "user_guide/01-page.qmd": """\
+            ---
+            title: Page
+            ---
+
+            A user-guide page, to confirm project-level CSS applies outside the
+            homepage too.
+        """,
+    },
+    # ── great-docs.yml ────────────────────────────────────────────────
+    "config": {
+        "site": {
+            "css": ["docs/custom.css"],
+        },
+    },
+    # ── Expected outcomes ─────────────────────────────────────────────
+    "expected": {
+        "detected_name": "gdtest-custom-css",
+        "detected_module": "gdtest_custom_css",
+        "detected_parser": "numpy",
+        "export_names": ["widget"],
+        "num_exports": 1,
+        "section_titles": ["Functions"],
+        "has_user_guide": True,
+        "user_guide_files": ["01-page.qmd"],
+        "has_license_page": False,
+        "has_citation_page": False,
+        # Custom-CSS-specific expectations (consumed by dedicated tests)
+        "has_custom_css": True,
+        "custom_css_file": "custom.css",
+        "coverage_exclude": ["nodoc", "bigcl", "supp", "hdg"],
+    },
+}

--- a/tests/test_synthetic.py
+++ b/tests/test_synthetic.py
@@ -979,6 +979,43 @@ def test_L3_bibliography_wired_into_quarto_config(pkg_name: str, tmp_path: Path)
 
 
 @pytest.mark.parametrize("pkg_name", _AVAILABLE_PACKAGES)
+def test_L3_custom_css_wired_into_quarto_config(pkg_name: str, tmp_path: Path):
+    """Project-level site.css is copied into the build dir and wired into _quarto.yml."""
+    pkg_dir, spec = _make_package(pkg_name, tmp_path)
+    expected = spec.get("expected", {})
+    if not expected.get("has_custom_css"):
+        pytest.skip("No 'has_custom_css' in spec expected outcomes")
+
+    from yaml12 import read_yaml
+
+    docs = GreatDocs(project_path=str(pkg_dir))
+
+    # The generated great-docs.yml already carries the site.css key, so the
+    # build directory prep alone should copy the file and wire the config.
+    docs._prepare_build_directory()
+
+    css_file = expected["custom_css_file"]
+
+    # The .css file is copied into the build directory by basename.
+    assert (docs.project_path / css_file).exists(), (
+        f"{css_file!r} should be copied into the build dir {docs.project_path}"
+    )
+
+    # _quarto.yml references the CSS by basename.
+    quarto_yml = docs.project_path / "_quarto.yml"
+
+    assert quarto_yml.exists(), "_quarto.yml was not created"
+
+    with open(quarto_yml, encoding="utf-8") as f:
+        config = read_yaml(f)
+
+    assert css_file in (config.get("format", {}).get("html", {}).get("css") or []), (
+        f"Expected {css_file!r} in _quarto.yml format.html.css, "
+        f"got {config.get('format', {}).get('html', {}).get('css')!r}"
+    )
+
+
+@pytest.mark.parametrize("pkg_name", _AVAILABLE_PACKAGES)
 def test_L3_blended_homepage_index_content(pkg_name: str, tmp_path: Path):
     """In blended mode, index.qmd contains first UG page content + metadata sidebar."""
     pkg_dir, spec = _make_package(pkg_name, tmp_path)


### PR DESCRIPTION
This PR corrects an issue where recipes/05-add-custom-css.qmd documented a `site.css` key in great-docs.yml, but nothing read it: the file was never copied into the build directory or wired into _quarto.yml as format.html.css.

fixes #248