### PR TITLE
Preserve authored frontmatter title on index page

### DIFF
--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -10786,6 +10786,11 @@ title: "Authors and Citation"
         for warning in warnings:
             print(warning)
 
+        # Title for the generated homepage. Empty by default so "Home" doesn't
+        # appear on an auto-generated landing page; a user-authored source file
+        # may override it via its frontmatter title.
+        homepage_title = ""
+
         if source_file is None:
             print("No index source file found (index.qmd, index.md, README.md, or README.rst)")
             print("Generating landing page from package metadata...")
@@ -10809,8 +10814,12 @@ title: "Authors and Citation"
             # wrapper template below supplies its own frontmatter, so embedding
             # the source's frontmatter mid-document would render it as a
             # horizontal rule plus visible raw YAML text (e.g. index.qmd files,
-            # which universally start with a `---` block).
-            _, readme_content = self._split_frontmatter(readme_content)
+            # which universally start with a `---` block). The source title is
+            # carried over into the wrapper so an authored title survives.
+            source_fm, readme_content = self._split_frontmatter(readme_content)
+            source_title = source_fm.get("title", "")
+            if isinstance(source_title, str) and source_title:
+                homepage_title = source_title
 
             # Copy images referenced in the source file to the build directory
             self._copy_readme_images(source_file)
@@ -10859,7 +10868,6 @@ section.level2:first-of-type > h2:first-child,
 """
 
         # Create a qmd file with the README content
-        # Use empty title so "Home" doesn't appear on landing page
         # Add margin content in a special div that Quarto will place in the margin
         # Prepend hero section (raw HTML block) when enabled
         hero_block = ""
@@ -10869,9 +10877,13 @@ section.level2:first-of-type > h2:first-child,
 
 """
 
+        # Render the title line YAML-safe (quotes/colons in an authored title
+        # are escaped). Empty title renders as `title: ""`.
+        title_line = format_yaml({"title": homepage_title}).rstrip()
+
         if margin_content:
             qmd_content = f"""---
-title: ""
+{title_line}
 toc: false
 body-classes: "gd-homepage"
 ---
@@ -10884,7 +10896,7 @@ body-classes: "gd-homepage"
 """
         else:
             qmd_content = f"""---  # pragma: no cover
-title: ""
+{title_line}
 toc: false
 body-classes: "gd-homepage"
 ---

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -4157,6 +4157,96 @@ def test_readme_rst_not_used_when_readme_md_exists():
         assert "RST readme" not in content
 
 
+def _homepage_frontmatter(content: str) -> dict:
+    """Parse the leading YAML frontmatter block from generated homepage content."""
+    assert content.startswith("---")
+    _, fm_text, _ = content.split("---", 2)
+    return parse_yaml(fm_text) or {}
+
+
+def test_index_qmd_frontmatter_title_preserved():
+    """Authored frontmatter title on the index source survives into index.qmd."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        (project_path / "pyproject.toml").write_text(
+            '[project]\nname = "test"\nversion = "1.0"\n'
+        )
+        (project_path / "great-docs.yml").write_text("")
+
+        (project_path / "index.qmd").write_text(
+            '---\ntitle: "My Package"\n---\n\n## Getting Started\n\nHello.\n'
+        )
+
+        pkg_dir = project_path / "test"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text("")
+
+        docs = GreatDocs(project_path=tmp_dir)
+        docs.project_path.mkdir(parents=True, exist_ok=True)
+        docs._create_index_from_readme(force_rebuild=True)
+
+        content = (docs.project_path / "index.qmd").read_text()
+        fm = _homepage_frontmatter(content)
+
+        assert fm["title"] == "My Package"
+        assert fm["toc"] is False
+        assert fm["body-classes"] == "gd-homepage"
+
+
+def test_index_qmd_frontmatter_title_empty_without_source_title():
+    """A source file with no title yields an empty homepage title."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        (project_path / "pyproject.toml").write_text(
+            '[project]\nname = "test"\nversion = "1.0"\n'
+        )
+        (project_path / "great-docs.yml").write_text("")
+
+        (project_path / "README.md").write_text("## Getting Started\n\nHello.\n")
+
+        pkg_dir = project_path / "test"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text("")
+
+        docs = GreatDocs(project_path=tmp_dir)
+        docs.project_path.mkdir(parents=True, exist_ok=True)
+        docs._create_index_from_readme(force_rebuild=True)
+
+        content = (docs.project_path / "index.qmd").read_text()
+        fm = _homepage_frontmatter(content)
+
+        assert fm["title"] == ""
+
+
+def test_index_qmd_frontmatter_title_yaml_safe():
+    """A title with YAML-special characters round-trips through the frontmatter."""
+    tricky_title = 'A: B "quoted"'
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        (project_path / "pyproject.toml").write_text(
+            '[project]\nname = "test"\nversion = "1.0"\n'
+        )
+        (project_path / "great-docs.yml").write_text("")
+
+        source_fm = format_yaml({"title": tricky_title}).rstrip()
+        (project_path / "index.qmd").write_text(
+            f"---\n{source_fm}\n---\n\n## Getting Started\n\nHello.\n"
+        )
+
+        pkg_dir = project_path / "test"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text("")
+
+        docs = GreatDocs(project_path=tmp_dir)
+        docs.project_path.mkdir(parents=True, exist_ok=True)
+        docs._create_index_from_readme(force_rebuild=True)
+
+        content = (docs.project_path / "index.qmd").read_text()
+        fm = _homepage_frontmatter(content)
+
+        assert fm["title"] == tricky_title
+
+
 def test_convert_rst_to_markdown_real_pandoc():
     """Test RST to Markdown conversion via pandoc."""
 


### PR DESCRIPTION
The homepage builder discarded the source file's frontmatter and hardcoded `title: ""`, causing Quarto to promote the first content heading to the page H1. Carry over a non-empty string title from the source frontmatter into the generated index.qmd, rendered YAML-safe via format_yaml, and keep the empty-title fallback for the auto-generated landing page and title-less sources.

Fixes #258