### PR TITLE
fix: correct failing GDG test spec

### DIFF
--- a/test-packages/synthetic/specs/gdtest_constants.py
+++ b/test-packages/synthetic/specs/gdtest_constants.py
@@ -30,7 +30,6 @@ SPEC = {
                 "DEFAULT_TIMEOUT",
                 "MAX_RETRIES",
                 "SUPPORTED_FORMATS",
-                "HandlerFunc",
                 "process",
             ]
 
@@ -81,11 +80,9 @@ SPEC = {
             "DEFAULT_TIMEOUT",
             "MAX_RETRIES",
             "SUPPORTED_FORMATS",
-            "HandlerFunc",
             "process",
         ],
-        "nodoc_items": ["HandlerFunc"],
-        "num_exports": 5,
+        "num_exports": 4,
         "has_user_guide": False,
         "coverage_exclude": ["nodoc", "bigcl", "ug", "supp", "sechdg", "sbsec", "hdg"],
     },


### PR DESCRIPTION
This PR makes a small update to the `gdtest_constants.py` test spec by removing the `HandlerFunc` export and related documentation exclusion.