### PR TITLE
feat: add code includes

### DIFF
--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -2865,15 +2865,13 @@ class GreatDocs:
             dest_dir = self.project_path / slug
             dest_dir.mkdir(parents=True, exist_ok=True)
 
-            # Copy asset directories (directories without .qmd files)
+            # Copy asset directories (images, data, code snippets, etc.)
             for item in source_path.iterdir():
-                if item.is_dir():
-                    has_qmd = any(f.suffix == ".qmd" for f in item.rglob("*"))
-                    if not has_qmd:
-                        dst_dir = dest_dir / item.name
-                        if dst_dir.exists():
-                            shutil.rmtree(dst_dir)
-                        shutil.copytree(item, dst_dir)
+                if item.is_dir() and self._is_asset_dir(item):
+                    dst_dir = dest_dir / item.name
+                    if dst_dir.exists():
+                        shutil.rmtree(dst_dir)
+                    shutil.copytree(item, dst_dir)
 
             if section_type == "blog":
                 # Blog sections use Quarto's native listing directive
@@ -3005,6 +3003,9 @@ class GreatDocs:
 
             content = src_file.read_text(encoding="utf-8")
 
+            # Expand {{< code-include >}} shortcodes before Quarto sees the file
+            content = self._expand_code_includes(content, src_file.parent)
+
             # Fix links to .qmd files with numeric prefixes
             content = self._fix_numeric_prefix_links(content)
 
@@ -3096,6 +3097,9 @@ class GreatDocs:
             content_dirs.add(src_file.parent)
 
             content = src_file.read_text(encoding="utf-8")
+
+            # Expand {{< code-include >}} shortcodes before Quarto sees the file
+            content = self._expand_code_includes(content, src_file.parent)
 
             # Parse frontmatter for metadata (but don't modify it —
             # Quarto's listing needs the original frontmatter)
@@ -5503,6 +5507,9 @@ class GreatDocs:
             with open(src_path, "r", encoding="utf-8") as f:
                 content = f.read()
 
+            # Expand {{< code-include >}} shortcodes before Quarto sees the file
+            content = self._expand_code_includes(content, src_path.parent)
+
             # In auto-discovery mode, fix links to .qmd files with numeric prefixes
             if not is_explicit:
                 content = self._fix_numeric_prefix_links(content)
@@ -5516,19 +5523,33 @@ class GreatDocs:
 
             copied_files.append(f"user-guide/{dest_rel_path}")
 
-        # Also copy any asset directories (directories without .qmd files)
+        # Also copy any asset directories (images, data, code snippets, etc.)
         for item in source_dir.iterdir():
-            if item.is_dir():
-                # Check if this directory has any .qmd files
-                has_qmd = any(f.suffix == ".qmd" for f in item.rglob("*"))
-                if not has_qmd:
-                    # This is likely an asset directory, copy it
-                    dst_dir = target_dir / item.name
-                    if dst_dir.exists():
-                        shutil.rmtree(dst_dir)  # pragma: no cover
-                    shutil.copytree(item, dst_dir)
+            if item.is_dir() and self._is_asset_dir(item):
+                dst_dir = target_dir / item.name
+                if dst_dir.exists():
+                    shutil.rmtree(dst_dir)  # pragma: no cover
+                shutil.copytree(item, dst_dir)
 
         return copied_files
