### PR TITLE
fix: copying of dark mode assets

### DIFF
--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -11686,12 +11686,16 @@ anchor-sections: true
             if lb_res not in config["project"]["resources"]:
                 config["project"]["resources"].append(lb_res)
 
-        # Add user-guide/images/** to resources so that images referenced only
-        # via data attributes (e.g., dark-mode variants) get copied to _site
-        ug_images_dir = self.project_path / "user-guide" / "images"
-        if ug_images_dir.exists() and ug_images_dir.is_dir():
-            if "user-guide/images/**" not in config["project"]["resources"]:
-                config["project"]["resources"].append("user-guide/images/**")
+        # Add all user-guide asset directories to resources so that images
+        # referenced only via data attributes (e.g., dark-mode variants) get
+        # copied to _site
+        ug_dir = self.project_path / "user-guide"
+        if ug_dir.exists() and ug_dir.is_dir():
+            for item in ug_dir.iterdir():
+                if item.is_dir() and not any(f.suffix == ".qmd" for f in item.rglob("*")):
+                    res_glob = f"user-guide/{item.name}/**"
+                    if res_glob not in config["project"]["resources"]:
+                        config["project"]["resources"].append(res_glob)
 
         # Add assets directory to resources if it exists
         assets_dir = self.project_path / "assets"

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -11703,6 +11703,26 @@ anchor-sections: true
             if "assets/**" not in config["project"]["resources"]:
                 config["project"]["resources"].append("assets/**")
 
+        # Add custom section asset directories to resources
+        sections_config = self._config.sections
+        if sections_config and isinstance(sections_config, list):
+            for section_cfg in sections_config:
+                if not isinstance(section_cfg, dict):
+                    continue
+                src_dir = section_cfg.get("dir")
+                if not src_dir:
+                    continue
+                slug = src_dir.replace("_", "-").replace(" ", "-").lower()
+                section_build_dir = self.project_path / slug
+                if section_build_dir.exists() and section_build_dir.is_dir():
+                    for item in section_build_dir.iterdir():
+                        if item.is_dir() and not any(
+                            f.suffix == ".qmd" for f in item.rglob("*")
+                        ):
+                            res_glob = f"{slug}/{item.name}/**"
+                            if res_glob not in config["project"]["resources"]:
+                                config["project"]["resources"].append(res_glob)
+
         # Add skill.md and .well-known to resources (so Quarto copies them to _site)
         # Also exclude them from rendering so Quarto doesn't convert them to HTML
         if self._config.skill_enabled:

--- a/test-packages/synthetic/catalog.py
+++ b/test-packages/synthetic/catalog.py
@@ -402,6 +402,8 @@ ALL_PACKAGES: list[str] = [
     "gdtest_custom_css",  # 199
     # 200: Minimal Go CLI project — go.mod + cobra-style --help, no Python module
     "gdtest_go_cli",  # 200
+    # 201: Dark-mode image assets in user guide non-images/ subdirectories
+    "gdtest_ug_dark_assets",  # 201
 ]
 
 
@@ -2258,6 +2260,14 @@ PACKAGE_DESCRIPTIONS: dict[str, str] = {
         "and 'help' excluded). Each subcommand should have its own page with "
         "flags documented. The landing page comes from README.md. There is no "
         "API Reference section — the site is driven entirely by the Go CLI."
+    ),
+    # ── 201: Dark-mode image assets in user guide subdirectories ─────
+    "gdtest_ug_dark_assets": (
+        "User guide with dark-mode image assets in non-images/ subdirectories "
+        "(assets/orientation/, assets/charts/, assets/diagrams/). Tests that "
+        "dark-mode siblings — both naming-convention (.light./.dark.) and "
+        "explicit dark= attribute — are copied to _site. Regression test for "
+        "GitHub issue #268."
     ),
 }
 

