### PR TITLE
A hook registry to organise event handlers by priority

### DIFF
--- a/great_docs/_builtin/_directives.py
+++ b/great_docs/_builtin/_directives.py
@@ -22,7 +22,7 @@ _SEEALSO_LINE_RE = re.compile(
 _SEEALSO_TITLE = "see also"
 
 
-@on_object_resolved
+@on_object_resolved(priority=-100)
 def exclude_nodoc(obj: gf.Object | gf.Alias) -> gf.Object | gf.Alias | None:
     """
     Skip an object whose docstring carries the `%nodoc` directive
@@ -43,7 +43,7 @@ def exclude_nodoc(obj: gf.Object | gf.Alias) -> gf.Object | gf.Alias | None:
     return obj
 
 
-@on_object_resolved
+@on_object_resolved(priority=100)
 def add_seealso(obj: gf.Object | gf.Alias) -> gf.Object | gf.Alias:
     """
     Merge an object's `%seealso` entries into its See Also section

--- a/great_docs/hooks/_object_resolved.py
+++ b/great_docs/hooks/_object_resolved.py
@@ -10,45 +10,27 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable
 
+from ._registry import HookRegistry
+
 if TYPE_CHECKING:
     import griffe as gf
 
 ObjectResolvedHook = Callable[["gf.Object | gf.Alias"], "gf.Object | gf.Alias | None"]
 """A handler that inspects, replaces, or skips a resolved object"""
 
-_OBJECT_RESOLVED_HOOKS: list[ObjectResolvedHook] = []
+REGISTRY: HookRegistry[ObjectResolvedHook] = HookRegistry()
+"""The object_resolved handlers, ordered by priority"""
 
-
-def on_object_resolved(hook: ObjectResolvedHook) -> ObjectResolvedHook:
-    """
-    Register a handler for the `object_resolved` event
-
-    Parameters
-    ----------
-    hook
-        Receives the resolved object and returns the object to carry forward,
-        or `None` to skip it.
-
-    Returns
-    -------
-    The same `hook`, so this can be used as a decorator.
-
-    Notes
-    -----
-    Handlers run in registration order, each receiving the previous handler's
-    result.
-    """
-    _OBJECT_RESOLVED_HOOKS.append(hook)
-    return hook
+on_object_resolved = REGISTRY.register
+"""Register a handler for the `object_resolved` event (bare or `priority=`-parameterized)"""
 
 
 def emit_object_resolved(obj: gf.Object | gf.Alias) -> gf.Object | gf.Alias | None:
     """
     Emit the `object_resolved` event and return the object its handlers produce
 
-    Handlers run in registration order, each receiving the previous handler's
-    result; the first to return `None` skips the object and the rest are not
-    consulted.
+    Handlers run in priority order (lower first, ties in registration order);
+    the first to return `None` skips the object and the rest are not consulted.
 
     Parameters
     ----------
@@ -59,7 +41,7 @@ def emit_object_resolved(obj: gf.Object | gf.Alias) -> gf.Object | gf.Alias | No
     -------
     The object to document, or `None` when a handler skips it.
     """
-    for hook in _OBJECT_RESOLVED_HOOKS:
+    for hook in REGISTRY:
         result = hook(obj)
         if result is None:
             return None

--- a/great_docs/hooks/_registry.py
+++ b/great_docs/hooks/_registry.py
@@ -1,0 +1,78 @@
+"""
+A priority-ordered registry of event handlers, shared by the pipeline events
+
+Holds handlers paired with a numeric priority and yields them in run order:
+lower priority first, ties in registration order. Registration doubles as a
+decorator, used bare or with a priority. The event modules each own one
+instance and supply their own emit semantics.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Generic, TypeVar
+
+H = TypeVar("H", bound=Callable[..., object])
+
+
+class HookRegistry(Generic[H]):
+    """
+    A priority-ordered collection of event handlers
+
+    Iterating the registry yields handlers in run order: lower priority first,
+    ties in registration order. The run order is cached and rebuilt only when a
+    new handler is registered.
+    """
+
+    def __init__(self) -> None:
+        self._entries: list[tuple[int, int, H]] = []  # (priority, sequence, hook)
+        self._sequence = 0
+        self._ordered: list[H] | None = None
+
+    def register(
+        self,
+        hook: H | None = None,
+        *,
+        priority: int = 0,
+    ) -> H | Callable[[H], H]:
+        """
+        Register a handler, optionally with a priority
+
+        Parameters
+        ----------
+        hook
+            The handler to register. Omitted when used with arguments
+            (`@registry.register(priority=...)`).
+        priority
+            Run order; lower runs first. Ties keep registration order.
+
+        Returns
+        -------
+        The handler when used bare, otherwise a decorator that registers the
+        handler it receives. Either way the handler is returned unchanged.
+        """
+
+        def add(h: H) -> H:
+            self._entries.append((priority, self._sequence, h))
+            self._sequence += 1
+            self._ordered = None
+            return h
+
+        return add(hook) if hook is not None else add
+
+    def __iter__(self):
+        """Iterate the handlers in run order, sorted by `(priority, sequence)`"""
+        if self._ordered is None:
+            self._ordered = [h for _, _, h in sorted(self._entries, key=lambda e: e[:2])]
+        return iter(self._ordered)
+
+    def __contains__(self, hook: object) -> bool:
+        return any(h is hook for _, _, h in self._entries)
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def clear(self) -> None:
+        """Drop all registered handlers"""
+        self._entries.clear()
+        self._sequence = 0
+        self._ordered = None

--- a/tests/renderer/test_hooks.py
+++ b/tests/renderer/test_hooks.py
@@ -6,11 +6,15 @@ from great_docs.hooks import _object_resolved
 
 @pytest.fixture
 def clean_hooks():
-    """Snapshot and restore the object_resolved handler list around a test"""
-    saved = list(_object_resolved._OBJECT_RESOLVED_HOOKS)
-    _object_resolved._OBJECT_RESOLVED_HOOKS[:] = []
+    """Save and restore the object_resolved registry entries around a test"""
+    reg = _object_resolved.REGISTRY
+    saved = list(reg._entries)
+    saved_seq = reg._sequence
+    reg.clear()
     yield
-    _object_resolved._OBJECT_RESOLVED_HOOKS[:] = saved
+    reg._entries[:] = saved
+    reg._sequence = saved_seq
+    reg._ordered = None
 
 
 def test_only_on_object_resolved_is_exported():
@@ -56,3 +60,51 @@ def test_on_object_resolved_returns_the_handler(clean_hooks):
 def test_emit_object_resolved_with_no_handlers_is_identity(clean_hooks):
     sentinel = object()
     assert _object_resolved.emit_object_resolved(sentinel) is sentinel
+
+
+def test_bare_decorator_registers_the_hook(clean_hooks):
+    @hooks.on_object_resolved
+    def h(obj):
+        return obj
+
+    assert h in _object_resolved.REGISTRY
+    assert list(_object_resolved.REGISTRY) == [h]
+
+
+def test_priority_orders_emit_low_to_high(clean_hooks):
+    order: list[str] = []
+
+    @hooks.on_object_resolved(priority=100)
+    def late(obj):
+        order.append("late")
+        return obj
+
+    @hooks.on_object_resolved(priority=-100)
+    def early(obj):
+        order.append("early")
+        return obj
+
+    @hooks.on_object_resolved
+    def mid(obj):
+        order.append("mid")
+        return obj
+
+    _object_resolved.emit_object_resolved("X")
+    assert order == ["early", "mid", "late"]
+
+
+def test_low_priority_none_short_circuits_before_high(clean_hooks):
+    calls: list[str] = []
+
+    @hooks.on_object_resolved(priority=100)
+    def never(obj):
+        calls.append("never")
+        return obj
+
+    @hooks.on_object_resolved(priority=-100)
+    def drop(obj):
+        calls.append("drop")
+        return None
+
+    assert _object_resolved.emit_object_resolved("X") is None
+    assert calls == ["drop"]

--- a/tests/renderer/test_nodoc.py
+++ b/tests/renderer/test_nodoc.py
@@ -27,7 +27,7 @@ def test_exclude_nodoc_registers_on_import():
     # exclude_nodoc registered via this module's top-level import (the decorator).
     from great_docs.hooks import _object_resolved
 
-    assert exclude_nodoc in _object_resolved._OBJECT_RESOLVED_HOOKS
+    assert exclude_nodoc in _object_resolved.REGISTRY
 
 
 import textwrap
@@ -110,7 +110,7 @@ def test_importing_great_docs_registers_builtin_handlers():
         import great_docs  # noqa: F401
         from great_docs.hooks import _object_resolved
 
-        modules = {h.__module__ for h in _object_resolved._OBJECT_RESOLVED_HOOKS}
+        modules = {h.__module__ for h in _object_resolved.REGISTRY}
         assert "great_docs._builtin._directives" in modules, modules
         """
     )

