### PR TITLE
Fix mid-word truncation of Go CLI command descriptions

### DIFF
--- a/great_docs/_go_cli.py
+++ b/great_docs/_go_cli.py
@@ -319,6 +319,45 @@ def _parse_cobra_flag(raw: str) -> dict | None:
     }
 
 
+def _short_help(description: str, limit: int = 150) -> str:
+    """Condense a full command description into a one-line summary.
+
+    Cobra's root/group `--help` prints the command's full (Long) description, which can span
+    several sentences. The CLI reference *index* page shows only a one-line summary per command, so
+    this trims the description to the first sentence when that is short enough, otherwise truncates
+    on a word boundary and appends an ellipsis. Mirrors the Click path's
+    ``get_short_help_str(limit=...)`` behaviour so both ecosystems read consistently.
+
+    Parameters
+    ----------
+    description
+        The full (already whitespace-collapsed) command description.
+    limit
+        Maximum length of the returned summary, excluding the ellipsis.
+
+    Returns
+    -------
+    str
+        A one-line summary, never cut mid-word.
+    """
+    description = description.strip()
+    if not description:
+        return ""
+
+    # Prefer the first sentence when it comfortably fits.
+    first_sentence = description.split(". ", 1)[0].rstrip(".")
+    if len(first_sentence) <= limit:
+        return first_sentence
+
+    if len(description) <= limit:
+        return description
+
+    # Truncate on a word boundary and mark the elision. Uses "..." (three dots)
+    # to match Click's get_short_help_str placeholder for consistency.
+    truncated = description[:limit].rsplit(" ", 1)[0].rstrip()
+    return f"{truncated}..."
+
+
 def _extract_cobra_commands(
     binary_path: Path,
     name: str,
@@ -482,7 +521,7 @@ def _parse_cobra_help(
         "name": name,
         "full_path": node_full_path,
         "help": description,
-        "short_help": description[:80] if description else "",
+        "short_help": _short_help(description),
         "help_text": help_text,
         "description": description,
         "examples": "",

--- a/tests/test_go_cli.py
+++ b/tests/test_go_cli.py
@@ -22,6 +22,7 @@ from great_docs._go_cli import (
     _parse_cobra_flag,
     _parse_cobra_help,
     _parse_go_module_path,
+    _short_help,
     _uses_cobra,
     build_go_binary,
     detect_go_cli_project,
@@ -342,6 +343,40 @@ SAMPLE_COBRA_HELP = textwrap.dedent("""\
 
     Use "hello [command] --help" for more information about a command.
 """)
+
+
+class TestShortHelp:
+    def test_empty(self):
+        assert _short_help("") == ""
+        assert _short_help("   ") == ""
+
+    def test_short_description_unchanged(self):
+        assert _short_help("Fetch from all configured sources") == (
+            "Fetch from all configured sources"
+        )
+
+    def test_first_sentence_preferred(self):
+        desc = "Fetch metrics. Also does other things across many sources and registries."
+        assert _short_help(desc) == "Fetch metrics"
+
+    def test_long_first_sentence_truncated_on_word_boundary(self):
+        # A single long sentence with no ". " break: must truncate, never mid-word.
+        desc = (
+            "velocirepo tracks your open-source project's pulse across package registries, "
+            "GitHub, and the web collecting daily metrics from many different services "
+            "including PyPI, CRAN, Homebrew, Plausible, OpenVSX, and YouTube every day"
+        )
+        result = _short_help(desc)
+        assert result.endswith("...")
+        assert len(result) <= 153  # limit (150) + "..."
+        # No mid-word cut: the trimmed body is a prefix ending at a full word.
+        body = result.removesuffix("...")
+        assert desc.startswith(body)
+        assert desc[len(body)] == " "
+
+    def test_no_ellipsis_when_within_limit(self):
+        desc = "A single sentence that stays under the character limit for summaries"
+        assert not _short_help(desc).endswith("...")
 
 
 class TestParseCobraHelp:


### PR DESCRIPTION
## Problem

On the CLI reference index page (`/reference/cli/`), a Go CLI's command summary was cut off mid-word with no ellipsis:

```
velocirepo tracks your open-source project's pulse across package registries, Gi
```

The summary (`short_help`) for Cobra commands was built with a hard `description[:80]` slice in `_go_cli.py`. Cobra's root and group `--help` output carries the full (Long) description, so slicing the first 80 characters cut it mid-word.

(Subcommands were unaffected — their summaries come from Cobra's concise "Available Commands" listing. The Click CLI path already handled this correctly via `get_short_help_str(limit=150)`; the Go path just didn't match it.)

## Fix

Introduce a `_short_help()` helper that prefers the first sentence and otherwise truncates on a word boundary with an ellipsis, using the **same 150-char limit and `...` placeholder** as the Click path so both ecosystems read consistently.

## Testing

- Added `TestShortHelp` covering the empty, short, first-sentence, long-single-sentence (word-boundary + ellipsis), and within-limit cases.
- All 60 `tests/test_go_cli.py` tests pass.
- Verified end-to-end: rebuilding a Go project (velocirepo) now renders the summary truncated on a word boundary with `...` instead of a mid-word cut.