--- a/test-packages/synthetic/specs/gdtest_ug_dark_assets.py
+++ b/test-packages/synthetic/specs/gdtest_ug_dark_assets.py
@@ -1,0 +1,189 @@
+"""
+gdtest_ug_dark_assets — Dark-mode image assets in user guide subdirectories.
+
+Dimensions: M1
+Focus: Verify that dark-mode image siblings (both naming-convention and
+explicit `dark=` attribute) are copied to `_site` when images live in
+non-`images/` asset subdirectories within the user guide (e.g.,
+`assets/`, `figures/`).
+"""
+
+
+def _svg(width, height, bg, label, text_color="white"):
+    """Generate a simple labeled SVG as a string."""
+    return (
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}">'
+        f'<rect width="{width}" height="{height}" fill="{bg}" rx="8"/>'
+        f'<text x="{width // 2}" y="{height // 2 + 6}" text-anchor="middle" '
+        f'fill="{text_color}" font-size="16" font-family="sans-serif">{label}</text>'
+        f"</svg>\n"
+    )
+
+
+SPEC = {
+    "name": "gdtest_ug_dark_assets",
+    "description": "User guide with dark-mode image assets in non-images/ subdirectories.",
+    "dimensions": ["M1"],
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-ug-dark-assets",
+            "version": "0.1.0",
+            "description": "Test dark-mode asset copying in user guide subdirectories.",
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    },
+    "files": {
+        "gdtest_ug_dark_assets/__init__.py": ('"""Test package for dark-mode asset copying."""\n'),
+        "gdtest_ug_dark_assets/core.py": '''\
+            """Core module."""
+
+
+            def process(data: str) -> str:
+                """Process input data.
+
+                Parameters
+                ----------
+                data : str
+                    The input data to process.
+
+                Returns
+                -------
+                str
+                    The processed output.
+                """
+                return data
+        ''',
+        "README.md": "# gdtest-ug-dark-assets\n\nTest dark-mode asset copying.\n",
+        # ── User guide pages ─────────────────────────────────────────
+        "user_guide/01-naming-convention.qmd": """\
+            ---
+            title: "Naming Convention Dark Mode"
+            ---
+
+            ## Auto-Detected Dark Variants
+
+            Images using the `.light.ext` / `.dark.ext` naming convention
+            swap automatically when the reader toggles dark mode.
+
+            ![Sweep generator](assets/orientation/sweep-generator.light.svg){.lightbox}
+
+            The dark variant `sweep-generator.dark.svg` should load in dark mode.
+
+            ## Second Example
+
+            ![Dashboard overview](assets/charts/dashboard.light.svg){.lightbox}
+        """,
+        "user_guide/02-explicit-dark.qmd": """\
+            ---
+            title: "Explicit Dark Attribute"
+            ---
+
+            ## Explicit dark= Attribute
+
+            Use `dark="..."` to point at a non-conventionally named dark variant:
+
+            ![Component diagram](assets/diagrams/component-day.svg){.lightbox dark="assets/diagrams/component-night.svg"}
+
+            ## Mixed: Convention + Explicit
+
+            Convention-based (auto-detected):
+
+            ![Flow chart](assets/diagrams/flow.light.svg){.lightbox}
+
+            Explicit override on a convention-named file:
+
+            ![Dashboard overview](assets/charts/dashboard.light.svg){.lightbox dark="assets/charts/dashboard-custom-dark.svg"}
+        """,
+        "user_guide/03-in-images-dir.qmd": """\
+            ---
+            title: "Images in Standard Directory"
+            ---
+
+            ## Standard images/ Directory
+
+            Images in `images/` have always worked. This page confirms that:
+
+            ![Status panel](images/status.light.svg){.lightbox}
+        """,
+        # ── Asset files: assets/orientation/ ──────────────────────────
+        "user_guide/assets/orientation/sweep-generator.light.svg": _svg(
+            600, 400, "#f0f4f8", "Sweep Generator (Light)", "#333"
+        ),
+        "user_guide/assets/orientation/sweep-generator.dark.svg": _svg(
+            600, 400, "#1a1a2e", "Sweep Generator (Dark)"
+        ),
+        # ── Asset files: assets/charts/ ──────────────────────────────
+        "user_guide/assets/charts/dashboard.light.svg": _svg(
+            700, 450, "#ffffff", "Dashboard (Light)", "#333"
+        ),
+        "user_guide/assets/charts/dashboard.dark.svg": _svg(
+            700, 450, "#16213e", "Dashboard (Dark)"
+        ),
+        "user_guide/assets/charts/dashboard-custom-dark.svg": _svg(
+            700, 450, "#0d1117", "Dashboard (Custom Dark)"
+        ),
+        # ── Asset files: assets/diagrams/ ────────────────────────────
+        "user_guide/assets/diagrams/component-day.svg": _svg(
+            600, 380, "#fafafa", "Component Diagram (Day)", "#333"
+        ),
+        "user_guide/assets/diagrams/component-night.svg": _svg(
+            600, 380, "#0f3460", "Component Diagram (Night)"
+        ),
+        "user_guide/assets/diagrams/flow.light.svg": _svg(
+            500, 350, "#f5f5f5", "Flow Chart (Light)", "#333"
+        ),
+        "user_guide/assets/diagrams/flow.dark.svg": _svg(500, 350, "#1e1e2f", "Flow Chart (Dark)"),
+        # ── Asset files: images/ (standard dir, for comparison) ──────
+        "user_guide/images/status.light.svg": _svg(
+            500, 300, "#e8f0fe", "Status Panel (Light)", "#333"
+        ),
+        "user_guide/images/status.dark.svg": _svg(500, 300, "#1a1a2e", "Status Panel (Dark)"),
+    },
+    "expected": {
+        "detected_name": "gdtest-ug-dark-assets",
+        "detected_module": "gdtest_ug_dark_assets",
+        "detected_parser": "numpy",
+        "has_user_guide": True,
+        "files_exist": [
+            # User guide pages rendered
+            "great-docs/user-guide/naming-convention.html",
+            "great-docs/user-guide/explicit-dark.html",
+            "great-docs/user-guide/in-images-dir.html",
+            # Light images must be in _site
+            "great-docs/_site/user-guide/assets/orientation/sweep-generator.light.svg",
+            "great-docs/_site/user-guide/assets/charts/dashboard.light.svg",
+            "great-docs/_site/user-guide/assets/diagrams/component-day.svg",
+            "great-docs/_site/user-guide/assets/diagrams/flow.light.svg",
+            "great-docs/_site/user-guide/images/status.light.svg",
+            # Dark siblings must ALSO be in _site (this is the bug fix)
+            "great-docs/_site/user-guide/assets/orientation/sweep-generator.dark.svg",
+            "great-docs/_site/user-guide/assets/charts/dashboard.dark.svg",
+            "great-docs/_site/user-guide/assets/charts/dashboard-custom-dark.svg",
+            "great-docs/_site/user-guide/assets/diagrams/component-night.svg",
+            "great-docs/_site/user-guide/assets/diagrams/flow.dark.svg",
+            "great-docs/_site/user-guide/images/status.dark.svg",
+        ],
+        "coverage_exclude": [
+            "ref",
+            "nodoc",
+            "bigcl",
+            "ug",
+            "supp",
+            "title",
+            "badge",
+            "sig",
+            "desc",
+            "param",
+            "pmatch",
+            "ret",
+            "refidx",
+            "sechdg",
+            "sbar",
+            "sbsec",
+            "hdg",
+        ],
+    },
+}