+
+    @staticmethod
+    def _is_asset_dir(directory: Path) -> bool:
+        """
+        Determine whether *directory* is an asset directory (images, data, snippets, etc.).
+
+        A directory is considered an asset directory when either:
+
+        - It contains no ``.qmd`` files at any depth, **or**
+        - Its name starts with ``_`` (e.g., ``_includes/``, ``_snippets/``).
+
+        The underscore rule lets authors store ``.qmd`` snippets intended for
+        ``code-include`` (or other non-page purposes) alongside images and data
+        files without the directory being mistaken for a content subdirectory.
+        """
+        if directory.name.startswith("_"):
+            return True
+        return not any(f.suffix == ".qmd" for f in directory.rglob("*"))
 
     def _add_frontmatter_option(self, content: str, key: str, value) -> str:
         """
@@ -5577,6 +5598,192 @@ class GreatDocs:
 
         # No frontmatter, create one
         return f"---\n{key}: {yaml_value}\n---\n\n{content}"
+
+    _CODE_INCLUDE_RE = re.compile(
+        r"\{\{<\s*include\s+(.*?)\s*>\}\}",
+    )
+
+    _CONTENT_EXTENSIONS = {".qmd", ".md"}
+
+    _EXT_TO_LANG: dict[str, str] = {
+        ".py": "python",
+        ".r": "r",
+        ".js": "javascript",
+        ".ts": "typescript",
+        ".jsx": "jsx",
+        ".tsx": "tsx",
+        ".rb": "ruby",
+        ".rs": "rust",
+        ".go": "go",
+        ".java": "java",
+        ".cpp": "cpp",
+        ".cc": "cpp",
+        ".cxx": "cpp",
+        ".c": "c",
+        ".h": "c",
+        ".hpp": "cpp",
+        ".cs": "csharp",
+        ".css": "css",
+        ".scss": "scss",
+        ".html": "html",
+        ".sql": "sql",
+        ".sh": "bash",
+        ".bash": "bash",
+        ".zsh": "bash",
+        ".yaml": "yaml",
+        ".yml": "yaml",
+        ".json": "json",
+        ".toml": "toml",
+        ".xml": "xml",
+        ".lua": "lua",
+        ".swift": "swift",
+        ".kt": "kotlin",
+        ".scala": "scala",
+        ".jl": "julia",
+        ".m": "matlab",
+        ".pl": "perl",
+        ".php": "php",
+    }
+
+    def _expand_code_includes(self, content: str, source_dir: Path) -> str:
+        """
+        Replace ``{{< include path >}}`` shortcodes with fenced code blocks.
+
+        Only intercepts includes that target code files (non-``.qmd``/``.md``)
+        or that use the ``lang`` or ``lines`` keywords.  Plain
+        ``{{< include _shared.qmd >}}`` shortcodes are left untouched so
+        Quarto can handle them natively.
+
+        Supports optional keyword arguments:
+
+        - ``lang="python"`` — override the auto-detected language
+        - ``lines="5-10"`` — include only the specified line range (1-based, inclusive)
+
+        File paths are resolved first relative to *source_dir* (the directory
+        containing the source ``.qmd`` file), then relative to the project root.
+
+        Parameters
+        ----------
+        content
+            The ``.qmd`` file content.
+        source_dir
+            Directory of the source file (for relative path resolution).
+
+        Returns
+        -------
+        str
+            Content with code-file ``include`` shortcodes replaced by fenced
+            code blocks.
+        """
+
+        def _replace(m: re.Match) -> str:
+            raw_args = m.group(1)
+
+            file_path_str, lang, lines_spec = self._parse_code_include_args(raw_args)
+
+            if not file_path_str:
+                return m.group(0)
+
+            ext = Path(file_path_str).suffix.lower()
+            is_content_file = ext in self._CONTENT_EXTENSIONS
+
+            if is_content_file and not lang and not lines_spec:
+                return m.group(0)
+
+            resolved = self._resolve_code_include_path(file_path_str, source_dir)
+            if resolved is None:
+                return f"<!-- include error: file not found: {file_path_str} -->"
+
+            try:
+                file_content = resolved.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as e:
+                return f"<!-- include error: {e} -->"
+
+            if lines_spec:
+                file_content = self._select_lines(file_content, lines_spec)
+
+            if not lang:
+                lang = self._EXT_TO_LANG.get(resolved.suffix.lower(), "")
+
+            longest_run = 0
+            current_run = 0
+            for ch in file_content:
+                if ch == "`":
+                    current_run += 1
+                    longest_run = max(longest_run, current_run)
+                else:
+                    current_run = 0
+            fence = "`" * max(3, longest_run + 1)
+            return f"{fence}{lang}\n{file_content.rstrip()}\n{fence}"
+
+        return self._CODE_INCLUDE_RE.sub(_replace, content)
+
+    @staticmethod
+    def _parse_code_include_args(raw: str) -> tuple[str, str, str]:
+        """
+        Parse ``include`` shortcode arguments.
+
+        Returns `(file_path, lang, lines)` where *lang* and *lines* may be empty strings if not
+        specified.
+        """
+        lang = ""
+        lines = ""
+        file_path = ""
+
+        # Extract keyword arguments
+        kw_re = re.compile(r'(\w+)\s*=\s*"([^"]*)"')
+        for kw_match in kw_re.finditer(raw):
+            key, value = kw_match.group(1), kw_match.group(2)
+            if key == "lang":
+                lang = value
+            elif key == "lines":
+                lines = value
+
+        # The file path is whatever remains after stripping keyword args
+        remaining = kw_re.sub("", raw).strip()
+        # Remove surrounding quotes if present
+        if remaining and remaining[0] in ('"', "'") and remaining[-1] == remaining[0]:
+            remaining = remaining[1:-1]
+        file_path = remaining
+
+        return file_path, lang, lines
+
+    def _resolve_code_include_path(self, file_path_str: str, source_dir: Path) -> Path | None:
+        """
+        Resolve a code-include file path.
+
+        Tries *source_dir* first, then the project root.
+        """
+        candidates = [
+            source_dir / file_path_str,
+            self.project_root / file_path_str,
+        ]
+        for candidate in candidates:
+            resolved = candidate.resolve()
+            if resolved.is_file():
+                return resolved
+        return None
+
+    @staticmethod
+    def _select_lines(content: str, lines_spec: str) -> str:
+        """
+        Select a range of lines from *content*.
+
+        *lines_spec* is `"start-end"` (1-based, inclusive) or `"N"` for a single line.
+        """
+        all_lines = content.splitlines(keepends=True)
+
+        if "-" in lines_spec:
+            parts = lines_spec.split("-", 1)
+            start = int(parts[0]) - 1
+            end = int(parts[1])
+        else:
+            start = int(lines_spec) - 1
+            end = start + 1
+
+        start = max(0, start)
+        end = min(len(all_lines), end)
+        return "".join(all_lines[start:end])
 
     # Regex for detecting a top-level `freeze:` key in YAML frontmatter
     _FREEZE_FM_RE = re.compile(r"^freeze:\s+(.+)$", re.MULTILINE)
@@ -11692,7 +11899,7 @@ anchor-sections: true
         ug_dir = self.project_path / "user-guide"
         if ug_dir.exists() and ug_dir.is_dir():
             for item in ug_dir.iterdir():
-                if item.is_dir() and not any(f.suffix == ".qmd" for f in item.rglob("*")):
+                if item.is_dir() and self._is_asset_dir(item):
                     res_glob = f"user-guide/{item.name}/**"
                     if res_glob not in config["project"]["resources"]:
                         config["project"]["resources"].append(res_glob)
@@ -11716,9 +11923,7 @@ anchor-sections: true
                 section_build_dir = self.project_path / slug
                 if section_build_dir.exists() and section_build_dir.is_dir():
                     for item in section_build_dir.iterdir():
-                        if item.is_dir() and not any(
-                            f.suffix == ".qmd" for f in item.rglob("*")
-                        ):
+                        if item.is_dir() and self._is_asset_dir(item):
                             res_glob = f"{slug}/{item.name}/**"
                             if res_glob not in config["project"]["resources"]:
                                 config["project"]["resources"].append(res_glob)

--- a/test-packages/synthetic/catalog.py
+++ b/test-packages/synthetic/catalog.py
@@ -404,6 +404,8 @@ ALL_PACKAGES: list[str] = [
     "gdtest_go_cli",  # 200
     # 201: Dark-mode image assets in user guide non-images/ subdirectories
     "gdtest_ug_dark_assets",  # 201
+    # 202: Code-include shortcode in user guide pages
+    "gdtest_code_include",  # 202
 ]
 
 
@@ -2268,6 +2270,14 @@ PACKAGE_DESCRIPTIONS: dict[str, str] = {
         "dark-mode siblings — both naming-convention (.light./.dark.) and "
         "explicit dark= attribute — are copied to _site. Regression test for "
         "GitHub issue #268."
+    ),
+    "gdtest_code_include": (
+        "User guide page exercising the {{< code-include >}} shortcode. "
+        "Includes a Python example file with auto language detection, a YAML "
+        "config file, a line-range selection (lines='1-3'), and a language "
+        "override (lang='text'). The module exports Widget (class) and "
+        "run_widget (function). Key test: code-include shortcode renders "
+        "embedded source files correctly in user guide pages."
     ),
 }
 

--- a/test-packages/synthetic/specs/gdtest_code_include.py
+++ b/test-packages/synthetic/specs/gdtest_code_include.py
@@ -1,0 +1,172 @@
+"""
+gdtest_code_include — Code-include shortcode in user guide pages.
+
+Dimensions: A1, B1, C4, D1, E6, F1, G1, H7
+Focus: {{< include >}} shortcode usage in user guide pages.
+       Tests basic includes with auto language detection, different file types,
+       line ranges, and language overrides.
+"""
+
+SPEC = {
+    "name": "gdtest_code_include",
+    "description": "Code-include shortcode in user guide pages",
+    "dimensions": ["A1", "B1", "C4", "D1", "E6", "F1", "G1", "H7"],
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-code-include",
+            "version": "0.1.0",
+            "description": "A synthetic test package demonstrating the include shortcode",
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    },
+    "files": {
+        "gdtest_code_include/__init__.py": '''\
+            """A test package demonstrating the include shortcode."""
+
+            __version__ = "0.1.0"
+            __all__ = ["Widget", "run_widget"]
+
+
+            class Widget:
+                """
+                A configurable widget.
+
+                Parameters
+                ----------
+                name
+                    The widget name.
+                """
+
+                def __init__(self, name: str):
+                    self.name = name
+                    self._color = "red"
+                    self._size = 5
+
+                def configure(self, color: str = "red", size: int = 5) -> None:
+                    """
+                    Configure the widget appearance.
+
+                    Parameters
+                    ----------
+                    color
+                        Widget color.
+                    size
+                        Widget size.
+                    """
+                    self._color = color
+                    self._size = size
+
+                def run(self) -> str:
+                    """
+                    Run the widget and return a result string.
+
+                    Returns
+                    -------
+                    str
+                        A summary of the widget state.
+                    """
+                    return f"{self.name}: color={self._color}, size={self._size}"
+
+
+            def run_widget(name: str, color: str = "blue", size: int = 10) -> str:
+                """
+                Create, configure, and run a widget in one call.
+
+                Parameters
+                ----------
+                name
+                    The widget name.
+                color
+                    Widget color.
+                size
+                    Widget size.
+
+                Returns
+                -------
+                str
+                    The widget result string.
+                """
+                w = Widget(name)
+                w.configure(color=color, size=size)
+                return w.run()
+        ''',
+        "gdtest_code_include/examples/demo.py": '''\
+            from gdtest_code_include import Widget
+
+            # Create and configure a widget
+            widget = Widget("demo")
+            widget.configure(color="blue", size=10)
+
+            # Run the widget
+            result = widget.run()
+            print(f"Result: {result}")
+        ''',
+        "gdtest_code_include/examples/config.yaml": '''\
+            app:
+              name: my-app
+              version: "1.0"
+              settings:
+                debug: true
+                log_level: info
+        ''',
+        "user_guide/01-includes.qmd": '''\
+            ---
+            title: Code Includes
+            guide-section: Tutorials
+            ---
+
+            This guide demonstrates the `include` shortcode, which lets you
+            embed source files directly into your documentation pages.
+
+            ## Basic Python Include
+
+            The simplest usage includes an entire file with automatic language
+            detection. The shortcode infers the language from the file extension.
+
+            {{< include gdtest_code_include/examples/demo.py >}}
+
+            ## Including a YAML File
+
+            The `include` shortcode works with any text file type. Here we
+            include a YAML configuration file, and the language is detected
+            automatically from the `.yaml` extension.
+
+            {{< include gdtest_code_include/examples/config.yaml >}}
+
+            ## Selecting a Line Range
+
+            You can include only specific lines from a file using the `lines`
+            parameter. This is useful for highlighting a particular section
+            without showing the entire file.
+
+            {{< include gdtest_code_include/examples/demo.py lines="1-3" >}}
+
+            ## Overriding the Language
+
+            Sometimes a file extension doesn't match the highlighting you want.
+            Use the `lang` parameter to override the auto-detected language. Here
+            we display a Python file with R syntax highlighting instead.
+
+            {{< include gdtest_code_include/examples/demo.py lang="r" >}}
+        ''',
+        "README.md": """\
+            # gdtest-code-include
+
+            A synthetic test package demonstrating the include shortcode.
+        """,
+    },
+    "expected": {
+        "detected_name": "gdtest-code-include",
+        "detected_module": "gdtest_code_include",
+        "detected_parser": "numpy",
+        "export_names": ["Widget", "run_widget"],
+        "num_exports": 2,
+        "section_titles": ["Classes", "Functions"],
+        "has_user_guide": True,
+        "user_guide_files": ["01-includes.qmd"],
+        "coverage_exclude": ["nodoc", "bigcl", "supp", "hdg"],
+    },
+}

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -2906,6 +2906,400 @@ def test_user_guide_discovers_mixed_extensions_and_nested_files():
         assert (docs_ug / "section1" / "topic1" / "deep-notes.md").exists()
 
 
+def test_expand_code_includes_basic():
+    """Test that code-include shortcodes are expanded into fenced code blocks."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        pyproject = project_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        # Create a code file to include
+        examples = project_path / "examples"
+        examples.mkdir()
+        (examples / "demo.py").write_text('print("hello")\nx = 42\n')
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        content = 'Some text\n\n{{< include examples/demo.py >}}\n\nMore text'
+        result = docs._expand_code_includes(content, project_path)
+
+        assert '```python\nprint("hello")\nx = 42\n```' in result
+        assert "Some text" in result
+        assert "More text" in result
+
+
+def test_expand_code_includes_lang_override():
+    """Test that the lang keyword overrides auto-detected language."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        pyproject = project_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        (project_path / "script.py").write_text("x = 1\n")
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        content = '{{< include script.py lang="text" >}}'
+        result = docs._expand_code_includes(content, project_path)
+        assert result.startswith("```text\n")
+
+
+def test_expand_code_includes_lines():
+    """Test that the lines keyword selects a range of lines."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        pyproject = project_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        (project_path / "code.py").write_text("line1\nline2\nline3\nline4\nline5\n")
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        content = '{{< include code.py lines="2-4" >}}'
+        result = docs._expand_code_includes(content, project_path)
+        assert "line2\nline3\nline4" in result
+        assert "line1" not in result
+        assert "line5" not in result
+
+
+def test_expand_code_includes_single_line():
+    """Test selecting a single line."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        pyproject = project_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        (project_path / "code.py").write_text("line1\nline2\nline3\n")
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        content = '{{< include code.py lines="2" >}}'
+        result = docs._expand_code_includes(content, project_path)
+        assert "line2" in result
+        assert "line1" not in result
+        assert "line3" not in result
+
+
+def test_expand_code_includes_relative_to_source_dir():
+    """Test that paths resolve relative to the source file's directory first."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        pyproject = project_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        user_guide = project_path / "user_guide"
+        user_guide.mkdir()
+        snippets = user_guide / "snippets"
+        snippets.mkdir()
+        (snippets / "example.py").write_text("local_code = True\n")
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        content = '{{< include snippets/example.py >}}'
+        result = docs._expand_code_includes(content, user_guide)
+        assert "local_code = True" in result
+
+
+def test_expand_code_includes_fallback_to_project_root():
+    """Test that paths fall back to project root if not found in source dir."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        pyproject = project_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        # File at project root level
+        src = project_path / "src"
+        src.mkdir()
+        (src / "app.js").write_text('console.log("hello");\n')
+
+        # Source dir is user_guide (doesn't contain src/app.js)
+        user_guide = project_path / "user_guide"
+        user_guide.mkdir()
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        content = '{{< include src/app.js >}}'
+        result = docs._expand_code_includes(content, user_guide)
+        assert "```javascript" in result
+        assert 'console.log("hello")' in result
+
+
+def test_expand_code_includes_missing_file():
+    """Test that a missing file produces an HTML comment error."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        pyproject = project_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        content = '{{< include does/not/exist.py >}}'
+        result = docs._expand_code_includes(content, project_path)
+        assert "<!-- include error:" in result
+        assert "file not found" in result
+
+
+def test_expand_code_includes_no_shortcodes():
+    """Test that content without code-include shortcodes passes through unchanged."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        pyproject = project_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        content = "# Hello\n\nSome regular content.\n\n{{< icon heart >}}\n"
+        result = docs._expand_code_includes(content, project_path)
+        assert result == content
+
+
+def test_expand_code_includes_passes_through_qmd():
+    """Test that {{< include file.qmd >}} without lang/lines is left for Quarto."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        pyproject = project_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        (project_path / "_shared.qmd").write_text("# Shared content\n")
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        content = "Before\n\n{{< include _shared.qmd >}}\n\nAfter"
+        result = docs._expand_code_includes(content, project_path)
+        assert result == content
+
+
+def test_expand_code_includes_qmd_with_lang_is_expanded():
+    """Test that {{< include file.qmd lang="markdown" >}} is expanded as code."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        pyproject = project_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        (project_path / "snippet.qmd").write_text("---\ntitle: Example\n---\n\nHello\n")
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        content = '{{< include snippet.qmd lang="markdown" >}}'
+        result = docs._expand_code_includes(content, project_path)
+        assert "```markdown" in result
+        assert "title: Example" in result
+
+
+def test_expand_code_includes_qmd_with_lines_is_expanded():
+    """Test that {{< include file.qmd lines="1-3" >}} is expanded as code."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        pyproject = project_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        (project_path / "snippet.qmd").write_text("line1\nline2\nline3\nline4\n")
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        content = '{{< include snippet.qmd lines="2-3" >}}'
+        result = docs._expand_code_includes(content, project_path)
+        assert "line2" in result
+        assert "line1" not in result
+        assert "{{< include" not in result
+
+
+def test_expand_code_includes_multiple():
+    """Test multiple include shortcodes in one file."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        pyproject = project_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        (project_path / "a.py").write_text("alpha\n")
+        (project_path / "b.yaml").write_text("key: value\n")
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        content = "First:\n\n{{< include a.py >}}\n\nSecond:\n\n{{< include b.yaml >}}\n"
+        result = docs._expand_code_includes(content, project_path)
+        assert "```python\nalpha\n```" in result
+        assert "```yaml\nkey: value\n```" in result
+
+
+def test_expand_code_includes_unknown_extension():
+    """Test that unknown file extensions produce an unfenced code block."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        pyproject = project_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        (project_path / "data.xyz").write_text("some data\n")
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        content = '{{< include data.xyz >}}'
+        result = docs._expand_code_includes(content, project_path)
+        assert result == "```\nsome data\n```"
+
+
+def test_expand_code_includes_backticks_in_content():
+    """Test that included files containing triple backticks use a longer fence."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        pyproject = project_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        (project_path / "example.txt").write_text("Some text\n```python\nx = 1\n```\nMore text\n")
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        content = '{{< include example.txt >}}'
+        result = docs._expand_code_includes(content, project_path)
+        # Should use a 4-backtick fence since the content has 3-backtick runs
+        assert result.startswith("````")
+        assert result.endswith("````")
+        assert "```python" in result
+
+
+def test_expand_code_includes_lang_and_lines_combined():
+    """Test combining lang and lines keyword arguments."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        pyproject = project_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        (project_path / "code.py").write_text("# header\nimport os\nprint(os.getcwd())\n")
+
+        docs = GreatDocs(project_path=tmp_dir)
+
+        content = '{{< include code.py lines="2-3" lang="text" >}}'
+        result = docs._expand_code_includes(content, project_path)
+        assert result.startswith("```text\n")
+        assert "import os" in result
+        assert "# header" not in result
+
+
+def test_expand_code_includes_in_user_guide_copy():
+    """Test that code-include shortcodes are expanded during user guide copy."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        pyproject = project_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        # Create a code file at project root
+        examples = project_path / "examples"
+        examples.mkdir()
+        (examples / "sample.py").write_text("x = 1\n")
+
+        # Create user guide with code-include
+        user_guide = project_path / "user_guide"
+        user_guide.mkdir()
+        (user_guide / "01-tutorial.qmd").write_text(
+            "---\ntitle: Tutorial\n---\n\n{{< include examples/sample.py >}}\n"
+        )
+
+        docs = GreatDocs(project_path=tmp_dir)
+        user_guide_info = docs._discover_user_guide()
+        assert user_guide_info is not None
+
+        docs._copy_user_guide_to_docs(user_guide_info)
+
+        # Verify the expanded content in the build directory
+        built_file = docs.project_path / "user-guide" / "tutorial.qmd"
+        assert built_file.exists()
+        built_content = built_file.read_text(encoding="utf-8")
+        assert "```python" in built_content
+        assert "x = 1" in built_content
+        assert "{{< include" not in built_content
+
+
+def test_parse_code_include_args():
+    """Test argument parsing for code-include shortcodes."""
+    parse = GreatDocs._parse_code_include_args
+
+    # Basic path
+    path, lang, lines = parse("examples/demo.py")
+    assert path == "examples/demo.py"
+    assert lang == ""
+    assert lines == ""
+
+    # Path with lang
+    path, lang, lines = parse('examples/demo.py lang="python"')
+    assert path == "examples/demo.py"
+    assert lang == "python"
+    assert lines == ""
+
+    # Path with lines
+    path, lang, lines = parse('examples/demo.py lines="5-10"')
+    assert path == "examples/demo.py"
+    assert lines == "5-10"
+
+    # Path with both
+    path, lang, lines = parse('examples/demo.py lines="1-3" lang="text"')
+    assert path == "examples/demo.py"
+    assert lang == "text"
+    assert lines == "1-3"
+
+
+def test_is_asset_dir_no_qmd():
+    """Test that directories without .qmd files are asset directories."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        d = Path(tmp_dir) / "images"
+        d.mkdir()
+        (d / "logo.png").write_bytes(b"PNG")
+        assert GreatDocs._is_asset_dir(d) is True
+
+
+def test_is_asset_dir_with_qmd():
+    """Test that directories with .qmd files are NOT asset directories."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        d = Path(tmp_dir) / "chapter"
+        d.mkdir()
+        (d / "page.qmd").write_text("---\ntitle: Test\n---\n")
+        assert GreatDocs._is_asset_dir(d) is False
+
+
+def test_is_asset_dir_underscore_prefix_with_qmd():
+    """Test that _-prefixed dirs are asset dirs even when they contain .qmd files."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        d = Path(tmp_dir) / "_includes"
+        d.mkdir()
+        (d / "snippet.qmd").write_text("```python\nx = 1\n```\n")
+        assert GreatDocs._is_asset_dir(d) is True
+
+
+def test_underscore_dir_copied_as_assets_with_qmd():
+    """Test that _-prefixed dirs with .qmd files are copied during user guide build."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        pyproject = project_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "test"\nversion = "0.1.0"')
+
+        user_guide = project_path / "user_guide"
+        user_guide.mkdir()
+        (user_guide / "01-tutorial.qmd").write_text(
+            "---\ntitle: Tutorial\n---\n\n"
+            '{{< include _includes/example.qmd lang="markdown" >}}\n'
+        )
+
+        includes = user_guide / "_includes"
+        includes.mkdir()
+        (includes / "example.qmd").write_text("```python\nprint('hello')\n```\n")
+
+        docs = GreatDocs(project_path=tmp_dir)
+        ug_info = docs._discover_user_guide()
+        assert ug_info is not None
+
+        docs._copy_user_guide_to_docs(ug_info)
+
+        # The _includes dir should be copied as an asset directory
+        copied_includes = docs.project_path / "user-guide" / "_includes"
+        assert copied_includes.exists(), "_includes dir was not copied"
+        assert (copied_includes / "example.qmd").exists()
+
+        # The include with lang= should have been expanded in the built file
+        built = docs.project_path / "user-guide" / "tutorial.qmd"
+        built_content = built.read_text(encoding="utf-8")
+        assert "```markdown" in built_content
+        assert "print('hello')" in built_content
+
+
 def test_user_guide_sidebar_uses_clean_urls():
     """Test that the generated sidebar uses clean URLs without numeric prefixes."""
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_synthetic.py
+++ b/tests/test_synthetic.py
@@ -1139,6 +1139,42 @@ def test_L3_blended_homepage_sidebar_first_entry(pkg_name: str, tmp_path: Path):
     )
 
 
+def test_L3_code_include_expansion(tmp_path: Path):
+    """gdtest_code_include: include shortcodes for code files are expanded in user guide."""
+    pkg_dir, spec = _make_package("gdtest_code_include", tmp_path)
+    docs = GreatDocs(project_path=str(pkg_dir))
+    docs._prepare_build_directory()
+
+    ug_info = docs._discover_user_guide()
+    assert ug_info is not None
+
+    docs._copy_user_guide_to_docs(ug_info)
+
+    built = docs.project_path / "user-guide" / "includes.qmd"
+    assert built.exists(), "includes.qmd not found in build dir"
+
+    content = built.read_text(encoding="utf-8")
+
+    # Basic include should have expanded to a python code block
+    assert "```python" in content
+    assert "Widget" in content
+
+    # YAML include should have expanded to a yaml code block
+    assert "```yaml" in content
+    assert "my-app" in content
+
+    # Language override should use "r" instead of "python"
+    assert "```r" in content
+
+    # Code-file includes should be fully expanded (no shortcodes remain
+    # for .py/.yaml files — only .qmd/.md includes pass through to Quarto)
+    assert "{{< include" not in content or all(
+        ".qmd" in line or ".md" in line
+        for line in content.splitlines()
+        if "{{< include" in line
+    )
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # Generator Sanity
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/user_guide/03-authoring-qmd-files.qmd
+++ b/user_guide/03-authoring-qmd-files.qmd
@@ -570,8 +570,8 @@ greet("World")
 ````
 
 **Rich HTML outputs.** When the output is a rich HTML object (such as a GT table or a styled
-DataFrame), the frame is automatically removed to avoid a double-border — these objects already
-carry their own visual structure. With `output-title`, the title appears as a floating label above
+DataFrame), the frame is automatically removed to avoid a double-border (these objects already
+carry their own visual structure). With `output-title`, the title appears as a floating label above
 the output; with `output-frame`, the container is effectively invisible since the object supplies
 its own styling.
 
@@ -619,7 +619,7 @@ chat.chat("I need your help.", header=False)
 
 The reader sees only the clean code above `# ---`, while the code below `# ---` runs and produces
 the output. Other hash-pipe options (`output-title`, `output-frame`, `warning`, etc.) compose
-naturally — see [Output Titles and Frames] above for examples.
+naturally (see [Output Titles and Frames] above for examples).
 
 **Edge cases:**
 
@@ -983,6 +983,119 @@ Includes are useful for:
 
 Includes promote the "write once, use everywhere" principle. When a paragraph or setup block appears
 in multiple pages, extracting it into an include file means you only need to update it in one place.
+
+### Code Includes
+
+When the `include` shortcode references a code file (anything other than `.qmd` or `.md`), Great
+Docs automatically wraps the file contents in a syntax-highlighted code block:
+
+````markdown
+{{{< include src/mypackage/examples/demo.py >}}}
+````
+
+The language is auto-detected from the file extension. A `.py` file becomes a `python` code block,
+a `.js` file becomes `javascript`, and so on. This is the same `include` shortcode used for content
+includes above. Great Docs handles code files automatically while passing `.qmd` and `.md` includes
+through to Quarto as usual.
+
+Code includes are ideal for keeping documentation in sync with real code. Instead of copying code
+snippets into your pages (where they can drift out of date), reference the source files directly.
+
+#### Including existing source files
+
+If your library already has runnable examples, tests, or configuration files that you want to
+showcase in the documentation, point `include` at them directly:
+
+````markdown
+{{{< include src/mypackage/examples/usage.py >}}}
+{{{< include tests/test_core.py lines="12-30" >}}}
+{{{< include pyproject.toml >}}}
+````
+
+Because paths are resolved relative to the project root, any file in your repository is reachable.
+This is the primary use case: your code examples are real, tested code that stays in sync
+automatically. When the source file changes, the documentation updates on the next build with no
+manual copying required.
+
+#### Writing new snippets for the docs
+
+When you need purpose-written examples that don't belong in your library's source tree, place them
+in an underscore-prefixed subdirectory of your user guide directory (for example,
+`user_guide/_includes/` or `user_guide/_snippets/`):
+
+```text
+user_guide/
+├── _includes/
+│   ├── quickstart.py
+│   ├── config-example.yaml
+│   └── shortcode-demo.qmd
+├── 01-introduction.qmd
+└── 02-tutorial.qmd
+```
+
+Then reference them with a path relative to the user guide directory:
+
+````markdown
+{{{< include _includes/quickstart.py >}}}
+{{{< include _includes/shortcode-demo.qmd lang="markdown" >}}}
+````
+
+This keeps documentation-only snippets close to the pages that use them, separate from the real
+source code. You can include `.qmd` files as code too, just add the `lang` or `lines` keyword to
+tell Great Docs to wrap the contents in a fenced code block instead of passing it through to Quarto
+for rendering.
+
+::: {.callout-important}
+## Use underscore-prefixed directories for snippet files
+
+Directories inside `user_guide/` that contain `.qmd` files are normally treated as content
+subdirectories. Their `.qmd` files are discovered as user guide pages. A leading underscore
+(e.g., `_includes/`, `_snippets/`) tells Great Docs to treat the directory as an **asset
+directory** instead: the files are copied to the build output but are not discovered as standalone
+pages.
+
+This means you can safely store `.qmd` snippets in `_includes/` without them appearing as pages in
+your site navigation. Without the underscore prefix, any `.qmd` files in the directory would either
+be picked up as user guide pages or prevent the directory from being copied as an asset directory.
+
+For non-`.qmd` snippet files (`.py`, `.js`, `.yaml`, etc.), the underscore prefix is not strictly
+required but using it consistently keeps all your snippet files in one predictable place.
+:::
+
+#### Options
+
+**Line ranges**: include only specific lines with the `lines` keyword:
+
+````markdown
+{{{< include src/mypackage/core.py lines="10-25" >}}}
+````
+
+Line numbers are 1-based and inclusive. This is useful for highlighting a specific function or block
+without showing the entire file.
+
+**Language override**: override the auto-detected language with the `lang` keyword:
+
+````markdown
+{{{< include config/settings.conf lang="toml" >}}}
+````
+
+**Combining options**: both keywords can be used together:
+
+````markdown
+{{{< include src/mypackage/core.py lines="5-15" lang="python" >}}}
+````
+
+#### Path resolution
+
+File paths are resolved relative to the directory containing the `.qmd` file first, then relative to
+the project root. This two-step lookup means you can use whichever style is most natural:
+
+- `_includes/example.py`: relative to the user guide directory (documentation-only snippets)
+- `src/mypackage/utils.py`: relative to the project root (existing source files)
+- `tests/test_core.py`: any file in the project tree
+
+If the referenced file is not found, a warning comment is inserted in the output so you can catch
+broken references during review.
 
 ## Math Equations
 


### PR DESCRIPTION
This PR adds support for expanding `{{< include ... >}}` (code-include) shortcodes in user guide and section `.qmd` files, enabling source code and config files to be embedded directly in documentation pages with syntax highlighting, line selection, and language override features. It also refactors asset directory detection for improved reliability and maintainability, and introduces a test package (GDG site) for the new include functionality.

Fixes: https://github.com/posit-dev/great-docs/issues/267