### PR TITLE
Stop dynamic introspection from building self-referential aliases

### DIFF
--- a/great_docs/_apiref/introspect.py
+++ b/great_docs/_apiref/introspect.py
@@ -74,7 +74,6 @@ def make_loader(parser: str = "numpy") -> gf.GriffeLoader:
 def get_object(
     path: str,
     parser: str = "numpy",
-    load_aliases: bool = True,
     dynamic: bool | str = False,
     loader: gf.GriffeLoader | None = None,
 ) -> gf.Object | gf.Alias:
@@ -87,8 +86,6 @@ def get_object(
         For example, `my_package:get_object` or `my_package:MyClass.render`.
     parser :
         A docstring parser to use.
-    load_aliases :
-        For aliases that were imported from other modules, should we load that module?
     dynamic :
         Whether to dynamically import object. Useful if docstring is not hard-coded,
         but was set on object by running python code.
@@ -116,7 +113,7 @@ def get_object(
 
         return dynamic_alias(path, loader=loader)
 
-    return _static_object(module_path, object_path, loader, load_aliases)
+    return _static_object(module_path, object_path, loader)
 
 
 def _split_path(path: str) -> tuple[str, str | None]:
@@ -142,9 +139,36 @@ def _static_object(
     module_path: str,
     object_path: str | None,
     loader: gf.GriffeLoader,
-    load_aliases: bool,
 ) -> gf.Object | gf.Alias:
-    """The griffe object at a path, as griffe's static analysis models it"""
+    """
+    The griffe object at a path, as griffe's static analysis models it
+
+    An alias imported from elsewhere brings its target's module along, so the
+    target can be resolved.
+
+    Parameters
+    ----------
+    module_path :
+        Dotted path of the module to read from.
+    object_path :
+        Dotted path of the object within that module, or `None` for the module
+        itself.
+    loader :
+        Loader whose collection the module has already been loaded into.
+
+    Returns
+    -------
+    :
+        The node at the path. An imported name comes back as an alias, and a
+        function or attribute reached through an aliased parent keeps that
+        parent.
+
+    Raises
+    ------
+    KeyError
+        When the static model holds nothing at the path. The key names the
+        object that was asked for, which callers turn into a user-facing error.
+    """
     # griffe uses only periods for the path
     griffe_path = f"{module_path}.{object_path}" if object_path else module_path
     obj = loader.modules_collection[griffe_path]
@@ -153,7 +177,7 @@ def _static_object(
     if isinstance(parent, gf.Alias) and isinstance(obj, (gf.Function, gf.Attribute)):
         obj = gf.Alias(obj.name, obj, parent=parent)
 
-    if isinstance(obj, gf.Alias) and load_aliases:
+    if isinstance(obj, gf.Alias):
         target_mod = obj.target_path.split(".")[0]
         if target_mod != module_path:
             _ = loader.load(target_mod)

--- a/great_docs/_apiref/introspect.py
+++ b/great_docs/_apiref/introspect.py
@@ -419,34 +419,6 @@ def _clone_docstring(
     )
 
 
-def dynamic_alias(
-    path: str,
-    loader: gf.GriffeLoader | None = None,
-) -> gf.Object | gf.Alias:
-    """Resolve a griffe object for `path` via a dynamic import.
-
-    Parameters
-    ----------
-    path :
-        Full path to the object. E.g. `my_package.get_object`.
-    loader :
-        An existing griffe loader to reuse. A fresh loader is created when omitted.
-    """
-    module_path, object_path = _split_path(path)
-    module = importlib.import_module(module_path)
-
-    located = _locate_runtime_attr(module, module_path, object_path, path, loader)
-    if isinstance(located, _DeclarationOnly):
-        return located.obj
-
-    documented = _load_documenting_object(located, loader)
-    replace_docstring(documented.obj, located.value)
-
-    if _same_path(documented.path, located.access_path):
-        return documented.obj
-    return _alias_into_parent(located, documented.obj, loader)
-
-
 @dataclass(frozen=True)
 class _LocatedAttr:
     """
@@ -478,8 +450,56 @@ class _Documented:
 
 
 def _same_path(one: str, other: str) -> bool:
-    """Whether two paths name the same object, ignoring the `:` / `.` separator"""
+    """
+    Whether two paths name the same object, ignoring the `:` / `.` separator
+
+    Parameters
+    ----------
+    one, other :
+        Paths to compare, each in either `module:object` or dotted form.
+
+    Returns
+    -------
+    :
+        True when both name the same object.
+    """
     return one.replace(":", ".") == other.replace(":", ".")
+
+
+def dynamic_alias(
+    path: str,
+    loader: gf.GriffeLoader | None = None,
+) -> gf.Object | gf.Alias:
+    """
+    Resolve a griffe object for `path` via a dynamic import
+
+    Parameters
+    ----------
+    path :
+        Full path to the object. E.g. `my_package.get_object`.
+    loader :
+        An existing griffe loader to reuse. A fresh loader is created when omitted.
+
+    Returns
+    -------
+    :
+        The node griffe models at `path`, carrying the runtime docstring. It
+        comes back as an alias member of the thing it was accessed through only
+        when it lives somewhere else.
+    """
+    module_path, object_path = _split_path(path)
+    module = importlib.import_module(module_path)
+
+    located = _locate_runtime_attr(module, module_path, object_path, path, loader)
+    if isinstance(located, _DeclarationOnly):
+        return located.obj
+
+    documented = _load_documenting_object(located, loader)
+    replace_docstring(documented.obj, located.value)
+
+    if _same_path(documented.path, located.access_path):
+        return documented.obj
+    return _alias_into_parent(located, documented.obj, loader)
 
 
 def _locate_runtime_attr(
@@ -515,11 +535,18 @@ def _locate_runtime_attr(
 
     Raises
     ------
+    KeyError
+        When the path names neither a runtime attribute nor a declaration,
+        from the static lookup that `_locate_declaration` falls back to.
+    ImportError
+        When that static lookup needs a module that cannot be loaded.
     AttributeError
-        When the path names neither a runtime attribute nor a declaration.
+        The narrower case of a missing runtime attribute: raised only when
+        the static model DOES carry a value for it, so the absence is a
+        genuine error rather than a declaration to fall back to.
     """
     if object_path is None:
-        return _LocatedAttr(module, module_path.rsplit(".", 1)[-1], path, module.__name__)
+        return _LocatedAttr(module, module_path.rsplit(".", 1)[-1], module_path, module.__name__)
 
     names = object_path.split(".")
     value: object = module

--- a/great_docs/_apiref/introspect.py
+++ b/great_docs/_apiref/introspect.py
@@ -75,7 +75,7 @@ def make_loader(parser: str = "numpy") -> gf.GriffeLoader:
 def get_object(
     path: str,
     parser: str | None = None,
-    dynamic: bool | str = False,
+    dynamic: bool = False,
     loader: gf.GriffeLoader | None = None,
 ) -> gf.Object | gf.Alias:
     """
@@ -90,8 +90,8 @@ def get_object(
         A docstring parser to configure a new loader with. Ignored, with a warning,
         when `loader` is given, since the loader already carries a parser.
     dynamic :
-        Whether to dynamically import object. Useful if docstring is not hard-coded,
-        but was set on object by running python code.
+        Whether to dynamically import the object. Useful when the docstring is not
+        hard-coded, but was set on the object by running python code.
     loader :
         An existing griffe loader to reuse. A fresh loader is created when omitted.
 
@@ -101,6 +101,8 @@ def get_object(
         The node griffe models at `path` — an object, or an alias when the path
         reaches it through a re-export.
     """
+    _validate_dynamic(dynamic)
+
     if loader is None:
         loader = make_loader(parser or "numpy")
     elif parser is not None:
@@ -118,9 +120,6 @@ def get_object(
         _ = loader.load(module_path)
 
     if dynamic:
-        if isinstance(dynamic, str):
-            return dynamic_alias(path, target=dynamic, loader=loader)
-
         return dynamic_alias(path, loader=loader)
 
     return _static_object(module_path, object_path, loader)
@@ -422,7 +421,6 @@ def _clone_docstring(
 
 def dynamic_alias(
     path: str,
-    target: str | None = None,
     loader: gf.GriffeLoader | None = None,
 ) -> gf.Object | gf.Alias:
     """Resolve a griffe object for `path` via a dynamic import.
@@ -431,9 +429,6 @@ def dynamic_alias(
     ----------
     path :
         Full path to the object. E.g. `my_package.get_object`.
-    target :
-        Optional path to the ultimate alias target. By default, this is
-        inferred using the `__module__` attribute of the imported object.
     loader :
         An existing griffe loader to reuse. A fresh loader is created when omitted.
     """
@@ -444,7 +439,7 @@ def dynamic_alias(
     if isinstance(located, _DeclarationOnly):
         return located.obj
 
-    documented = _load_documenting_object(located, target, loader)
+    documented = _load_documenting_object(located, loader)
     replace_docstring(documented.obj, located.value)
 
     if _same_path(documented.path, located.access_path):
@@ -588,7 +583,6 @@ def _locate_declaration(
 
 def _load_documenting_object(
     located: _LocatedAttr,
-    target: str | None,
     loader: gf.GriffeLoader | None,
 ) -> _Documented:
     """
@@ -614,9 +608,6 @@ def _load_documenting_object(
         Callers compare that path against the access path to decide whether the
         attribute still needs re-exposing.
     """
-    if target:
-        return _Documented(get_object(target, loader=loader), target)
-
     if located.canonical_path is not None:
         try:
             obj = get_object(located.canonical_path, loader=loader)
@@ -734,3 +725,12 @@ def _has_no_value(obj: gf.Object | gf.Alias) -> bool:
             return True
 
     return False
+
+
+def _validate_dynamic(value: object, *, allow_none: bool = False) -> None:
+    if isinstance(value, bool) or (allow_none and value is None):
+        return
+    raise ValueError(
+        f"`dynamic` accepts true or false, got {value!r}. "
+        "It selects how an object is inspected, not what it points to."
+    )

--- a/great_docs/_apiref/introspect.py
+++ b/great_docs/_apiref/introspect.py
@@ -26,15 +26,37 @@ DEFAULT_OPTIONS: dict[str, dict[str, object]] = {}
 
 
 def get_parser_defaults(name: str) -> dict[str, object]:
-    """Get the default parser options registered for the named docstring style.
+    """
+    Get the default parser options registered for the named docstring style
 
-    Returns an empty dict when no defaults have been registered for `name`.
+    Parameters
+    ----------
+    name :
+        Name of a docstring style, e.g. `numpy` or `google`.
+
+    Returns
+    -------
+    :
+        The registered options, or an empty dict when the style has none.
     """
     return DEFAULT_OPTIONS.get(name, {})
 
 
 def make_loader(parser: str = "numpy") -> gf.GriffeLoader:
-    """Configure a griffe loader with the defaults for a docstring parser"""
+    """
+    Configure a griffe loader with the defaults for a docstring parser
+
+    Parameters
+    ----------
+    parser :
+        Name of the docstring style the loader parses with.
+
+    Returns
+    -------
+    :
+        A loader with its own module and line collections, so it shares no
+        cached state with any other loader.
+    """
     raw_defaults = get_parser_defaults(parser)
     docstring_options = cast("DocstringOptions", raw_defaults) if raw_defaults else None
     return gf.GriffeLoader(
@@ -71,40 +93,68 @@ def get_object(
         but was set on object by running python code.
     loader :
         An existing griffe loader to reuse. A fresh loader is created when omitted.
+
+    Returns
+    -------
+    :
+        The node griffe models at `path` — an object, or an alias when the path
+        reaches it through a re-export.
     """
     if loader is None:
         loader = make_loader(parser)
 
-    try:
-        module, object_path = path.split(":", 1)
-    except ValueError:
-        module, object_path = path, None
+    module_path, object_path = _split_path(path)
 
-    # load the module if it hasn't been already.
-    root_mod = module.split(".", 1)[0]
+    root_mod = module_path.split(".", 1)[0]
     if root_mod not in loader.modules_collection:
-        _ = loader.load(module)
+        _ = loader.load(module_path)
 
-    # griffe uses only periods for the path
-    griffe_path = f"{module}.{object_path}" if object_path else module
-
-    # Case 1: dynamic loading
     if dynamic:
         if isinstance(dynamic, str):
             return dynamic_alias(path, target=dynamic, loader=loader)
 
         return dynamic_alias(path, loader=loader)
 
-    # Case 2: static loading an object
-    parent = loader.modules_collection[griffe_path.rsplit(".", 1)[0]]
+    return _static_object(module_path, object_path, loader, load_aliases)
+
+
+def _split_path(path: str) -> tuple[str, str | None]:
+    """
+    Split a `module:object` path into its module part and its object part
+
+    Parameters
+    ----------
+    path :
+        A path of the form `path.to.module:object`, or `path.to.module` alone.
+
+    Returns
+    -------
+    :
+        The module part, and the object part or `None` when the path names a
+        module only.
+    """
+    module_path, _, object_path = path.partition(":")
+    return module_path, object_path or None
+
+
+def _static_object(
+    module_path: str,
+    object_path: str | None,
+    loader: gf.GriffeLoader,
+    load_aliases: bool,
+) -> gf.Object | gf.Alias:
+    """The griffe object at a path, as griffe's static analysis models it"""
+    # griffe uses only periods for the path
+    griffe_path = f"{module_path}.{object_path}" if object_path else module_path
     obj = loader.modules_collection[griffe_path]
+    parent = loader.modules_collection[griffe_path.rsplit(".", 1)[0]]
 
     if isinstance(parent, gf.Alias) and isinstance(obj, (gf.Function, gf.Attribute)):
         obj = gf.Alias(obj.name, obj, parent=parent)
 
     if isinstance(obj, gf.Alias) and load_aliases:
         target_mod = obj.target_path.split(".")[0]
-        if target_mod != module:
+        if target_mod != module_path:
             _ = loader.load(target_mod)
 
     return obj
@@ -119,6 +169,19 @@ def resolve_alias(
     Follows `Alias.target` links until a non-alias node is reached. An
     unresolved link is re-loaded through `get_object` when one is provided;
     otherwise the `AliasResolutionError` propagates.
+
+    Parameters
+    ----------
+    obj :
+        The node to resolve. One that is not an alias is returned unchanged.
+    get_object :
+        Callable used to re-load a link whose target is absent from the
+        collection. When omitted, such a link raises instead.
+
+    Returns
+    -------
+    :
+        The concrete object at the end of the chain.
 
     Raises
     ------
@@ -204,6 +267,17 @@ def _locate_runtime_object(obj: gf.Object) -> object | None:
     A member of a (possibly nested) class is reached by walking the class
     chain, e.g. `Node.add_child` inside `Tree` resolves to
     `mod.Tree.Node.add_child`.
+
+    Parameters
+    ----------
+    obj :
+        The documented node whose runtime counterpart is wanted.
+
+    Returns
+    -------
+    :
+        The imported object, or `None` when the class chain or the attribute
+        itself cannot be reached at runtime.
     """
     mod = importlib.import_module(obj.module.canonical_path)
 
@@ -235,6 +309,16 @@ def _promote_callable_attribute(obj: gf.Attribute, f: object, doc: str) -> None:
 
     The function carries the runtime signature when it is recoverable, so
     the member renders function-style instead of attribute-style.
+
+    Parameters
+    ----------
+    obj :
+        The attribute to replace on its parent.
+    f :
+        The runtime callable the attribute holds. Its signature is copied when
+        `inspect` can read it, and omitted when it cannot.
+    doc :
+        Docstring for the replacement function.
     """
     assert obj.parent is not None
 
@@ -270,7 +354,24 @@ def _promote_callable_attribute(obj: gf.Attribute, f: object, doc: str) -> None:
 def _clone_docstring(
     old: gf.Docstring | None, value: str, parent: gf.Object | None
 ) -> gf.Docstring:
-    """Clone a docstring with a new value, keeping the old one's position and parser"""
+    """
+    Clone a docstring with a new value, keeping the old one's position and parser
+
+    Parameters
+    ----------
+    old :
+        Docstring to copy the position and parser settings from. `None` yields
+        a docstring with no position.
+    value :
+        Text of the new docstring.
+    parent :
+        Node the new docstring belongs to.
+
+    Returns
+    -------
+    :
+        A docstring carrying `value`.
+    """
     return gf.Docstring(
         value=value,
         lineno=getattr(old, "lineno", None),
@@ -298,11 +399,7 @@ def dynamic_alias(
     loader :
         An existing griffe loader to reuse. A fresh loader is created when omitted.
     """
-    try:
-        mod_name, object_path = path.split(":", 1)
-    except ValueError:
-        mod_name, object_path = path, None
-
+    mod_name, object_path = _split_path(path)
     mod = importlib.import_module(mod_name)
 
     if object_path is None:
@@ -347,6 +444,27 @@ def _locate_runtime_attr(
 
     Returns the statically-loaded griffe object instead when the path names a
     declaration-only attribute (one that carries no runtime value).
+
+    Parameters
+    ----------
+    module :
+        The already-imported module the walk starts from.
+    module_path :
+        Dotted path `module` was imported by.
+    object_path :
+        Dotted path of the attribute within the module, or `None` for the
+        module itself.
+    path :
+        The full path as written, used in error messages.
+    loader :
+        Loader to read the static model through when the walk finds no runtime
+        value.
+
+    Returns
+    -------
+    :
+        The attribute together with the paths it is known by, or the static node
+        when the path names a declaration that holds no runtime value.
 
     Raises
     ------

--- a/great_docs/_apiref/introspect.py
+++ b/great_docs/_apiref/introspect.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import enum
 import importlib
 import inspect
+from dataclasses import dataclass
 from types import ModuleType
 from typing import TYPE_CHECKING, Callable, cast
 
@@ -205,7 +206,8 @@ def resolve_alias(
 
 
 def replace_docstring(obj: gf.Object | gf.Alias, runtime_obj: object = None) -> None:
-    """Replace the griffe object's docstring in place with the imported runtime docstring
+    """
+    Replace the griffe object's docstring in place with the imported runtime docstring
 
     Callable attributes (the `method = some_function` pattern) are also
     promoted to functions so they render with a signature.
@@ -262,7 +264,8 @@ def replace_docstring(obj: gf.Object | gf.Alias, runtime_obj: object = None) -> 
 
 
 def _locate_runtime_object(obj: gf.Object) -> object | None:
-    """Locate the imported runtime object that `obj` documents, or return None if unreachable
+    """
+    Locate the imported runtime object that `obj` documents, or return None if unreachable
 
     A member of a (possibly nested) class is reached by walking the class
     chain, e.g. `Node.add_child` inside `Tree` resolves to
@@ -305,7 +308,8 @@ def _locate_runtime_object(obj: gf.Object) -> object | None:
 
 
 def _promote_callable_attribute(obj: gf.Attribute, f: object, doc: str) -> None:
-    """Re-register the attribute on its parent as a `gf.Function`
+    """
+    Re-register the attribute on its parent as a `gf.Function`
 
     The function carries the runtime signature when it is recoverable, so
     the member renders function-style instead of attribute-style.
@@ -399,51 +403,65 @@ def dynamic_alias(
     loader :
         An existing griffe loader to reuse. A fresh loader is created when omitted.
     """
-    mod_name, object_path = _split_path(path)
-    mod = importlib.import_module(mod_name)
+    module_path, object_path = _split_path(path)
+    module = importlib.import_module(module_path)
 
-    if object_path is None:
-        attr: object = mod
-        canonical_path: str = mod.__name__
-        attr_name = ""
-    else:
-        located = _locate_runtime_attr(mod, object_path, path, loader)
-        if isinstance(located, (gf.Object, gf.Alias)):
-            return located
-        attr, canonical_path, attr_name = located
+    located = _locate_runtime_attr(module, module_path, object_path, path, loader)
+    if isinstance(located, _DeclarationOnly):
+        return located.obj
 
-    if target:
-        obj = get_object(target, loader=loader)
-    else:
-        try:
-            obj = get_object(canonical_path, loader=loader)
-        except (KeyError, ModuleNotFoundError, ImportError):
-            # The canonical path computed via `__module__` doesn't refer to a
-            # loadable Python module, which is typical for PyO3 classes whose Rust
-            # `#[pyclass]` lacks `module = "..."` so `__module__` defaults
-            # to `"builtins"`. Fall back to the access path the user actually
-            # wrote, which by definition is importable.
-            obj = get_object(path, loader=loader)
-            canonical_path = path.replace(":", ".")
+    documented = _load_documenting_object(located, target, loader)
+    replace_docstring(documented.obj, located.value)
 
-    replace_docstring(obj, attr)
+    if _same_path(documented.path, located.access_path):
+        return documented.obj
+    return _alias_into_parent(located, documented.obj, loader)
 
-    if obj.canonical_path == path.replace(":", "."):
-        return obj
-    return _alias_into_parent(mod_name, object_path, attr_name, obj, loader)
+
+@dataclass(frozen=True)
+class _LocatedAttr:
+    """
+    A runtime attribute reached by walking an access path
+
+    `canonical_path` is `None` when the attribute does not report where it
+    lives, leaving `access_path` the only path known for it.
+    """
+
+    value: object
+    name: str
+    access_path: str
+    canonical_path: str | None
+
+
+@dataclass(frozen=True)
+class _DeclarationOnly:
+    """A path that names a declaration carrying no runtime value, e.g. an instance attribute"""
+
+    obj: gf.Object | gf.Alias
+
+
+@dataclass(frozen=True)
+class _Documented:
+    """The griffe object documenting an attribute, and the path it was loaded from"""
+
+    obj: gf.Object | gf.Alias
+    path: str
+
+
+def _same_path(one: str, other: str) -> bool:
+    """Whether two paths name the same object, ignoring the `:` / `.` separator"""
+    return one.replace(":", ".") == other.replace(":", ".")
 
 
 def _locate_runtime_attr(
-    mod: ModuleType,
-    object_path: str,
+    module: ModuleType,
+    module_path: str,
+    object_path: str | None,
     path: str,
     loader: gf.GriffeLoader | None,
-) -> tuple[object, str, str] | gf.Object | gf.Alias:
+) -> _LocatedAttr | _DeclarationOnly:
     """
-    Locate the runtime object at `object_path` in `mod`, its canonical path, and its final name
-
-    Returns the statically-loaded griffe object instead when the path names a
-    declaration-only attribute (one that carries no runtime value).
+    Walk `object_path` from `module` to the runtime attribute it names
 
     Parameters
     ----------
@@ -469,61 +487,154 @@ def _locate_runtime_attr(
     Raises
     ------
     AttributeError
-        When an attribute in the path does not exist at runtime.
-    ValueError
-        When no canonical import path can be determined.
+        When the path names neither a runtime attribute nor a declaration.
     """
-    splits = object_path.split(".")
+    if object_path is None:
+        return _LocatedAttr(module, module_path.rsplit(".", 1)[-1], path, module.__name__)
 
-    attr_name = ""
+    names = object_path.split(".")
+    value: object = module
     canonical_path: str | None = None
-    current_part: object = mod
-    for ii, attr_name in enumerate(splits):
-        new_canonical_path = _probe_canonical_path(current_part, ".".join(splits[ii:]))
-        if new_canonical_path is not None:
-            canonical_path = new_canonical_path
+
+    for index, name in enumerate(names):
+        home = _probe_canonical_path(value, ".".join(names[index:]))
+        if home is not None:
+            canonical_path = home
 
         try:
-            current_part = getattr(current_part, attr_name)
+            value = getattr(value, name)
         except AttributeError:
-            if canonical_path:
-                obj = get_object(canonical_path, loader=loader)
-                if _is_valueless(obj):
-                    return obj
+            return _locate_declaration(canonical_path or path, name, path, loader)
 
-            raise AttributeError(f"No attribute named `{attr_name}` in the path `{path}`.")
+    home = _probe_canonical_path(value, "")
+    if home is not None:
+        canonical_path = home
 
-    new_canonical_path = _probe_canonical_path(current_part, "")
-    if new_canonical_path is not None:
-        canonical_path = new_canonical_path
+    return _LocatedAttr(value, names[-1], path, canonical_path)
 
-    if canonical_path is None:
-        raise ValueError(f"Cannot find canonical path for `{path}`")
 
-    return current_part, canonical_path, attr_name
+def _locate_declaration(
+    static_path: str,
+    name: str,
+    path: str,
+    loader: gf.GriffeLoader | None,
+) -> _DeclarationOnly:
+    """
+    Fall back to griffe's static model for an attribute with no runtime value
+
+    Parameters
+    ----------
+    static_path :
+        Path to read the static model at.
+    name :
+        Name of the attribute that was missing at runtime, for the error
+        message.
+    path :
+        The full path as written, for the error message.
+    loader :
+        Loader to read the static model through.
+
+    Returns
+    -------
+    :
+        The static node, when it is a declaration that carries no value of its
+        own.
+
+    Raises
+    ------
+    AttributeError
+        When the static model does carry a value, so the missing runtime
+        attribute is a genuine absence rather than a declaration.
+    """
+    obj = get_object(static_path, loader=loader)
+    if _has_no_value(obj):
+        return _DeclarationOnly(obj)
+    raise AttributeError(f"No attribute named `{name}` in the path `{path}`.")
+
+
+def _load_documenting_object(
+    located: _LocatedAttr,
+    target: str | None,
+    loader: gf.GriffeLoader | None,
+) -> _Documented:
+    """
+    Load the griffe object that documents `located`
+
+    Prefers the attribute's canonical home, falling back to the path it was
+    accessed by. The fallback covers both an attribute that cannot report a
+    home and one whose `__module__` names a module that cannot be imported,
+    typical of PyO3 classes whose Rust `#[pyclass]` lacks `module = "..."` so
+    `__module__` defaults to `"builtins"`.
+
+    Parameters
+    ----------
+    located :
+        The attribute whose documentation is wanted.
+    loader :
+        Loader to read the static model through.
+
+    Returns
+    -------
+    :
+        The node that documents the attribute, and the path it was read from.
+        Callers compare that path against the access path to decide whether the
+        attribute still needs re-exposing.
+    """
+    if target:
+        return _Documented(get_object(target, loader=loader), target)
+
+    if located.canonical_path is not None:
+        try:
+            obj = get_object(located.canonical_path, loader=loader)
+        except (KeyError, ModuleNotFoundError, ImportError):
+            pass
+        else:
+            return _Documented(obj, located.canonical_path)
+
+    return _Documented(get_object(located.access_path, loader=loader), located.access_path)
 
 
 def _alias_into_parent(
-    mod_name: str,
-    object_path: str | None,
-    attr_name: str,
+    located: _LocatedAttr,
     obj: gf.Object | gf.Alias,
     loader: gf.GriffeLoader | None,
 ) -> gf.Alias:
-    """Re-expose `obj` as an alias member of the object it was accessed through"""
-    if object_path:
-        if "." in object_path:
-            prev_member = object_path.rsplit(".", 1)[0]
-            parent_path = f"{mod_name}:{prev_member}"
-        else:
-            parent_path = mod_name
+    """
+    Re-expose `obj` as an alias member of the object it was accessed through
+
+    Only called when the object lives somewhere other than where it was
+    accessed, so the alias can never target its own path.
+
+    Parameters
+    ----------
+    located :
+        The attribute as it was reached. Its access path names the parent, and
+        its name becomes the alias's name.
+    obj :
+        The node to re-expose.
+    loader :
+        Loader to read the parent through.
+
+    Returns
+    -------
+    :
+        An alias named after the accessed attribute, parented to the module or
+        class it was reached through. It is left unparented when the access path
+        names something that cannot hold members.
+    """
+    module_path, object_path = _split_path(located.access_path)
+
+    if object_path is None:
+        parent_path = module_path.rsplit(".", 1)[0]
+    elif "." in object_path:
+        parent_path = f"{module_path}:{object_path.rsplit('.', 1)[0]}"
     else:
-        parent_path = mod_name.rsplit(".", 1)[0]
+        parent_path = module_path
 
     parent = get_object(parent_path, loader=loader, dynamic=True)
     if isinstance(parent, (gf.Module, gf.Class, gf.Alias)):
-        return gf.Alias(attr_name, obj, parent=parent)
-    return gf.Alias(attr_name, obj)
+        return gf.Alias(located.name, obj, parent=parent)
+    return gf.Alias(located.name, obj)
 
 
 def _probe_canonical_path(part: object, qualname: str) -> str | None:
@@ -568,12 +679,23 @@ def _canonical_path(current_part: object, qualname: str) -> str | None:
     return None
 
 
-def _is_valueless(obj: gf.Object | gf.Alias) -> bool:
-    """Whether `obj` is an attribute that carries no runtime value.
+def _has_no_value(obj: gf.Object | gf.Alias) -> bool:
+    """
+    Whether `obj` is an attribute that carries no runtime value
 
     True for class/module attributes with no assigned value, and for
     all instance attributes (which are declaration-only in griffe's static
     model).
+
+    Parameters
+    ----------
+    obj :
+        The node to test. Anything that is not an attribute is False.
+
+    Returns
+    -------
+    :
+        True when the attribute carries no value of its own.
     """
     if isinstance(obj, gf.Attribute):
         if obj.labels & {"class-attribute", "module-attribute"} and obj.value is None:

--- a/great_docs/_apiref/introspect.py
+++ b/great_docs/_apiref/introspect.py
@@ -497,7 +497,7 @@ def _locate_runtime_attr(
     canonical_path: str | None = None
 
     for index, name in enumerate(names):
-        home = _probe_canonical_path(value, ".".join(names[index:]))
+        home = _canonical_path(value, ".".join(names[index:]))
         if home is not None:
             canonical_path = home
 
@@ -506,7 +506,7 @@ def _locate_runtime_attr(
         except AttributeError:
             return _locate_declaration(canonical_path or path, name, path, loader)
 
-    home = _probe_canonical_path(value, "")
+    home = _canonical_path(value, "")
     if home is not None:
         canonical_path = home
 
@@ -637,46 +637,42 @@ def _alias_into_parent(
     return gf.Alias(located.name, obj)
 
 
-def _probe_canonical_path(part: object, qualname: str) -> str | None:
-    """Probe for the canonical path of `part`, returning `None` when it does not expose one"""
-    try:
-        return _canonical_path(part, qualname)
-    except AttributeError:
+def _canonical_path(current_part: object, qualname: str) -> str | None:
+    """
+    The path at which `current_part` reports it lives, extended by `qualname`
+
+    `None` when the object reports no home. A module knows its own `__name__`
+    but not where its members were defined, so it reports a home only for
+    itself. Plain instances carry no `__qualname__` of their own.
+
+    Parameters
+    ----------
+    current_part :
+        The runtime object to ask.
+    qualname :
+        Dotted names to append to the reported home, empty for the object
+        itself.
+
+    Returns
+    -------
+    :
+        The reported path in `module:qualname` form, or `None` when the object
+        reports no home.
+    """
+    if isinstance(current_part, ModuleType):
+        return None if qualname else current_part.__name__
+
+    module = getattr(current_part, "__module__", None)
+    qualified = getattr(current_part, "__qualname__", None)
+
+    # `callable` rather than `inspect.isfunction` so that PyO3 / C-extension
+    # callables (`builtin_function_or_method`, `method-wrapper`) report their
+    # canonical home too.
+    if not (module and qualified and callable(current_part)):
         return None
 
-
-def _canonical_path(current_part: object, qualname: str) -> str | None:
-    """Build the canonical import path for `current_part`, extended by `qualname`.
-
-    Returns `None` when no canonical path can be determined (e.g. for
-    plain data objects that carry no `__module__` or `__qualname__`).
-    """
-    suffix = (":" + qualname) if qualname else ""
-    if isinstance(current_part, ModuleType):
-        return current_part.__name__ + suffix
-
-    if inspect.isclass(current_part) or inspect.isfunction(current_part):
-        _mod = getattr(current_part, "__module__", None)
-
-        if _mod is None:
-            return None
-
-        qual_parts = [] if not qualname else qualname.split(".")
-        return _mod + ":" + ".".join([current_part.__qualname__, *qual_parts])
-
-    # PyO3 / C-extension callables (e.g. `builtin_function_or_method`,
-    # `method-wrapper`) don't satisfy `inspect.isfunction` but they do carry
-    # `__module__` / `__qualname__` attributes. Treat them as function-like
-    # so `dynamic_alias` can resolve them to their canonical home rather than
-    # building a self-referential alias on the re-exporting facade module
-    # (which produces `CyclicAliasError` downstream).
-    _mod = getattr(current_part, "__module__", None)
-    _qn = getattr(current_part, "__qualname__", None)
-    if _mod and _qn and callable(current_part):
-        qual_parts = [] if not qualname else qualname.split(".")
-        return _mod + ":" + ".".join([_qn, *qual_parts])
-
-    return None
+    qual_parts = qualname.split(".") if qualname else []
+    return module + ":" + ".".join([qualified, *qual_parts])
 
 
 def _has_no_value(obj: gf.Object | gf.Alias) -> bool:

--- a/great_docs/_apiref/introspect.py
+++ b/great_docs/_apiref/introspect.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import enum
 import importlib
 import inspect
+import warnings
 from dataclasses import dataclass
 from types import ModuleType
 from typing import TYPE_CHECKING, Callable, cast
@@ -73,11 +74,12 @@ def make_loader(parser: str = "numpy") -> gf.GriffeLoader:
 
 def get_object(
     path: str,
-    parser: str = "numpy",
+    parser: str | None = None,
     dynamic: bool | str = False,
     loader: gf.GriffeLoader | None = None,
 ) -> gf.Object | gf.Alias:
-    """Get the griffe object at the given import path.
+    """
+    Get the griffe object at the given import path
 
     Parameters
     ----------
@@ -85,7 +87,8 @@ def get_object(
         An import path to the object. This should have the form `path.to.module:object`.
         For example, `my_package:get_object` or `my_package:MyClass.render`.
     parser :
-        A docstring parser to use.
+        A docstring parser to configure a new loader with. Ignored, with a warning,
+        when `loader` is given, since the loader already carries a parser.
     dynamic :
         Whether to dynamically import object. Useful if docstring is not hard-coded,
         but was set on object by running python code.
@@ -99,7 +102,14 @@ def get_object(
         reaches it through a re-export.
     """
     if loader is None:
-        loader = make_loader(parser)
+        loader = make_loader(parser or "numpy")
+    elif parser is not None:
+        warnings.warn(
+            f"Ignoring parser {parser!r} because `loader` was given; "
+            "the loader already carries a docstring parser.",
+            UserWarning,
+            stacklevel=2,
+        )
 
     module_path, object_path = _split_path(path)
 

--- a/great_docs/_apiref/resolve.py
+++ b/great_docs/_apiref/resolve.py
@@ -326,7 +326,7 @@ class _Resolver:
         obj: gf.Object | gf.Alias,
         *,
         path: str,
-        dynamic: bool | str,
+        dynamic: bool,
     ) -> list[object]:
         """Resolve the members of `obj`, each wrapped per the entry's children style"""
         # Member precedence: the member's own name, then `member_options`,

--- a/great_docs/_apiref/spec.py
+++ b/great_docs/_apiref/spec.py
@@ -15,6 +15,7 @@ from enum import Enum
 from typing import Any, Self, cast
 
 from ._walkable import MISSING, MissingType, Walkable
+from .introspect import _validate_dynamic
 
 
 class ChildrenStyle(Enum):
@@ -43,7 +44,7 @@ class SpecOptions(Walkable):
 
     include: str | None = None
     exclude: list[str] | None = None
-    dynamic: bool | str | None = None
+    dynamic: bool | None = None
     children: ChildrenStyle = ChildrenStyle.embedded
     package: str | MissingType | None = MISSING
     member_order: str = "alphabetical"
@@ -76,6 +77,7 @@ class SpecOptions(Walkable):
                 object.__setattr__(self, f.name, f.default_factory())
             # else: field has no default — it must be in kwargs or will error
         object.__setattr__(self, "_fields_specified", tuple(kwargs.keys()))
+        _validate_dynamic(self.dynamic, allow_none=True)
 
     def replace(self, **changes: object) -> Self:
         """Return a copy with the given fields replaced
@@ -85,6 +87,9 @@ class SpecOptions(Walkable):
         (`dataclasses.replace` would instead re-run `__init__` with every
         field and mark them all as specified.)
         """
+        if "dynamic" in changes:
+            _validate_dynamic(changes["dynamic"], allow_none=True)
+
         new = self.copy()
         for name, value in changes.items():
             object.__setattr__(new, name, value)

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -7821,9 +7821,7 @@ class GreatDocs:
                 from great_docs._apiref.introspect import make_loader
 
                 _shared_loader = make_loader("numpy")
-                gd_get_object = partial(
-                    qd_get_object, dynamic=True, parser="numpy", loader=_shared_loader
-                )
+                gd_get_object = partial(qd_get_object, dynamic=True, loader=_shared_loader)
             except ImportError:  # pragma: no cover
                 pass  # pragma: no cover
 

--- a/tests/renderer/test_pyo3.py
+++ b/tests/renderer/test_pyo3.py
@@ -41,9 +41,9 @@ def test_canonical_path_returns_none_for_plain_value():
 
 
 def test_canonical_path_module():
-    """Modules continue to resolve to their dotted name."""
+    """A module reports a home for itself only, never for its members."""
     assert _canonical_path(sys, "") == "sys"
-    assert _canonical_path(sys, "path") == "sys:path"
+    assert _canonical_path(sys, "path") is None
 
 
 def _make_facade_with_builtin(monkeypatch):

--- a/tests/renderer/test_type_alias_introspection.py
+++ b/tests/renderer/test_type_alias_introspection.py
@@ -102,6 +102,16 @@ def test_instance_defined_in_the_accessing_module_keeps_the_access_path(monkeypa
     assert obj.canonical_path == "gdta_local_singleton.SETTINGS"
 
 
+def test_trailing_colon_module_path_does_not_self_alias():
+    """A degenerate `module:` path resolves the module, not a self-referential alias."""
+    from great_docs._apiref.introspect import get_object
+
+    obj = get_object("json.decoder:", dynamic=True)
+
+    if isinstance(obj, gf.Alias):
+        assert obj.target_path != obj.path
+
+
 def test_a_genuine_alias_cycle_still_raises(monkeypatch, tmp_path):
     """A cycle the package really authored is reported, not silently absorbed."""
     from great_docs._apiref.introspect import get_object

--- a/tests/renderer/test_type_alias_introspection.py
+++ b/tests/renderer/test_type_alias_introspection.py
@@ -1,0 +1,131 @@
+"""Tests for objects whose canonical path cannot be read off the runtime object."""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+import griffe as gf
+import pytest
+
+
+def _write_package(tmp_path: Path, name: str, files: dict[str, str]) -> Path:
+    """Write an importable package into `tmp_path` and return its parent directory"""
+    pkg = tmp_path / name
+    pkg.mkdir(parents=True, exist_ok=True)
+    for filename, content in files.items():
+        (pkg / filename).write_text(textwrap.dedent(content))
+    return tmp_path
+
+
+def _install(monkeypatch, root: Path) -> None:
+    """Make `root` importable and drop any cached modules under it"""
+    monkeypatch.syspath_prepend(str(root))
+    for mod in list(sys.modules):
+        if mod.startswith("gdta_"):
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+
+
+def test_reexported_instance_resolves_to_its_definition_module(monkeypatch, tmp_path):
+    """A re-exported instance documents the module that defines it, not the facade."""
+    from great_docs._apiref.introspect import get_object
+
+    root = _write_package(
+        tmp_path,
+        "gdta_reexported_singleton",
+        {
+            "_conf.py": '''
+                class Config:
+                    """A config object."""
+
+                SETTINGS = Config()
+            ''',
+            "__init__.py": '''
+                """Package."""
+
+                from gdta_reexported_singleton._conf import SETTINGS
+            ''',
+        },
+    )
+    _install(monkeypatch, root)
+
+    obj = get_object("gdta_reexported_singleton:SETTINGS", dynamic=True)
+
+    assert obj.canonical_path == "gdta_reexported_singleton._conf.SETTINGS"
+
+
+def test_future_annotations_member_does_not_cycle(monkeypatch, tmp_path):
+    """`from __future__ import annotations` leaves a member that reports no home."""
+    from great_docs._apiref.introspect import get_object
+
+    root = _write_package(
+        tmp_path,
+        "gdta_future_annotations",
+        {
+            "__init__.py": '''
+                """Package."""
+
+                from __future__ import annotations
+            '''
+        },
+    )
+    _install(monkeypatch, root)
+
+    obj = get_object("gdta_future_annotations:annotations", dynamic=True)
+
+    assert obj.canonical_path == "__future__.annotations"
+
+
+def test_instance_defined_in_the_accessing_module_keeps_the_access_path(monkeypatch, tmp_path):
+    """An instance that is not re-exported is documented where it was found."""
+    from great_docs._apiref.introspect import get_object
+
+    root = _write_package(
+        tmp_path,
+        "gdta_local_singleton",
+        {
+            "__init__.py": '''
+                """Package."""
+
+                class Config:
+                    """A config object."""
+
+                SETTINGS = Config()
+            '''
+        },
+    )
+    _install(monkeypatch, root)
+
+    obj = get_object("gdta_local_singleton:SETTINGS", dynamic=True)
+
+    assert obj.canonical_path == "gdta_local_singleton.SETTINGS"
+
+
+def test_a_genuine_alias_cycle_still_raises(monkeypatch, tmp_path):
+    """A cycle the package really authored is reported, not silently absorbed."""
+    from great_docs._apiref.introspect import get_object
+
+    root = _write_package(
+        tmp_path,
+        "gdta_alias_cycle",
+        {
+            "a.py": """
+                from typing import TYPE_CHECKING
+
+                if TYPE_CHECKING:
+                    from gdta_alias_cycle import x
+                else:
+                    x = 1
+            """,
+            "__init__.py": '''
+                """Package."""
+
+                from gdta_alias_cycle.a import x
+            ''',
+        },
+    )
+    _install(monkeypatch, root)
+
+    with pytest.raises(gf.CyclicAliasError):
+        _ = get_object("gdta_alias_cycle:x", dynamic=True).canonical_path

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -28015,6 +28015,21 @@ def test_replace_docstring_enum_no_member_docstrings():
             sys.modules.pop("introtest_enum_nodoc", None)
 
 
+def test_split_path_without_a_colon_is_all_module():
+    """`resolve_alias` re-loads targets by dotted path, with no object part."""
+    from great_docs._apiref.introspect import _split_path
+
+    assert _split_path("pkg.mod.func") == ("pkg.mod.func", None)
+
+
+def test_split_path_separates_the_object_part():
+    """Only the first colon separates; the object part keeps its dots."""
+    from great_docs._apiref.introspect import _split_path
+
+    assert _split_path("json:dumps") == ("json", "dumps")
+    assert _split_path("pkg.mod:A.b") == ("pkg.mod", "A.b")
+
+
 def test_canonical_path_module():
     """_canonical_path for a module returns module name."""
     from great_docs._apiref.introspect import _canonical_path

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -117,7 +117,7 @@ from great_docs._apiref.content import (
     SummaryItem,
 )
 from great_docs._apiref.introspect import (
-    _is_valueless,
+    _has_no_value,
     dynamic_alias,
     get_object,
     get_parser_defaults,
@@ -28030,6 +28030,14 @@ def test_split_path_separates_the_object_part():
     assert _split_path("pkg.mod:A.b") == ("pkg.mod", "A.b")
 
 
+def test_same_path_ignores_the_separator():
+    """The `:` in an access path is a module boundary, not part of the name."""
+    from great_docs._apiref.introspect import _same_path
+
+    assert _same_path("pkg:SETTINGS", "pkg.SETTINGS")
+    assert not _same_path("pkg._conf:SETTINGS", "pkg.SETTINGS")
+
+
 def test_canonical_path_module():
     """_canonical_path for a module returns module name."""
     from great_docs._apiref.introspect import _canonical_path
@@ -28103,56 +28111,56 @@ def test_canonical_path_class_no_module():
     assert result is None
 
 
-def test_is_valueless_class_attribute_no_value():
-    """_is_valueless returns True for class-attribute with no value."""
+def test_has_no_value_class_attribute_no_value():
+    """_has_no_value returns True for class-attribute with no value."""
 
     attr = gf.Attribute(name="x", lineno=1, value=None)
     attr.labels.add("class-attribute")
 
-    assert _is_valueless(attr) is True
+    assert _has_no_value(attr) is True
 
 
-def test_is_valueless_instance_attribute():
-    """_is_valueless returns True for instance-attribute."""
+def test_has_no_value_instance_attribute():
+    """_has_no_value returns True for instance-attribute."""
 
     attr = gf.Attribute(name="x", lineno=1)
     attr.labels.add("instance-attribute")
 
-    assert _is_valueless(attr) is True
+    assert _has_no_value(attr) is True
 
 
-def test_is_valueless_class_attribute_with_value():
-    """_is_valueless returns False for class-attribute with a value."""
+def test_has_no_value_class_attribute_with_value():
+    """_has_no_value returns False for class-attribute with a value."""
 
     attr = gf.Attribute(name="x", lineno=1, value="42")
     attr.labels.add("class-attribute")
 
-    assert _is_valueless(attr) is False
+    assert _has_no_value(attr) is False
 
 
-def test_is_valueless_unlabelled_attribute():
-    """_is_valueless returns False for an attribute with none of the labels."""
+def test_has_no_value_unlabelled_attribute():
+    """_has_no_value returns False for an attribute with none of the labels."""
 
     attr = gf.Attribute(name="x", lineno=1, value=None)
 
-    assert _is_valueless(attr) is False
+    assert _has_no_value(attr) is False
 
 
-def test_is_valueless_function():
-    """_is_valueless returns False for a function."""
+def test_has_no_value_function():
+    """_has_no_value returns False for a function."""
 
     func = gf.Function(name="f", lineno=1)
 
-    assert _is_valueless(func) is False
+    assert _has_no_value(func) is False
 
 
-def test_is_valueless_module_attribute_no_value():
-    """_is_valueless returns True for module-attribute with no value."""
+def test_has_no_value_module_attribute_no_value():
+    """_has_no_value returns True for module-attribute with no value."""
 
     attr = gf.Attribute(name="x", lineno=1, value=None)
     attr.labels.add("module-attribute")
 
-    assert _is_valueless(attr) is True
+    assert _has_no_value(attr) is True
 
 
 def test_insert_contents_list():

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -27812,6 +27812,11 @@ def test_get_object_dynamic_mode():
     assert obj.name == "dumps"
 
 
+def test_get_object_rejects_a_path_for_dynamic():
+    with pytest.raises(ValueError, match="accepts true or false"):
+        get_object("json:dumps", dynamic="json:dumps")
+
+
 def test_get_object_warns_when_parser_is_ignored():
     """A parser cannot apply to a loader that already carries one."""
     from great_docs._apiref.introspect import make_loader
@@ -28298,14 +28303,6 @@ def test_dynamic_alias_nested_class_method():
     assert obj is not None
 
 
-def test_dynamic_alias_with_target():
-    """dynamic_alias with explicit target uses that target."""
-
-    obj = dynamic_alias("json:dumps", target="json:dumps")
-    assert obj is not None
-    assert obj.name == "dumps"
-
-
 def test_dynamic_alias_nonexistent_attr_raises():
     """dynamic_alias raises KeyError for nonexistent attributes in a real module."""
 
@@ -28396,12 +28393,19 @@ def test_dynamic_alias_reexported_creates_alias():
             sys.modules.pop("introtest_reexp.sub", None)
 
 
-def test_get_object_dynamic_string_target():
-    """get_object with dynamic=<string> passes target to dynamic_alias."""
+def test_spec_object_rejects_a_path_for_dynamic():
+    """`dynamic` selects how an object is inspected, so only a bool will do."""
+    from great_docs._apiref.spec import SpecObject
 
-    obj = get_object("json:dumps", dynamic="json:dumps")
-    assert obj is not None
-    assert obj.name == "dumps"
+    with pytest.raises(ValueError, match="accepts true or false"):
+        SpecObject(**{"name": "dumps", "dynamic": "json:dumps"})
+
+
+def test_spec_options_replace_rejects_a_path_for_dynamic():
+    from great_docs._apiref.spec import SpecOptions
+
+    with pytest.raises(ValueError, match="accepts true or false"):
+        SpecOptions().replace(dynamic="json:dumps")
 
 
 def _make_api_ref(**block):

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -27813,10 +27813,10 @@ def test_get_object_dynamic_mode():
 
 
 def test_get_object_alias_loads_target_module():
-    """get_object with load_aliases=True loads the target module for aliases."""
+    """get_object loads the target module for aliases."""
 
     # os.path is typically an alias to posixpath or ntpath
-    obj = get_object("os:path", load_aliases=True)
+    obj = get_object("os:path")
     assert obj is not None
 
 

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -27812,6 +27812,24 @@ def test_get_object_dynamic_mode():
     assert obj.name == "dumps"
 
 
+def test_get_object_warns_when_parser_is_ignored():
+    """A parser cannot apply to a loader that already carries one."""
+    from great_docs._apiref.introspect import make_loader
+
+    with pytest.warns(UserWarning, match="Ignoring parser"):
+        get_object("json:dumps", parser="numpy", loader=make_loader("numpy"))
+
+
+def test_get_object_does_not_warn_for_parser_or_loader_alone():
+    """Either argument on its own is unambiguous."""
+    from great_docs._apiref.introspect import make_loader
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        get_object("json:dumps", loader=make_loader("numpy"))
+        get_object("json:dumps", parser="numpy")
+
+
 def test_get_object_alias_loads_target_module():
     """get_object loads the target module for aliases."""
 

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -28047,13 +28047,13 @@ def test_canonical_path_module():
     assert result == "json"
 
 
-def test_canonical_path_module_with_qualname():
-    """_canonical_path for a module with qualname appends suffix."""
+def test_canonical_path_module_reports_no_home_for_a_member():
+    """A module knows its own name but not where its members were defined."""
     from great_docs._apiref.introspect import _canonical_path
 
     result = _canonical_path(json, "dumps")
 
-    assert result == "json:dumps"
+    assert result is None
 
 
 def test_canonical_path_function():


### PR DESCRIPTION
This PR fixes `dynamic_alias` producing aliases that target themselves — and with that, a `CyclicAliasError` on first resolution. It then cleans up the surfaces in `introspect.py` that  the bug hid behind.