--- a/user_guide/43-lightbox.qmd
+++ b/user_guide/43-lightbox.qmd
@@ -92,6 +92,33 @@ With that markup, a dark-mode reader sees `city-toronto.dark.png` while a light-
 The naming convention only triggers on the `.light` opt-in. A plain `skyline.png` will not silently look for `skyline.dark.png`, because that guessed file usually does not exist and would produce a broken image in the enlarged view.
 :::
 
+### How Dark-Mode Assets Are Copied
+
+Great Docs automatically copies dark-mode image siblings to the built site, regardless of where the
+images live. You can place images in any asset subdirectory within your user guide (`images/`,
+`assets/`, `figures/`, or any other name) and both the light and dark variants will be included in
+the final `_site/` output.
+
+For example, a user guide structured like this:
+
+```
+user_guide/
+├── getting-started.qmd
+└── assets/
+    └── orientation/
+        ├── sweep-generator.light.png
+        └── sweep-generator.dark.png
+```
+
+will have both `sweep-generator.light.png` and `sweep-generator.dark.png` available at
+`user-guide/assets/orientation/` in the built site. The same applies to images referenced via the
+`dark="..."` attribute. The target file is copied as long as it lives in an asset directory within
+the user guide.
+
+Custom sections configured via `sections:` in `great_docs.yaml` follow the same rules: any asset
+subdirectory (a directory without `.qmd` files) is automatically registered for copying to the final
+site.
+
 ## Galleries
 
 Give several images the same `group` value to bind them into a gallery. Opening any one of them lets the reader page through the whole set with arrows, a filmstrip, keyboard keys, and touch swipes.


### PR DESCRIPTION
This PR improves how we handle dark-mode image assets in user guides. It ensures that both light and dark image variants are correctly copied to the built site, even when assets are stored in non-standard subdirectories. The PR also adds new regression tests (GDG site) and updates the documentation to clarify the new behavior.

Fixes: https://github.com/posit-dev/great-docs/issues/268