### PR TITLE
docs: explain mac dynamic library registration

### DIFF
--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -965,7 +965,7 @@ class GreatDocs:
                     "generation from SVG. Install it with:\n"
                     "  pip install 'great-docs[svg]'\n"
                     "On Linux you also need: apt install libcairo2-dev\n"
-                    "On macOS: brew install cairo"
+                    "On macOS (see installation notes): brew install cairo"
                 )
                 return result
 

--- a/user_guide/01-installation.qmd
+++ b/user_guide/01-installation.qmd
@@ -30,6 +30,22 @@ brew install quarto
 # Or download the installer from quarto.org
 ```
 
+::: {.details summary="SVG generation is not working"}
+Please confirm the successful import via
+
+```{.python filename="Python"}
+import cairosvg
+```
+
+If `cairosvg` is installed but the required libraries still cannot be found, add the brew dynamic
+library to your terminal environment by running:
+
+```{.bash filename="Terminal"}
+echo 'export DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib:$DYLD_FALLBACK_LIBRARY_PATH"' >> ~/.zshrc
+```
+
+:::
+
 ## Linux
 
 ```{.bash filename="Terminal"}


### PR DESCRIPTION
# Summary

The `quarto` installation on a Mac utilizes `brew`. The dynamic libraries provided by `brew` have to be "registered" to be found. This PR attempts to help the users encountering the same issue.

# Related GitHub Issues and PRs

- none

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [ ] I have added **pytest** unit tests for any new functionality. (--not applicable--)
