### PR TITLE
Fix enum docs

### DIFF
--- a/great_docs/_apiref/_render/html_table.py
+++ b/great_docs/_apiref/_render/html_table.py
@@ -62,7 +62,7 @@ def html_table(
     # Build table rows
     body_rows: list[str] = []
     for name, desc in rows:
-        name, desc = str(name), str(desc)
+        name, desc = str(name), str(desc) if desc is not None else ""
         # Convert markdown links to HTML
         name = _md_link_to_html(name)
 

--- a/great_docs/_apiref/introspect.py
+++ b/great_docs/_apiref/introspect.py
@@ -9,6 +9,7 @@ mode).
 
 from __future__ import annotations
 
+import enum
 import importlib
 import inspect
 from types import ModuleType
@@ -170,6 +171,15 @@ def replace_docstring(obj: gf.Object | gf.Alias, runtime_obj: object = None) -> 
         return
 
     doc: str = runtime_obj.__doc__  # type: ignore[assignment]
+
+    # Enum members inherit __doc__ from the enum class. Skip the
+    # replacement so griffe's statically-parsed per-member docstring
+    # (if any) is preserved; when there is none the member correctly
+    # shows no docstring rather than the class-level one.
+    if isinstance(runtime_obj, enum.Enum):
+        parent_cls = type(runtime_obj)
+        if doc == parent_cls.__doc__:
+            return
 
     # Reclassify callable attributes as functions.
     # When a class uses `method = some_function` pattern, griffe sees it as

--- a/great_docs/_apiref/resolve.py
+++ b/great_docs/_apiref/resolve.py
@@ -45,6 +45,10 @@ _BUILTIN_NOISE_DUNDERS = frozenset(
     }
 )
 
+_ENUM_BASES = frozenset(
+    {"Enum", "IntEnum", "StrEnum", "Flag", "IntFlag", "ReprEnum", "EnumCheck"}
+)
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -397,7 +401,14 @@ class _Resolver:
             _ = resolve_alias(member, self.get_object)
 
         # Phase 2 — content filters: require resolved targets.
-        if not el.include_empty:
+        # Enum members are always shown — their names and values are
+        # inherently meaningful even without a per-member docstring.
+        is_enum_cls = (
+            obj.is_class
+            and hasattr(obj, "bases")
+            and {str(b).rsplit(".", 1)[-1] for b in obj.bases} & _ENUM_BASES
+        )
+        if not el.include_empty and not is_enum_cls:
             candidates = {k: v for k, v in candidates.items() if v.docstring is not None}
 
         if not el.include_attributes:

--- a/test-packages/synthetic/specs/gdtest_enums.py
+++ b/test-packages/synthetic/specs/gdtest_enums.py
@@ -38,9 +38,13 @@ SPEC = {
                 Each color maps to a CSS-compatible color name.
                 """
                 RED = "red"
+                """A warm primary color."""
                 GREEN = "green"
+                """A cool secondary color."""
                 BLUE = "blue"
+                """A cool primary color."""
                 YELLOW = "yellow"
+                """A warm secondary color."""
 
 
             class Priority(IntEnum):

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -28376,6 +28376,62 @@ def test_replace_docstring_alias():
     replace_docstring(alias)
 
 
+def test_replace_docstring_enum_preserves_member_docstrings():
+    """replace_docstring does not overwrite per-member enum docstrings with class docstring."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        pkg = Path(tmp_dir) / "introtest_enum_doc"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text(
+            "from enum import Enum\n"
+            "class MyEnum(str, Enum):\n"
+            '    """Class docstring."""\n'
+            '    FOO = "foo"\n'
+            '    """Description for variant FOO."""\n'
+            '    BAR = "bar"\n'
+            '    """Description for variant BAR."""\n',
+            encoding="utf-8",
+        )
+        sys.path.insert(0, tmp_dir)
+        try:
+            obj = get_object("introtest_enum_doc:MyEnum")
+            replace_docstring(obj)
+            assert obj.docstring.value == "Class docstring."
+            foo = obj.members["FOO"]
+            bar = obj.members["BAR"]
+            assert foo.docstring.value == "Description for variant FOO."
+            assert bar.docstring.value == "Description for variant BAR."
+        finally:
+            sys.path.remove(tmp_dir)
+            sys.modules.pop("introtest_enum_doc", None)
+
+
+def test_replace_docstring_enum_no_member_docstrings():
+    """replace_docstring does not inject class docstring into undocumented enum members."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        pkg = Path(tmp_dir) / "introtest_enum_nodoc"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text(
+            "from enum import Enum\n"
+            "class MyEnum(Enum):\n"
+            '    """Class docstring."""\n'
+            "    A = 1\n"
+            "    B = 2\n",
+            encoding="utf-8",
+        )
+        sys.path.insert(0, tmp_dir)
+        try:
+            obj = get_object("introtest_enum_nodoc:MyEnum")
+            replace_docstring(obj)
+            assert obj.docstring.value == "Class docstring."
+            a = obj.members["A"]
+            b = obj.members["B"]
+            assert a.docstring is None
+            assert b.docstring is None
+        finally:
+            sys.path.remove(tmp_dir)
+            sys.modules.pop("introtest_enum_nodoc", None)
+
+
 def test_canonical_path_module():
     """_canonical_path for a module returns module name."""
     from great_docs._apiref.introspect import _canonical_path


### PR DESCRIPTION
This PR improves the handling of Python enums in API documentation generation. It ensures that enum member docstrings are preserved correctly and that enum members are always shown, even if they lack individual docstrings.

With this change we should see this (from the GDG site that tests enums):

<img width="666" height="999" alt="image" src="https://github.com/user-attachments/assets/54059ca1-5c02-4843-b21e-ccbc88de4315" />

Fixes: https://github.com/posit-dev/great-docs/issues/277