### PR TITLE
Skip API reference generation for non-Python projects

### DIFF
--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -11189,6 +11189,14 @@ anchor-sections: true
             self._has_api_reference = False
             return
 
+        # Python API reference only applies to projects with a Python component.
+        # Non-Python projects (e.g. project_type: go) have no importable package
+        # to introspect — skip rather than prompting for a package name.
+        if not self._config.is_python_project:
+            print("API reference skipped (non-Python project)")
+            self._has_api_reference = False
+            return
+
         quarto_yml = self.project_path / "_quarto.yml"
 
         with open(quarto_yml, "r") as f:

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -16343,6 +16343,36 @@ def test_add_api_reference_config_disabled():
         assert docs._has_api_reference is False
 
 
+def test_add_api_reference_config_non_python_project():
+    """Test _add_api_reference_config skips for non-Python projects.
+
+    A Go project has no importable Python package, so the step should skip
+    (setting _has_api_reference = False) rather than prompting for a package name.
+    """
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        docs = GreatDocs(project_path=tmp_dir)
+
+        # Go project marker; no pyproject.toml / __init__.py anywhere.
+        (Path(tmp_dir) / "go.mod").write_text("module example.com/tool\n", encoding="utf-8")
+
+        gd_yml = Path(tmp_dir) / "great-docs.yml"
+        gd_yml.write_text("project_type: go\n", encoding="utf-8")
+        docs._config = Config(Path(tmp_dir))
+
+        quarto_yml = docs.project_path / "_quarto.yml"
+        quarto_yml.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(quarto_yml, "w") as f:
+            write_yaml({"project": {"type": "website"}}, f)
+
+        # Must not call input() — patch it to fail loudly if the skip is missed.
+        with patch("builtins.input", side_effect=AssertionError("should not prompt")):
+            docs._add_api_reference_config()
+
+        assert docs._has_api_reference is False
+
+
 def test_add_api_reference_config_no_exports():
     """Test _add_api_reference_config skips when no exports found."""
 


### PR DESCRIPTION
## Problem

Running `great-docs build` in a Go-only project (`project_type: go`) blocks on an interactive prompt:

```
Could not auto-detect package name. Enter package name for API reference (or press Enter to skip):
```

`_add_api_reference_config()` ran for every project regardless of type. For a Go project there is no root `pyproject.toml` or top-level Python package, so `_detect_package_name()` returns `None` and the build drops into an `input()` prompt — which hangs non-interactive and `uvx`-driven builds.

## Fix

Gate the API-reference step on the existing `Config.is_python_project`, so non-Python projects skip it cleanly. This mirrors how the PyPI link already defaults off for non-Python projects, and needs no new config key — `project_type` already carries the necessary information. The separate Go CLI reference path is unaffected.

```python
if not self._config.is_python_project:
    print("API reference skipped (non-Python project)")
    self._has_api_reference = False
    return
```

## Testing

- Added `test_add_api_reference_config_non_python_project`, which patches `builtins.input` to fail loudly if the prompt is ever reached for a Go project.
- All 8 `add_api_reference_config` tests pass.
- Verified end-to-end: `great-docs build` on a Go project (velocirepo) now completes without prompting, prints `API reference skipped (non-Python project)`, and still generates the Go CLI reference.

The 23 pre-existing failures in `tests/test_synthetic.py` are unrelated to this change (confirmed by reproducing them on `main`).