### PR TITLE
fix: ensure frozen JS files end with newline

### DIFF
--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -15535,6 +15535,11 @@ anchor-sections: true
                 else:
                     shutil.copy2(item, dest)
 
+        for js_file in freeze_dst.rglob("*.js"):
+            data = js_file.read_bytes()
+            if data and not data.endswith(b"\n"):
+                js_file.write_bytes(data + b"\n")
+
         return sum(1 for _ in freeze_dst.rglob("*") if _.is_file())
 
     def _prepare_for_freeze(self) -> None:


### PR DESCRIPTION
This PR makes a small but pretty important improvement to the `_persist_freeze_cache()` method. After copying files, it ensures that all `.js` files in the freeze destination directory end with a newline character, which can help prevent issues when concatenating or processing JavaScript files.