--- a/tests/renderer/test_registry.py
+++ b/tests/renderer/test_registry.py
@@ -1,0 +1,82 @@
+import pytest
+
+from great_docs.hooks._registry import HookRegistry
+
+
+def test_bare_register_adds_the_hook():
+    reg: HookRegistry = HookRegistry()
+
+    @reg.register
+    def h(x):
+        return x
+
+    assert h in reg
+    assert list(reg) == [h]
+    assert reg.register(h) is h  # returns the hook (decorator contract)
+
+
+def test_iter_sorts_low_priority_first():
+    reg: HookRegistry = HookRegistry()
+
+    @reg.register(priority=100)
+    def late(x):
+        return x
+
+    @reg.register(priority=-100)
+    def early(x):
+        return x
+
+    @reg.register  # default 0, registered last
+    def mid(x):
+        return x
+
+    assert list(reg) == [early, mid, late]
+
+
+def test_equal_priority_keeps_registration_order():
+    reg: HookRegistry = HookRegistry()
+
+    @reg.register(priority=5)
+    def first(x):
+        return x
+
+    @reg.register(priority=5)
+    def second(x):
+        return x
+
+    assert list(reg) == [first, second]
+
+
+def test_priority_is_keyword_only():
+    reg: HookRegistry = HookRegistry()
+    with pytest.raises(TypeError):
+        reg.register(lambda x: x, 100)  # positional priority rejected
+
+
+def test_register_invalidates_run_order_cache():
+    reg: HookRegistry = HookRegistry()
+
+    @reg.register(priority=10)
+    def a(x):
+        return x
+
+    assert list(reg) == [a]
+
+    @reg.register(priority=-10)
+    def b(x):
+        return x
+
+    assert list(reg) == [b, a]  # cache rebuilt after the new registration
+
+
+def test_clear_drops_all_handlers():
+    reg: HookRegistry = HookRegistry()
+
+    @reg.register(priority=3)
+    def a(x):
+        return x
+
+    assert len(reg) == 1
+    reg.clear()
+    assert len(reg) == 0
+    assert list(reg) == []

