### PR TITLE
Add announcement.position (above / below navbar)

### DIFF
--- a/great_docs/assets/announcement-banner.js
+++ b/great_docs/assets/announcement-banner.js
@@ -17,6 +17,7 @@
   var dismissable = meta.getAttribute("data-dismissable") !== "false";
   var url = meta.getAttribute("data-url") || "";
   var style = meta.getAttribute("data-style") || "";
+  var position = meta.getAttribute("data-position") || "above-navbar";
 
   // Build a storage key from the banner content so a *new* announcement
   // is shown even if the user dismissed a previous one.
@@ -91,10 +92,18 @@
     banner.appendChild(btn);
   }
 
-  // ── insert into the fixed header, above the navbar ──
+  // ── insert into the fixed header ──
+  // Quarto places both positions inside #quarto-header: above-navbar before
+  // the <nav>, below-navbar after it (and after any secondary nav). We match.
   var header = document.getElementById("quarto-header");
-  if (header && header.firstChild) {
-    header.insertBefore(banner, header.firstChild);
+  if (header) {
+    if (position === "below-navbar") {
+      header.appendChild(banner);
+    } else if (header.firstChild) {
+      header.insertBefore(banner, header.firstChild);
+    } else {
+      header.appendChild(banner);
+    }
   } else {
     // Fallback: prepend to body
     document.body.insertBefore(banner, document.body.firstChild);

--- a/great_docs/assets/announcement-banner.js
+++ b/great_docs/assets/announcement-banner.js
@@ -1,7 +1,7 @@
 /**
  * Announcement Banner for Great Docs
  *
- * Renders a site-wide banner above the navbar. Supports dismiss with
+ * Renders a site-wide banner above or below the navbar. Supports dismiss with
  * sessionStorage so the banner stays hidden for the current browsing session.
  */
 (function () {
@@ -93,12 +93,20 @@
   }
 
   // ── insert into the fixed header ──
-  // Quarto places both positions inside #quarto-header: above-navbar before
-  // the <nav>, below-navbar after it (and after any secondary nav). We match.
+  // Both positions live inside #quarto-header: above-navbar before the <nav>,
+  // below-navbar after it. For below-navbar we insert *before* any secondary
+  // nav rather than appending: the secondary nav counter-translates by its own
+  // height to stay pinned when the header unpins on mobile, which only lands
+  // correctly if it remains the header's last child.
   var header = document.getElementById("quarto-header");
   if (header) {
     if (position === "below-navbar") {
-      header.appendChild(banner);
+      var secondaryNav = header.querySelector(".quarto-secondary-nav");
+      if (secondaryNav) {
+        header.insertBefore(banner, secondaryNav);
+      } else {
+        header.appendChild(banner);
+      }
     } else if (header.firstChild) {
       header.insertBefore(banner, header.firstChild);
     } else {

--- a/great_docs/config.py
+++ b/great_docs/config.py
@@ -1249,8 +1249,8 @@ class Config:
         Returns
         -------
         dict | None
-            Normalized dict with keys: content, type, dismissable, url. Returns `None` if no
-            announcement is configured.
+            Normalized dict with keys: `content`, `type`, `dismissable`, `url`, `style`,
+            `position`. Returns `None` if no announcement is configured.
         """
         raw = self.get("announcement")
         if raw is None or raw is False:

--- a/great_docs/config.py
+++ b/great_docs/config.py
@@ -154,11 +154,12 @@ DEFAULT_CONFIG: dict[str, Any] = {
     # False: disable both.
     # Dict form: {"widget": False} generates .md pages but hides the widget.
     "markdown_pages": True,
-    # Announcement banner (site-wide banner above the navbar)
+    # Announcement banner (site-wide banner above or below the navbar)
     # None/False: no banner (default)
     # str: banner message text (plain text or inline HTML)
     # dict: {"content": str, "type": "info"|"warning"|"success"|"danger",
-    #        "dismissable": bool, "url": str|None}
+    #        "dismissable": bool, "url": str|None,
+    #        "position": "above-navbar"|"below-navbar"}
     "announcement": None,
     # Multi-version documentation
     # None/[]: disabled (default — single-version site)
@@ -1255,17 +1256,28 @@ class Config:
         if raw is None or raw is False:
             return None
         if isinstance(raw, str):
-            return {"content": raw, "type": "info", "dismissable": True, "url": None, "style": None}
+            return {
+                "content": raw,
+                "type": "info",
+                "dismissable": True,
+                "url": None,
+                "style": None,
+                "position": "above-navbar",
+            }
         if isinstance(raw, dict):
             content = raw.get("content")
             if not content:
                 return None
+            position = raw.get("position", "above-navbar")
+            if position not in ("above-navbar", "below-navbar"):
+                position = "above-navbar"
             return {
                 "content": content,
                 "type": raw.get("type", "info"),
                 "dismissable": raw.get("dismissable", True),
                 "url": raw.get("url"),
                 "style": raw.get("style"),
+                "position": position,
             }
         return None
 

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -13128,6 +13128,7 @@ anchor-sections: true
             ann_dismissable = "true" if announcement.get("dismissable", True) else "false"
             ann_url = html_mod.escape(announcement.get("url") or "")
             ann_style = html_mod.escape(announcement.get("style") or "")
+            ann_position = html_mod.escape(announcement.get("position", "above-navbar"))
 
             ann_meta_tag = (
                 f'<meta name="gd-announcement"'
@@ -13135,7 +13136,8 @@ anchor-sections: true
                 f' data-type="{ann_type}"'
                 f' data-dismissable="{ann_dismissable}"'
                 f' data-url="{ann_url}"'
-                f' data-style="{ann_style}">'
+                f' data-style="{ann_style}"'
+                f' data-position="{ann_position}">'
             )
 
             # Add meta tag to header (replace any existing announcement meta)

--- a/recipes/08-customize-announcement-banner.qmd
+++ b/recipes/08-customize-announcement-banner.qmd
@@ -6,7 +6,7 @@ tags: [Theming, Customization]
 
 # The Announcement Banner
 
-The announcement banner appears above the navbar on every page of your site. It is useful for highlighting new releases, deprecation notices, migration information, or any other message you want every visitor to see.
+The announcement banner appears in the fixed header on every page of your site — above the navbar by default, or below it if you prefer. It is useful for highlighting new releases, deprecation notices, migration information, or any other message you want every visitor to see.
 
 ## Simple Banner
 
@@ -51,6 +51,22 @@ announcement:
 ```
 
 When `style` is set, the gradient overrides the `type` background color.
+
+## Position
+
+By default the banner sits above the navbar. Set `position` to `below-navbar` to place it after the navbar instead. Either way the banner stays in the fixed header at the top of the page:
+
+```{.yaml filename="great-docs.yml"}
+announcement:
+  content: "Scheduled maintenance this weekend."
+  type: warning
+  position: below-navbar
+```
+
+| Position | Placement |
+|----------|-----------|
+| `above-navbar` | Above the navbar (default) |
+| `below-navbar` | Below the navbar |
 
 ## Persistent vs. Dismissable
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -526,6 +526,7 @@ class TestAnnouncement:
             "dismissable": True,
             "url": None,
             "style": None,
+            "position": "above-navbar",
         }
 
     def test_dict_full(self, tmp_project: Path):
@@ -539,6 +540,7 @@ class TestAnnouncement:
                 "  dismissable: false\n"
                 "  url: https://example.com\n"
                 "  style: custom\n"
+                "  position: below-navbar\n"
             ),
         )
         assert cfg.announcement == {
@@ -547,7 +549,28 @@ class TestAnnouncement:
             "dismissable": False,
             "url": "https://example.com",
             "style": "custom",
+            "position": "below-navbar",
         }
+
+    def test_position_defaults_above_navbar_for_string(self, tmp_project: Path):
+        cfg = _make_config(tmp_project, "announcement: Hi\n")
+        assert cfg.announcement["position"] == "above-navbar"
+
+    def test_position_defaults_above_navbar_for_dict(self, tmp_project: Path):
+        cfg = _make_config(tmp_project, "announcement:\n  content: Hi\n")
+        assert cfg.announcement["position"] == "above-navbar"
+
+    def test_position_below_navbar(self, tmp_project: Path):
+        cfg = _make_config(
+            tmp_project, "announcement:\n  content: Hi\n  position: below-navbar\n"
+        )
+        assert cfg.announcement["position"] == "below-navbar"
+
+    def test_position_invalid_falls_back_to_above(self, tmp_project: Path):
+        cfg = _make_config(
+            tmp_project, "announcement:\n  content: Hi\n  position: sideways\n"
+        )
+        assert cfg.announcement["position"] == "above-navbar"
 
     def test_dict_empty_content_returns_none(self, tmp_project: Path):
         cfg = _make_config(tmp_project, "announcement:\n  type: info\n")

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -42041,7 +42041,7 @@ def test_build_metadata_margin_no_package_info_link_when_missing():
 
 
 def test_announcement_position_in_meta_tag():
-    """_update_quarto_config emits data-position on the gd-announcement meta tag."""
+    """_update_quarto_config emits data-position on the gd-announcement meta tag"""
     with tempfile.TemporaryDirectory() as tmp_dir:
         project_path = Path(tmp_dir)
         (project_path / "pyproject.toml").write_text(
@@ -42061,12 +42061,13 @@ def test_announcement_position_in_meta_tag():
 
         header = config["format"]["html"]["include-in-header"]
         meta_texts = [item.get("text", "") for item in header if isinstance(item, dict)]
-        ann = next(t for t in meta_texts if "gd-announcement" in t)
+        ann = next((t for t in meta_texts if "gd-announcement" in t), None)
+        assert ann is not None, "gd-announcement meta tag not found"
         assert 'data-position="below-navbar"' in ann
 
 
 def test_announcement_position_defaults_above_in_meta_tag():
-    """Default announcement position is above-navbar in the meta tag."""
+    """Default announcement position is above-navbar in the meta tag"""
     with tempfile.TemporaryDirectory() as tmp_dir:
         project_path = Path(tmp_dir)
         (project_path / "pyproject.toml").write_text(
@@ -42085,5 +42086,6 @@ def test_announcement_position_defaults_above_in_meta_tag():
 
         header = config["format"]["html"]["include-in-header"]
         meta_texts = [item.get("text", "") for item in header if isinstance(item, dict)]
-        ann = next(t for t in meta_texts if "gd-announcement" in t)
+        ann = next((t for t in meta_texts if "gd-announcement" in t), None)
+        assert ann is not None, "gd-announcement meta tag not found"
         assert 'data-position="above-navbar"' in ann

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -42038,3 +42038,52 @@ def test_build_metadata_margin_no_package_info_link_when_missing():
         result = docs._build_metadata_margin()
 
         assert "package-info.html" not in result
+
+
+def test_announcement_position_in_meta_tag():
+    """_update_quarto_config emits data-position on the gd-announcement meta tag."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        (project_path / "pyproject.toml").write_text(
+            '[project]\nname = "test"\nversion = "0.1.0"'
+        )
+        (project_path / "great-docs.yml").write_text(
+            "announcement:\n  content: Hi\n  position: below-navbar\n",
+            encoding="utf-8",
+        )
+
+        docs = GreatDocs(project_path=tmp_dir)
+        docs.project_path.mkdir(parents=True, exist_ok=True)
+        docs._update_quarto_config()
+
+        with open(docs.project_path / "_quarto.yml", "r") as f:
+            config = read_yaml(f)
+
+        header = config["format"]["html"]["include-in-header"]
+        meta_texts = [item.get("text", "") for item in header if isinstance(item, dict)]
+        ann = next(t for t in meta_texts if "gd-announcement" in t)
+        assert 'data-position="below-navbar"' in ann
+
+
+def test_announcement_position_defaults_above_in_meta_tag():
+    """Default announcement position is above-navbar in the meta tag."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        (project_path / "pyproject.toml").write_text(
+            '[project]\nname = "test"\nversion = "0.1.0"'
+        )
+        (project_path / "great-docs.yml").write_text(
+            "announcement: Hi\n", encoding="utf-8"
+        )
+
+        docs = GreatDocs(project_path=tmp_dir)
+        docs.project_path.mkdir(parents=True, exist_ok=True)
+        docs._update_quarto_config()
+
+        with open(docs.project_path / "_quarto.yml", "r") as f:
+            config = read_yaml(f)
+
+        header = config["format"]["html"]["include-in-header"]
+        meta_texts = [item.get("text", "") for item in header if isinstance(item, dict)]
+        ann = next(t for t in meta_texts if "gd-announcement" in t)
+        assert 'data-position="above-navbar"' in ann


### PR DESCRIPTION
This PR adds an `announcement.position` config key that lets users choose whether the site-wide announcement banner renders above or below the navbar.

```yaml
announcement:
  content: "Version 2.0 is out!"
  position: below-navbar   # or above-navbar (default)
```
_above-navbar_
<img width="2560" height="1800" alt="above-navbar" src="https://github.com/user-attachments/assets/9e4eace4-8110-4704-808c-d187dc90680e" />

_below-navbar_
<img width="2560" height="1800" alt="image" src="https://github.com/user-attachments/assets/1fb578c9-5fab-4d7a-ad56-bced05dff002" />

closes #273.