--- a/tests/renderer/test_seealso.py
+++ b/tests/renderer/test_seealso.py
@@ -138,15 +138,16 @@ def test_object_without_docstring_passes_through():
 def test_add_seealso_registers_on_import():
     from great_docs.hooks import _object_resolved
 
-    assert add_seealso in _object_resolved._OBJECT_RESOLVED_HOOKS
+    assert add_seealso in _object_resolved.REGISTRY
 
 
-def test_nodoc_is_registered_before_seealso():
-    # nodoc must short-circuit before seealso runs.
+def test_nodoc_runs_before_seealso():
+    # nodoc must short-circuit before seealso runs — enforced by priority,
+    # not import order. Assert run order, not the priority numbers.
     from great_docs._builtin._directives import exclude_nodoc
     from great_docs.hooks import _object_resolved
 
-    order = _object_resolved._OBJECT_RESOLVED_HOOKS
+    order = list(_object_resolved.REGISTRY)
     assert order.index(exclude_nodoc) < order.index(add_seealso)
 
 


### PR DESCRIPTION
This PR implements an explicit **priority** for event handlers, so run order can be influenced at the handler instead of always being implicitly inferred from import (registration) order.

The existing handlers for `%nodoc` and `%seealso` have been switched to use this registry.

Requires #257.