### PR TITLE
Add Pep695 type alias support

### DIFF
--- a/great_docs/_apiref/__init__.py
+++ b/great_docs/_apiref/__init__.py
@@ -4,11 +4,13 @@ from ._render.docattribute import RenderDocAttribute
 from ._render.docclass import RenderDocClass
 from ._render.docfunction import RenderDocFunction
 from ._render.docmodule import RenderDocModule
+from ._render.doctypealias import RenderDocTypeAlias
 from ._render.extending import (
     exclude_attributes,
     exclude_classes,
     exclude_functions,
     exclude_parameters,
+    exclude_type_aliases,
 )
 from ._render.mixin_call import RenderDocCallMixin
 from ._render.mixin_members import RenderDocMembersMixin
@@ -28,6 +30,7 @@ __all__ = (
     "RenderDocFunction",
     "RenderDocAttribute",
     "RenderDocModule",
+    "RenderDocTypeAlias",
     "RenderDocCallMixin",
     "RenderDocMembersMixin",
     "RenderReferencePage",
@@ -37,6 +40,7 @@ __all__ = (
     "exclude_classes",
     "exclude_functions",
     "exclude_parameters",
+    "exclude_type_aliases",
     "get_object",
     "APIReference",
     "remove_package_prefix",

--- a/great_docs/_apiref/_globals.py
+++ b/great_docs/_apiref/_globals.py
@@ -21,14 +21,15 @@ class Exclusions:
 
     Each mapping is keyed by a parent object's path (as shown on the API
     page); the value names the member — or members — of that object to
-    leave out: parameters of a callable, or attributes, functions, and
-    classes of a class or module.
+    leave out: parameters of a callable, or attributes, functions, classes,
+    and type aliases of a class or module.
     """
 
     parameters: ExclusionMap = field(default_factory=ExclusionMap)
     attributes: ExclusionMap = field(default_factory=ExclusionMap)
     functions: ExclusionMap = field(default_factory=ExclusionMap)
     classes: ExclusionMap = field(default_factory=ExclusionMap)
+    type_aliases: ExclusionMap = field(default_factory=ExclusionMap)
 
 
 EXCLUSIONS = Exclusions()

--- a/great_docs/_apiref/_render/__init__.py
+++ b/great_docs/_apiref/_render/__init__.py
@@ -7,6 +7,7 @@ from ..content import (
     DocClass,
     DocFunction,
     DocModule,
+    DocTypeAlias,
     Page,
     Section,
 )
@@ -15,6 +16,7 @@ from .docattribute import RenderDocAttribute
 from .docclass import RenderDocClass
 from .docfunction import RenderDocFunction
 from .docmodule import RenderDocModule
+from .doctypealias import RenderDocTypeAlias
 from .reference_page import RenderReferencePage
 from .reference_section import RenderReferenceSection
 
@@ -24,6 +26,7 @@ if TYPE_CHECKING:
 
 _class_mapping: dict[type[Documentable], type[RenderObjType]] = {
     DocAttribute: RenderDocAttribute,
+    DocTypeAlias: RenderDocTypeAlias,
     DocClass: RenderDocClass,
     DocFunction: RenderDocFunction,
     DocModule: RenderDocModule,
@@ -42,6 +45,10 @@ def get_render_type(obj: DocFunction) -> type[RenderDocFunction]: ...
 
 @overload
 def get_render_type(obj: DocAttribute) -> type[RenderDocAttribute]: ...
+
+
+@overload
+def get_render_type(obj: DocTypeAlias) -> type[RenderDocTypeAlias]: ...
 
 
 @overload

--- a/great_docs/_apiref/_render/_label.py
+++ b/great_docs/_apiref/_render/_label.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import griffe as gf
+
 if TYPE_CHECKING:
-    import griffe as gf
+    pass
 
 ENUMS = {"Enum", "IntEnum", "StrEnum", "Flag", "IntFlag", "ReprEnum", "EnumCheck"}
 EXCEPTIONS = {
@@ -94,7 +96,7 @@ def get_label(obj: gf.Alias | gf.Object) -> str:
 def _attribute_label(obj: gf.Attribute | gf.TypeAlias) -> str:
     # A PEP 695 alias (`type X = ...`) is a `TypeAlias`, which has no
     # `annotation`, so this must precede any use of one.
-    if obj.kind.value == "type alias":
+    if isinstance(obj, gf.TypeAlias):
         return "typealias"
 
     annotation = str(obj.annotation) if obj.annotation else ""

--- a/great_docs/_apiref/_render/_label.py
+++ b/great_docs/_apiref/_render/_label.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import griffe as gf
-
-if TYPE_CHECKING:
-    pass
 
 ENUMS = {"Enum", "IntEnum", "StrEnum", "Flag", "IntFlag", "ReprEnum", "EnumCheck"}
 EXCEPTIONS = {

--- a/great_docs/_apiref/_render/_label.py
+++ b/great_docs/_apiref/_render/_label.py
@@ -91,10 +91,15 @@ def get_label(obj: gf.Alias | gf.Object) -> str:
     return label
 
 
-def _attribute_label(obj: gf.Attribute) -> str:
+def _attribute_label(obj: gf.Attribute | gf.TypeAlias) -> str:
+    # A PEP 695 alias (`type X = ...`) is a `TypeAlias`, which has no
+    # `annotation`, so this must precede any use of one.
+    if obj.kind.value == "type alias":
+        return "typealias"
+
     annotation = str(obj.annotation) if obj.annotation else ""
 
-    if obj.kind.value == "type alias":
+    if "TypeAlias" in annotation:
         return "typealias"
     elif "TypeVar" in annotation or "ParamSpec" in annotation or "TypeVarTuple" in annotation:
         return "typevar"

--- a/great_docs/_apiref/_render/_label.py
+++ b/great_docs/_apiref/_render/_label.py
@@ -79,7 +79,11 @@ def get_label(obj: gf.Alias | gf.Object) -> str:
         label = _function_label(obj)  # pyright: ignore[reportArgumentType]
     elif obj.is_class:
         label = _class_label(obj)  # pyright: ignore[reportArgumentType]
-    elif obj.is_attribute or obj.is_type_alias:
+    elif obj.is_type_alias:
+        # A PEP 695 alias has no `annotation`, and may arrive as an `Alias`
+        # proxy rather than a `TypeAlias`, so decide it here by predicate.
+        label = "typealias"
+    elif obj.is_attribute:
         label = _attribute_label(obj)  # pyright: ignore[reportArgumentType]
     elif obj.is_module:
         label = "module"
@@ -88,12 +92,7 @@ def get_label(obj: gf.Alias | gf.Object) -> str:
     return label
 
 
-def _attribute_label(obj: gf.Attribute | gf.TypeAlias) -> str:
-    # A PEP 695 alias (`type X = ...`) is a `TypeAlias`, which has no
-    # `annotation`, so this must precede any use of one.
-    if isinstance(obj, gf.TypeAlias):
-        return "typealias"
-
+def _attribute_label(obj: gf.Attribute) -> str:
     annotation = str(obj.annotation) if obj.annotation else ""
 
     if "TypeAlias" in annotation:

--- a/great_docs/_apiref/_render/_label.py
+++ b/great_docs/_apiref/_render/_label.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-import griffe as gf
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import griffe as gf
 
 ENUMS = {"Enum", "IntEnum", "StrEnum", "Flag", "IntFlag", "ReprEnum", "EnumCheck"}
 EXCEPTIONS = {

--- a/great_docs/_apiref/_render/_label.py
+++ b/great_docs/_apiref/_render/_label.py
@@ -96,11 +96,19 @@ def get_label(obj: gf.Alias | gf.Object) -> str:
 
 
 def _attribute_label(obj: gf.Attribute) -> str:
-    annotation = str(obj.annotation) if obj.annotation else ""
+    annotation = obj.annotation
+    annotation_path = (
+        annotation.canonical_path if annotation and not isinstance(annotation, str) else annotation
+    )
 
-    if "TypeAlias" in annotation:
+    if annotation_path in {"TypeAlias", "typing.TypeAlias"}:
         return "typealias"
-    elif "TypeVar" in annotation or "ParamSpec" in annotation or "TypeVarTuple" in annotation:
+    annotation_text = str(annotation) if annotation else ""
+    if (
+        "TypeVar" in annotation_text
+        or "ParamSpec" in annotation_text
+        or "TypeVarTuple" in annotation_text
+    ):
         return "typevar"
     elif "property" in obj.labels:
         return "property"

--- a/great_docs/_apiref/_render/_type_parameters.py
+++ b/great_docs/_apiref/_render/_type_parameters.py
@@ -1,0 +1,55 @@
+"""
+Rendering of PEP 695 type parameter lists
+
+A leaf module: it imports nothing from `_apiref` at runtime, so it is safe to
+use from any render module and from a future generic-class/function renderer.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import griffe as gf
+
+# `*Ts` for a TypeVarTuple, `**P` for a ParamSpec, nothing for a plain TypeVar
+_KIND_PREFIX = {
+    "type-var": "",
+    "type-var-tuple": "*",
+    "param-spec": "**",
+}
+
+
+def render_type_parameters(type_parameters: gf.TypeParameters | None) -> str:
+    """
+    Render a PEP 695 type parameter list, brackets included
+
+    Returns an empty string when there are no type parameters, so callers can
+    concatenate the result unconditionally.
+    """
+    if not type_parameters:
+        return ""
+
+    rendered = ", ".join(_render_type_parameter(tp) for tp in type_parameters)
+    return f"[{rendered}]"
+
+
+def _render_type_parameter(tp: gf.TypeParameter) -> str:
+    """
+    Render one type parameter with its bound or constraints and any default
+
+    A constrained parameter (`S: (str, bytes)`) carries no bound, so the two
+    are alternatives rather than a bound with extra detail.
+    """
+    out = f"{_KIND_PREFIX.get(tp.kind.value, '')}{tp.name}"
+
+    if tp.bound is not None:
+        out += f": {tp.bound}"
+    elif tp.constraints:
+        constraints = ", ".join(str(c) for c in tp.constraints)
+        out += f": ({constraints})"
+
+    if tp.default is not None:
+        out += f" = {tp.default}"
+
+    return out

--- a/great_docs/_apiref/_render/base.py
+++ b/great_docs/_apiref/_render/base.py
@@ -30,6 +30,7 @@ class __RenderBase(Block):
         content.DocClass
         | content.DocFunction
         | content.DocAttribute
+        | content.DocTypeAlias
         | content.DocModule
         | content.Page
         | content.Section

--- a/great_docs/_apiref/_render/doc.py
+++ b/great_docs/_apiref/_render/doc.py
@@ -174,6 +174,16 @@ class __RenderDoc(RenderBase):
         return self.obj.kind.value
 
     @cached_property
+    def kind_slug(self) -> str:
+        """
+        The object's kind as a CSS class slug
+
+        Some kinds (e.g. `type alias`) contain a space, which a browser would
+        otherwise parse as two separate classes.
+        """
+        return self.kind.replace(" ", "-")
+
+    @cached_property
     def label(self) -> str:
         """
         A label for the object
@@ -225,7 +235,7 @@ class __RenderDoc(RenderBase):
             Attr(
                 classes=[
                     "doc-object-name",
-                    f"doc-{self.kind}",
+                    f"doc-{self.kind_slug}",
                     "doc-label",
                     f"doc-label-{self.label}",
                 ],
@@ -605,7 +615,7 @@ class __RenderDoc(RenderBase):
         link = Link(
             markdown_escape(self.summary_name),
             f"{self.page_path}#{anchor}",
-            attr=Attr(classes=[f"doc-{self.kind}", "doc-label", f"doc-label-{self.label}"]),
+            attr=Attr(classes=[f"doc-{self.kind_slug}", "doc-label", f"doc-label-{self.label}"]),
         )
         return [(str(link), self.docstring_subject)]
 

--- a/great_docs/_apiref/_render/doc.py
+++ b/great_docs/_apiref/_render/doc.py
@@ -169,7 +169,7 @@ class __RenderDoc(RenderBase):
         """
         The object's kind
 
-        class, function, method, property, attribute, module, alias
+        class, function, method, property, attribute, type alias, module, alias
         """
         return self.obj.kind.value
 

--- a/great_docs/_apiref/_render/docattribute.py
+++ b/great_docs/_apiref/_render/docattribute.py
@@ -40,10 +40,6 @@ class __RenderDocAttribute(RenderDoc):
         annotation = self.obj.annotation if self.show_signature_annotation else None
         default = getattr(self.obj, "value", None)
 
-        # For a TypeAlias, the name is the title and we can do without the annotation
-        if "type" in self.kind:
-            name, annotation = None, None
-
         term = self.render_variable_definition(name, annotation, default)
         return Div(
             Code(str(term)).html,

--- a/great_docs/_apiref/_render/docattribute.py
+++ b/great_docs/_apiref/_render/docattribute.py
@@ -43,7 +43,7 @@ class __RenderDocAttribute(RenderDoc):
         term = self.render_variable_definition(name, annotation, default)
         return Div(
             Code(str(term)).html,
-            Attr(classes=["doc-signature", f"doc-{self.kind}"]),
+            Attr(classes=["doc-signature", f"doc-{self.kind_slug}"]),
         )
 
     def render_description(self) -> BlockContent:

--- a/great_docs/_apiref/_render/doctypealias.py
+++ b/great_docs/_apiref/_render/doctypealias.py
@@ -3,16 +3,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+import griffe as gf
+
 from great_docs.pandoc.blocks import Blocks, Div
 from great_docs.pandoc.components import Attr
 from great_docs.pandoc.inlines import Code, Inlines0, Span
 
+from .._format import HAS_RUFF, format_value, render_formatted_expr
 from ._type_parameters import render_type_parameters
 from .doc import RenderDoc
 
 if TYPE_CHECKING:
-    import griffe as gf
-
     from great_docs.pandoc.blocks import BlockContent
     from great_docs.pandoc.inlines import InlineContentItem
 
@@ -38,6 +39,19 @@ class __RenderDocTypeAlias(RenderDoc):
 
         self.subject_above_signature = self.subject_above_signature is None and not self.contained
 
+    def _render_value(self, value: str | gf.Expr) -> str:
+        """
+        Format an alias value the way `render_variable_definition` formats an
+        annotation: ruff-format only when it is worth invoking ruff for (long
+        expressions), otherwise the plain recursive render, which also
+        normalizes string-literal quotes and highlights them
+        """
+        if not isinstance(value, gf.Expr):
+            return format_value(value)
+        if HAS_RUFF and len(str(value)) > 79:
+            return render_formatted_expr(value)
+        return self.render_annotation(value)
+
     def render_signature(self) -> BlockContent:
         """
         Render the alias in its source form, e.g. `type Pair[T] = tuple[T, T]`
@@ -49,11 +63,18 @@ class __RenderDocTypeAlias(RenderDoc):
             Span("type", Attr(classes=[f"doc-{_KIND_SLUG}-keyword", "kw"])),
             " ",
             Span(declared, Attr(classes=["doc-parameter-name"])),
-            " ",
-            Span("=", Attr(classes=["doc-parameter-default-sep", "op"])),
-            " ",
-            Span(str(self.obj.value), Attr(classes=["doc-parameter-default"])),
         ]
+
+        value = self.obj.value
+        if value is not None:
+            items.extend(
+                [
+                    " ",
+                    Span("=", Attr(classes=["doc-parameter-default-sep", "op"])),
+                    " ",
+                    Span(self._render_value(value), Attr(classes=["doc-parameter-default"])),
+                ]
+            )
 
         return Div(
             Code(str(Inlines0(items))).html,

--- a/great_docs/_apiref/_render/doctypealias.py
+++ b/great_docs/_apiref/_render/doctypealias.py
@@ -19,10 +19,6 @@ if TYPE_CHECKING:
 
     from .. import content
 
-# `obj.kind.value` is "type alias", with a space; used bare it would split into
-# two CSS classes, the second colliding with the `alias` kind.
-_KIND_SLUG = "type-alias"
-
 
 @dataclass
 class __RenderDocTypeAlias(RenderDoc):
@@ -60,7 +56,7 @@ class __RenderDocTypeAlias(RenderDoc):
         declared = f"{name}{render_type_parameters(self.obj.type_parameters)}"
 
         items: list[InlineContentItem] = [
-            Span("type", Attr(classes=[f"doc-{_KIND_SLUG}-keyword", "kw"])),
+            Span("type", Attr(classes=[f"doc-{self.kind_slug}-keyword", "kw"])),
             " ",
             Span(declared, Attr(classes=["doc-parameter-name"])),
         ]
@@ -78,7 +74,7 @@ class __RenderDocTypeAlias(RenderDoc):
 
         return Div(
             Code(str(Inlines0(items))).html,
-            Attr(classes=["doc-signature", f"doc-{_KIND_SLUG}"]),
+            Attr(classes=["doc-signature", f"doc-{self.kind_slug}"]),
         )
 
     def render_description(self) -> BlockContent:

--- a/great_docs/_apiref/_render/doctypealias.py
+++ b/great_docs/_apiref/_render/doctypealias.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from great_docs.pandoc.blocks import Blocks, Div
+from great_docs.pandoc.components import Attr
+from great_docs.pandoc.inlines import Code, Inlines0, Span
+
+from ._type_parameters import render_type_parameters
+from .doc import RenderDoc
+
+if TYPE_CHECKING:
+    import griffe as gf
+
+    from great_docs.pandoc.blocks import BlockContent
+    from great_docs.pandoc.inlines import InlineContentItem
+
+    from .. import content
+
+# `obj.kind.value` is "type alias", with a space; used bare it would split into
+# two CSS classes, the second colliding with the `alias` kind.
+_KIND_SLUG = "type-alias"
+
+
+@dataclass
+class __RenderDocTypeAlias(RenderDoc):
+    """
+    Render documentation for a PEP 695 type alias (`content.DocTypeAlias`)
+    """
+
+    def __post_init__(self):
+        super().__post_init__()
+        # We narrow the type with a TypeAlias since we do not expect
+        # any subclasses to have narrower types
+        self.doc: content.DocTypeAlias = self.doc
+        self.obj: gf.TypeAlias = self.obj
+
+        self.subject_above_signature = self.subject_above_signature is None and not self.contained
+
+    def render_signature(self) -> BlockContent:
+        """
+        Render the alias in its source form, e.g. `type Pair[T] = tuple[T, T]`
+        """
+        name = self.signature_name if self.show_signature_name else ""
+        declared = f"{name}{render_type_parameters(self.obj.type_parameters)}"
+
+        items: list[InlineContentItem] = [
+            Span("type", Attr(classes=[f"doc-{_KIND_SLUG}-keyword", "kw"])),
+            " ",
+            Span(declared, Attr(classes=["doc-parameter-name"])),
+            " ",
+            Span("=", Attr(classes=["doc-parameter-default-sep", "op"])),
+            " ",
+            Span(str(self.obj.value), Attr(classes=["doc-parameter-default"])),
+        ]
+
+        return Div(
+            Code(str(Inlines0(items))).html,
+            Attr(classes=["doc-signature", f"doc-{_KIND_SLUG}"]),
+        )
+
+    def render_description(self) -> BlockContent:
+        """
+        Render description for type aliases: subject above signature, no Usage label
+        """
+        return Blocks(
+            [
+                self.render_docstring_subject(),
+                self.render_signature() if self.show_signature else None,
+            ]
+        )
+
+
+class RenderDocTypeAlias(__RenderDocTypeAlias):
+    """
+    Extension point for the rendering of a `content.DocTypeAlias` object
+    """

--- a/great_docs/_apiref/_render/extending.py
+++ b/great_docs/_apiref/_render/extending.py
@@ -292,3 +292,43 @@ def exclude_classes(spec: dict[str, str | Sequence[str]]):
     from .._globals import EXCLUSIONS
 
     EXCLUSIONS.classes.update(spec)
+
+
+def exclude_type_aliases(spec: dict[str, str | Sequence[str]]):
+    """
+    Exclude the type aliases in a class or module from the documentation
+
+    When a class or module has deprecated type aliases, we may want to
+    exclude them from the documentation. Use this function in your
+    `_renderer.py` file to specify them.
+
+    Parameters
+    ----------
+    spec :
+        Parent object path and the type alias(es) to exclude.
+        The object path is as shown on the API page and _not_ the
+        canonical path. e.g.
+
+    Examples
+    --------
+    Assuming we are documenting the module `package` with the deprecated
+    type alias marked as shown below.
+
+    ```python
+    type Contract = int | str  # deprecated
+    type Payload = bytes
+    ```
+
+    We would use this to exclude the type alias from the documentation.
+
+    ```python
+    from great_docs.renderer import exclude_type_aliases
+
+    exclude_type_aliases({
+        "package": "Contract",
+    })
+    ```
+    """
+    from .._globals import EXCLUSIONS
+
+    EXCLUSIONS.type_aliases.update(spec)

--- a/great_docs/_apiref/_render/mixin_members.py
+++ b/great_docs/_apiref/_render/mixin_members.py
@@ -12,7 +12,13 @@ from great_docs.pandoc.blocks import (
 )
 from great_docs.pandoc.components import Attr
 
-from .._type_checks import griffe_to_doc, is_doc_attribute, is_doc_class, is_doc_function
+from .._type_checks import (
+    griffe_to_doc,
+    is_doc_attribute,
+    is_doc_class,
+    is_doc_function,
+    is_doc_type_alias,
+)
 from ..content import Doc, DocClass, MemberPage
 from .doc import RenderDoc
 from .html_table import html_table
@@ -22,7 +28,7 @@ if TYPE_CHECKING:
 
     import griffe as gf
 
-    from ..content import DocAttribute, DocFunction, DocModule
+    from ..content import DocAttribute, DocFunction, DocModule, DocTypeAlias
 
 
 @dataclass
@@ -57,18 +63,21 @@ class __RenderDocMembersMixin(RenderDoc):
     show_attributes: bool = True
     show_classes: bool = True
     show_functions: bool = True
+    show_type_aliases: bool = True
 
     show_members_summary: bool = True
     """All member (attribute, class and function) summaries"""
     show_attributes_summary: bool = True
     show_classes_summary: bool = True
     show_functions_summary: bool = True
+    show_type_aliases_summary: bool = True
 
     show_members_body: bool = True
     """All member (attribute, class and function) bodies"""
     show_attributes_body: bool = True
     show_classes_body: bool = True
     show_functions_body: bool = True
+    show_type_aliases_body: bool = True
 
     def __post_init__(self):
         super().__post_init__()
@@ -100,11 +109,13 @@ class __RenderDocMembersMixin(RenderDoc):
         """
         Render the docs of member objects
 
-        The member objects are attributes, classes and functions/methods
+        The member objects are type aliases, attributes, classes and
+        functions/methods
         """
         if not self.show_members:
             return []
         return [
+            self.render_type_aliases(),
             self.render_attributes(),
             self.render_classes(),
             self.render_functions(),
@@ -114,11 +125,13 @@ class __RenderDocMembersMixin(RenderDoc):
         """
         Render the docs of member objects
 
-        The member objects are attributes, classes and functions/methods
+        The member objects are type aliases, attributes, classes and
+        functions/methods
         """
         if not self.show_members:
             return []
         return [
+            self.render_type_alias_member_pages(),
             self.render_attribute_member_pages(),
             self.render_class_member_pages(),
             self.render_function_member_pages(),
@@ -188,6 +201,20 @@ class __RenderDocMembersMixin(RenderDoc):
         return [x for x in self.doc.members if is_doc_function(x) and x.name not in exclude]
 
     @cached_property
+    def type_aliases(self) -> list[DocTypeAlias]:
+        """
+        Members that are PEP 695 type aliases
+        """
+        from .._globals import EXCLUSIONS
+
+        exclude = EXCLUSIONS.type_aliases.get(self.obj.path, ())
+        if isinstance(exclude, str):
+            exclude = (exclude,)
+        exclude = set(exclude)
+
+        return [x for x in self.doc.members if is_doc_type_alias(x) and x.name not in exclude]
+
+    @cached_property
     def attribute_member_pages(self) -> list[MemberPage]:
         """
         Member pages of attributes
@@ -247,6 +274,25 @@ class __RenderDocMembersMixin(RenderDoc):
         pages = cast("list[MemberPage]", self.doc.members)
         return [p for p in pages if has_function(p) and p.obj.name not in exclude]
 
+    @cached_property
+    def type_alias_member_pages(self) -> list[MemberPage]:
+        """
+        Member pages of type aliases
+        """
+        from .._globals import EXCLUSIONS
+
+        exclude = EXCLUSIONS.type_aliases.get(self.obj.path, ())
+        if isinstance(exclude, str):
+            exclude = (exclude,)
+        exclude = set(exclude)
+
+        def has_type_alias(p: MemberPage) -> bool:
+            obj = p.obj
+            return cast("gf.Object", obj).is_type_alias
+
+        pages = cast("list[MemberPage]", self.doc.members)
+        return [p for p in pages if has_type_alias(p) and p.obj.name not in exclude]
+
     def render_classes(self) -> RenderedMembersGroup | None:
         """
         Render the class members of the Doc
@@ -264,6 +310,12 @@ class __RenderDocMembersMixin(RenderDoc):
         Render the attribute members of the Doc
         """
         return self._render_members_group("attributes") if self.show_attributes else None
+
+    def render_type_aliases(self) -> RenderedMembersGroup | None:
+        """
+        Render the type alias members of the Doc
+        """
+        return self._render_members_group("type-aliases") if self.show_type_aliases else None
 
     def render_class_member_pages(self) -> RenderedMemberPagesGroup | None:
         """
@@ -283,12 +335,18 @@ class __RenderDocMembersMixin(RenderDoc):
         """
         return self._render_member_pages_group("attributes") if self.show_attributes else None
 
+    def render_type_alias_member_pages(self) -> RenderedMemberPagesGroup | None:
+        """
+        Render the member pages of type aliases
+        """
+        return self._render_member_pages_group("type-aliases") if self.show_type_aliases else None
+
     def _render_members_group(
         self,
-        group: Literal["classes", "functions", "attributes"],
+        group: Literal["type-aliases", "classes", "functions", "attributes"],
     ) -> RenderedMembersGroup | None:
         """
-        Render all of class, function or attribute members
+        Render all of type alias, class, function or attribute members
 
         Parameters
         ----------
@@ -298,11 +356,15 @@ class __RenderDocMembersMixin(RenderDoc):
         member_group
             An identifier for the type of the members.
         """
-        from . import RenderDocAttribute, RenderDocClass, RenderDocFunction
+        from . import RenderDocAttribute, RenderDocClass, RenderDocFunction, RenderDocTypeAlias
 
         slug = group
 
-        if group == "classes":
+        if group == "type-aliases":
+            docables, Render = self.type_aliases, RenderDocTypeAlias
+            show_summary = self.show_type_aliases_summary
+            show_body = self.show_type_aliases_body
+        elif group == "classes":
             docables, Render = self.classes, RenderDocClass
             show_summary = self.show_classes_summary
             show_body = self.show_classes_body
@@ -322,7 +384,7 @@ class __RenderDocMembersMixin(RenderDoc):
 
         title = Header(
             self.level + 1,
-            slug.title(),
+            slug.replace("-", " ").title(),
             Attr(classes=[f"doc-{slug}"]),
         )
 
@@ -339,10 +401,10 @@ class __RenderDocMembersMixin(RenderDoc):
 
     def _render_member_pages_group(
         self,
-        group: Literal["classes", "functions", "attributes"],
+        group: Literal["type-aliases", "classes", "functions", "attributes"],
     ) -> RenderedMemberPagesGroup | None:
         """
-        Render all of the class, function or attribute member pages
+        Render all of the type alias, class, function or attribute member pages
 
         Parameters
         ----------
@@ -352,11 +414,14 @@ class __RenderDocMembersMixin(RenderDoc):
         member_group
             An identifier for the type of the members.
         """
-        from . import RenderDocAttribute, RenderDocClass, RenderDocFunction
+        from . import RenderDocAttribute, RenderDocClass, RenderDocFunction, RenderDocTypeAlias
 
         slug = group
 
-        if group == "classes":
+        if group == "type-aliases":
+            pages, Render = self.type_alias_member_pages, RenderDocTypeAlias
+            show_summary = self.show_type_aliases_summary
+        elif group == "classes":
             pages, Render = self.class_member_pages, RenderDocClass
             show_summary = self.show_classes_summary
         elif group == "attributes":
@@ -373,7 +438,7 @@ class __RenderDocMembersMixin(RenderDoc):
 
         title = Header(
             self.level + 1,
-            slug.title(),
+            slug.replace("-", " ").title(),
             Attr(classes=[f"doc-{slug}", "doc-pages"]),
         )
 

--- a/great_docs/_apiref/_render/mixin_members.py
+++ b/great_docs/_apiref/_render/mixin_members.py
@@ -59,21 +59,21 @@ class __RenderDocMembersMixin(RenderDoc):
     """
 
     show_members: bool = True
-    """All members (attributes, classes and functions) """
+    """All members (type aliases, attributes, classes and functions) """
     show_attributes: bool = True
     show_classes: bool = True
     show_functions: bool = True
     show_type_aliases: bool = True
 
     show_members_summary: bool = True
-    """All member (attribute, class and function) summaries"""
+    """All member (type alias, attribute, class and function) summaries"""
     show_attributes_summary: bool = True
     show_classes_summary: bool = True
     show_functions_summary: bool = True
     show_type_aliases_summary: bool = True
 
     show_members_body: bool = True
-    """All member (attribute, class and function) bodies"""
+    """All member (type alias, attribute, class and function) bodies"""
     show_attributes_body: bool = True
     show_classes_body: bool = True
     show_functions_body: bool = True

--- a/great_docs/_apiref/_type_checks.py
+++ b/great_docs/_apiref/_type_checks.py
@@ -83,6 +83,11 @@ def is_doc_attribute(el: DocMemberType) -> TypeGuard[content.DocAttribute]:
     return el.obj.is_attribute
 
 
+def is_doc_type_alias(el: DocMemberType) -> TypeGuard[content.DocTypeAlias]:
+    """Whether the member documents a type alias"""
+    return el.obj.is_type_alias
+
+
 def griffe_to_doc(
     obj: gf.Object | gf.Alias,
     *,

--- a/great_docs/_apiref/content.py
+++ b/great_docs/_apiref/content.py
@@ -36,7 +36,7 @@ class Doc(Walkable):
         anchor: str | None = None,
         flat: bool = False,
         signature_name: str = "relative",
-    ) -> DocFunction | DocAttribute | DocClass | DocModule:
+    ) -> DocFunction | DocAttribute | DocTypeAlias | DocClass | DocModule:
         if members is None:
             members = []
 
@@ -54,6 +54,8 @@ class Doc(Walkable):
             return DocFunction(**kwargs)
         elif kind == "attribute":
             return DocAttribute(**kwargs)
+        elif kind == "type alias":
+            return DocTypeAlias(**kwargs)
         elif kind == "class":
             return DocClass(members=members, flat=flat, **kwargs)
         elif kind == "module":
@@ -74,8 +76,8 @@ class DocClass(Doc):
     """Documentation node for a Python class, including its member list"""
 
     kind: str = "class"
-    members: list[DocClass | DocFunction | DocAttribute] = field(
-        default_factory=list["DocClass | DocFunction | DocAttribute"]
+    members: list[DocClass | DocFunction | DocAttribute | DocTypeAlias] = field(
+        default_factory=list["DocClass | DocFunction | DocAttribute | DocTypeAlias"]
     )
     flat: bool = False
 
@@ -88,12 +90,19 @@ class DocAttribute(Doc):
 
 
 @dataclass
+class DocTypeAlias(Doc):
+    """Documentation node for a PEP 695 type alias"""
+
+    kind: str = "type alias"
+
+
+@dataclass
 class DocModule(Doc):
     """Documentation node for a Python module, including its member list"""
 
     kind: str = "module"
-    members: list[DocClass | DocFunction | DocAttribute | DocModule] = field(
-        default_factory=list["DocClass | DocFunction | DocAttribute | DocModule"]
+    members: list[DocClass | DocFunction | DocAttribute | DocTypeAlias | DocModule] = field(
+        default_factory=list["DocClass | DocFunction | DocAttribute | DocTypeAlias | DocModule"]
     )
     flat: bool = False
 
@@ -114,8 +123,8 @@ class Page(Walkable):
     path: str = ""
     summary: SummaryItem | None = None
     flatten: bool = False
-    contents: list[DocClass | DocFunction | DocAttribute | DocModule] = field(
-        default_factory=list[DocClass | DocFunction | DocAttribute | DocModule]
+    contents: list[DocClass | DocFunction | DocAttribute | DocTypeAlias | DocModule] = field(
+        default_factory=list[DocClass | DocFunction | DocAttribute | DocTypeAlias | DocModule]
     )
 
     @property

--- a/great_docs/_apiref/introspect.py
+++ b/great_docs/_apiref/introspect.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import enum
 import importlib
 import inspect
+import sys
 import warnings
 from dataclasses import dataclass
 from types import ModuleType
@@ -21,6 +22,11 @@ import griffe as gf
 
 if TYPE_CHECKING:
     from griffe import DocstringOptions
+
+if sys.version_info >= (3, 12):
+    from typing import TypeAliasType
+else:  # Python 3.11 has no PEP 695 runtime support
+    TypeAliasType = None
 
 # Parser defaults ==============================================================
 
@@ -264,6 +270,13 @@ def replace_docstring(obj: gf.Object | gf.Alias, runtime_obj: object = None) -> 
         runtime_obj = _locate_runtime_object(obj)
         if runtime_obj is None:
             return
+
+    # A PEP 695 alias inherits `__doc__` from the `TypeAliasType` class, so the
+    # runtime docstring is CPython's prose about the `type` statement rather
+    # than the author's. Keep griffe's statically-parsed docstring; when there
+    # is none the alias correctly shows no docstring rather than boilerplate.
+    if TypeAliasType is not None and isinstance(runtime_obj, TypeAliasType):
+        return
 
     if getattr(runtime_obj, "__doc__", None) is None:
         return

--- a/great_docs/_apiref/inventory.py
+++ b/great_docs/_apiref/inventory.py
@@ -57,12 +57,18 @@ def create_inventory(
     }
 
 
+# Sphinx roles have no spaces, so griffe's kind values cannot be used verbatim.
+# A PEP 695 alias maps to `py:type` (Sphinx 7.4+); every other kind already
+# matches its role name.
+_KIND_ROLES = {"type alias": "type"}
+
+
 def _create_inventory_item(item: InventoryItem, priority: str = "1") -> dict[str, Any]:
     """Build a single inventory entry as a dict"""
     return {
         "name": item.name,
         "domain": "py",
-        "role": item.obj.kind.value,
+        "role": _KIND_ROLES.get(item.obj.kind.value, item.obj.kind.value),
         "priority": priority,
         "uri": item.uri,
         "dispname": item.dispname or "-",

--- a/great_docs/_apiref/typing.py
+++ b/great_docs/_apiref/typing.py
@@ -19,6 +19,7 @@ from .content import (
     DocClass,
     DocFunction,
     DocModule,
+    DocTypeAlias,
     MemberPage,
     Page,
     Section,
@@ -49,7 +50,9 @@ DocstringDefinitionType: TypeAlias = (
     | gf.DocstringWarn
 )
 
-Documentable: TypeAlias = DocClass | DocFunction | DocAttribute | DocModule | Page | Section
+Documentable: TypeAlias = (
+    DocClass | DocFunction | DocAttribute | DocTypeAlias | DocModule | Page | Section
+)
 
 RenderObjType: TypeAlias = (
     RenderDoc

--- a/great_docs/_apiref/typing.py
+++ b/great_docs/_apiref/typing.py
@@ -67,6 +67,6 @@ RenderObjType: TypeAlias = (
 
 AnyDocstringSection: TypeAlias = gf.DocstringSection | DCDocstringSection
 
-DocType: TypeAlias = DocClass | DocFunction | DocAttribute | DocModule
+DocType: TypeAlias = DocClass | DocFunction | DocAttribute | DocTypeAlias | DocModule
 
 DocMemberType: TypeAlias = MemberPage | Doc

--- a/great_docs/_apiref/typing.py
+++ b/great_docs/_apiref/typing.py
@@ -11,6 +11,7 @@ from ._render.docattribute import RenderDocAttribute
 from ._render.docclass import RenderDocClass
 from ._render.docfunction import RenderDocFunction
 from ._render.docmodule import RenderDocModule
+from ._render.doctypealias import RenderDocTypeAlias
 from ._render.reference_page import RenderReferencePage
 from ._render.reference_section import RenderReferenceSection
 from .content import (
@@ -59,6 +60,7 @@ RenderObjType: TypeAlias = (
     | RenderDocClass
     | RenderDocFunction
     | RenderDocAttribute
+    | RenderDocTypeAlias
     | RenderDocModule
     | RenderReferencePage
     | RenderAPIPage

--- a/great_docs/_apiref/typing_information.py
+++ b/great_docs/_apiref/typing_information.py
@@ -60,7 +60,7 @@ class TypeSections(Block):
             _TypeCategory(
                 "Type Aliases",
                 self.typealiases_items,
-                {"show_signature_name": False, "show_signature_annotation": False},
+                {"show_signature_annotation": False},
             ),
         ]
 

--- a/great_docs/assets/great-docs.scss
+++ b/great_docs/assets/great-docs.scss
@@ -223,6 +223,7 @@ h2.doc-attributes,
 h2.doc-functions,
 h2.doc-methods,
 h2.doc-classes,
+h2.doc-type-aliases,
 h2.doc-group {
   font-size: 22px;
   border-bottom: none;

--- a/great_docs/assets/great-docs.scss
+++ b/great_docs/assets/great-docs.scss
@@ -726,7 +726,7 @@ dt a.doc-method-name::after {
   }
 
   // Attribute signature (uses <p><code> rather than div.sourceCode)
-  .doc-signature.doc-attribute {
+  .doc-signature:is(.doc-attribute, .doc-type-alias) {
     code {
       background-color: #2d3748 !important;
       color: #e2e8f0 !important;

--- a/test-packages/synthetic/catalog.py
+++ b/test-packages/synthetic/catalog.py
@@ -409,6 +409,7 @@ ALL_PACKAGES: list[str] = [
     "gdtest_code_include",  # 202
     # 203: Mixed root files and subdirectories with numeric prefix interleaving
     "gdtest_ug_mixed_subdir_order",  # 203
+    "gdtest_type_aliases",  # 204
 ]
 
 
@@ -460,6 +461,7 @@ DIMENSIONS: dict[str, dict[str, str]] = {
     "C22": {"axis": "objects", "label": "Decorator functions"},
     "C23": {"axis": "objects", "label": "Custom exceptions"},
     "C24": {"axis": "objects", "label": "Re-exported symbols"},
+    "C25": {"axis": "objects", "label": "PEP 695 type aliases"},
     "D1": {"axis": "docstrings", "label": "NumPy"},
     "D2": {"axis": "docstrings", "label": "Google"},
     "D3": {"axis": "docstrings", "label": "Sphinx"},
@@ -650,6 +652,15 @@ DIMENSIONS: dict[str, dict[str, str]] = {
 # exercises and why it matters. Displayed on the hub card and detail pages.
 
 PACKAGE_DESCRIPTIONS: dict[str, str] = {
+    "gdtest_type_aliases": (
+        "A package whose public API is mostly PEP 695 `type X = ...` aliases: "
+        "generic, bounded, constrained, variadic, ParamSpec, recursive, and a long "
+        "Literal. On the Reference page you should see a 'Type Aliases' section "
+        "listing them, each signature rendered in its source form with the `type` "
+        "keyword. The Ledger class declares an alias in its own body, which should "
+        "appear under its own 'Type Aliases' heading rather than being dropped. "
+        "Requires Python 3.12+."
+    ),
     "gdtest_minimal": (
         "The simplest possible package: two functions (greet, add) with NumPy "
         "docstrings in a flat layout. On the Reference page you should see a "

--- a/test-packages/synthetic/specs/gdtest_type_aliases.py
+++ b/test-packages/synthetic/specs/gdtest_type_aliases.py
@@ -1,0 +1,211 @@
+"""
+gdtest_type_aliases — PEP 695 `type` statement aliases.
+
+Dimensions: A1, B1, C25, D1, E6, F6, G1, H7
+Focus: every PEP 695 type alias form, a class-nested alias, and the pre-PEP 695
+       `X: TypeAlias = ...` spelling alongside them.
+
+Requires Python 3.12: `type X = ...` is a SyntaxError before it, so griffe
+cannot parse this package on 3.11. `min_python` keeps it out of the parametrized
+runs there.
+
+PEP 696 type parameter defaults (`type X[T = int]`) are deliberately absent —
+that is 3.13 syntax, and gating this package at 3.13 would cost the 3.12 job all
+the coverage above. The unit tests carry those cases with their own marker.
+"""
+
+SPEC = {
+    "name": "gdtest_type_aliases",
+    "description": "PEP 695 type aliases",
+    "dimensions": ["A1", "B1", "C25", "D1", "E6", "F6", "G1", "H7"],
+    "min_python": (3, 12),
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-type-aliases",
+            "version": "0.1.0",
+            "description": "A synthetic test package built from PEP 695 type aliases",
+            "requires-python": ">=3.12",
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    },
+    "files": {
+        "gdtest_type_aliases/__init__.py": '''\
+            """A test package whose public API is mostly PEP 695 type aliases."""
+
+            __version__ = "0.1.0"
+            __all__ = [
+                "Clause",
+                "ContractId",
+                "Jurisdiction",
+                "Key",
+                "Ledger",
+                "Named",
+                "Pair",
+                "Row",
+                "Signature",
+                "Validator",
+                "sign",
+                "summarize",
+            ]
+
+            from collections.abc import Callable
+            from typing import Literal, TypeAlias
+
+            type ContractId = str
+            """An opaque identifier for a single contract"""
+
+            type Pair[T] = tuple[T, T]
+            """Two values of the same type, e.g. a counterparty pair"""
+
+            type Named[T: str] = dict[T, ContractId]
+            """Contracts keyed by name, where the key type is bounded by `str`"""
+
+            type Key[K: (str, bytes)] = dict[K, ContractId]
+            """A lookup keyed by either `str` or `bytes`, but not a mix of the two
+
+            griffe stores constraints separately from bounds, leaving `bound` as
+            None, so this is the form that catches reading only `bound`.
+            """
+
+            type Row[T, *Ts] = tuple[T, *Ts]
+            """A heterogeneous ledger row: a leading column plus any number of others"""
+
+            type Validator[**P] = Callable[P, bool]
+            """Any predicate, however it is called"""
+
+            type Clause = str | list[Clause]
+            """A contract clause, possibly nested
+
+            Refers to itself. PEP 695 evaluates alias values lazily, so this
+            needs no quoting and nothing resolves it while rendering.
+            """
+
+            type Jurisdiction = Literal[
+                "us-ca", "us-ny", "us-tx", "gb-eng", "gb-sct", "de-by", "fr-idf", "jp-13"
+            ]
+            """A supported governing jurisdiction, as an ISO-ish region code"""
+
+            Signature: TypeAlias = Literal["ed25519", "rsa"]
+            """Which signing scheme produced a signature
+
+            The pre-PEP 695 spelling. It stays a plain attribute rather than a
+            TypeAlias object, but should carry the same label as its neighbours.
+            """
+
+
+            class Ledger:
+                """
+                An append-only record of contract state changes.
+
+                Declares a type alias in its own body, which belongs under a
+                "Type Aliases" heading of its own rather than being dropped.
+                """
+
+                type Entry = tuple[ContractId, Jurisdiction]
+                """A single ledger entry: which contract, and where it applies"""
+
+                max_entries: int = 1000
+                """How many entries the ledger retains before rotating"""
+
+                def __init__(self) -> None:
+                    self._entries: list[Entry] = []
+
+                def append(self, contract_id: ContractId, where: Jurisdiction) -> None:
+                    """
+                    Record that `contract_id` applies in `where`.
+
+                    Parameters
+                    ----------
+                    contract_id
+                        The contract being recorded.
+                    where
+                        The jurisdiction it applies in.
+                    """
+                    self._entries.append((contract_id, where))
+
+                def entries(self) -> list[Entry]:
+                    """
+                    Every recorded entry, oldest first.
+
+                    Returns
+                    -------
+                    list
+                        The entries in insertion order.
+                    """
+                    return list(self._entries)
+
+
+            def sign(contract_id: ContractId, scheme: Signature) -> bool:
+                """
+                Sign a contract with the named scheme.
+
+                Parameters
+                ----------
+                contract_id
+                    The contract to sign.
+                scheme
+                    Which signing scheme to use.
+
+                Returns
+                -------
+                bool
+                    True when the contract was signed.
+                """
+                return bool(contract_id and scheme)
+
+
+            def summarize(rows: Row[ContractId], where: Jurisdiction = "us-ca") -> Named[str]:
+                """
+                Group contracts by name for one jurisdiction.
+
+                Parameters
+                ----------
+                rows
+                    The contracts to summarize.
+                where
+                    Which jurisdiction's rules to apply.
+
+                Returns
+                -------
+                dict
+                    Each contract name mapped to its identifier.
+                """
+                return {str(row): str(row) for row in rows}
+        ''',
+        "README.md": """\
+            # gdtest-type-aliases
+
+            A synthetic test package whose public API is mostly PEP 695 type aliases.
+        """,
+    },
+    "expected": {
+        "detected_name": "gdtest-type-aliases",
+        "detected_module": "gdtest_type_aliases",
+        "detected_parser": "numpy",
+        "export_names": [
+            "Clause",
+            "ContractId",
+            "Jurisdiction",
+            "Key",
+            "Ledger",
+            "Named",
+            "Pair",
+            "Row",
+            "Signature",
+            "Validator",
+            "sign",
+            "summarize",
+        ],
+        "num_exports": 12,
+        # Measured, not predicted. Note the legacy `Signature` lands in
+        # Constants while the eight PEP 695 aliases land in Type Aliases:
+        # the scan path categorises by griffe kind, and the pre-695 spelling
+        # is still an attribute.
+        "section_titles": ["Classes", "Functions", "Constants", "Type Aliases"],
+        "has_user_guide": False,
+        "coverage_exclude": ["nodoc", "bigcl", "ug", "supp", "hdg"],
+    },
+}

--- a/tests/renderer/test_type_alias_introspection.py
+++ b/tests/renderer/test_type_alias_introspection.py
@@ -235,3 +235,66 @@ def test_legacy_spelling_docstring_overwritten(monkeypatch, tmp_path):
 
     assert obj.docstring is not None
     assert obj.docstring.value == "Legacy docstring."
+
+
+@requires_pep695
+def test_facade_reexport_resolves_without_cyclic_alias(monkeypatch, tmp_path):
+    """A facade re-exported alias resolves and keeps its own docstring"""
+    from great_docs._apiref.introspect import get_object
+
+    root = _write_package(
+        tmp_path,
+        "gdta_facade",
+        {
+            "__init__.py": '''
+                """Facade."""
+                from ._impl import Contract
+
+                __all__ = ["Contract"]
+            ''',
+            "_impl.py": '''
+                """Impl."""
+                type Contract = int | str
+                """Real docstring."""
+            ''',
+        },
+    )
+    _install(monkeypatch, root)
+
+    obj = get_object("gdta_facade:Contract", dynamic=True)
+
+    assert obj.kind.value == "type alias"
+    assert obj.docstring is not None
+    assert obj.docstring.value == "Real docstring."
+
+
+@requires_pep695
+def test_plain_alias_still_resolves_dynamically(monkeypatch, tmp_path):
+    """The plain, non-re-exported case keeps working"""
+    from great_docs._apiref.introspect import get_object
+
+    root = _write_package(
+        tmp_path,
+        "gdta_plain",
+        {
+            "__init__.py": '''
+                """Package."""
+                type Contract = int | str
+                """Plain docstring."""
+            '''
+        },
+    )
+    _install(monkeypatch, root)
+
+    obj = get_object("gdta_plain:Contract", dynamic=True)
+
+    assert obj.kind.value == "type alias"
+    assert obj.docstring is not None
+    assert obj.docstring.value == "Plain docstring."
+
+
+def test_non_alias_canonical_paths_unchanged():
+    from great_docs._apiref.introspect import _canonical_path
+
+    assert _canonical_path(len, "") == "builtins:len"
+    assert _canonical_path(42, "") is None

--- a/tests/renderer/test_type_alias_introspection.py
+++ b/tests/renderer/test_type_alias_introspection.py
@@ -1,4 +1,9 @@
-"""Tests for objects whose canonical path cannot be read off the runtime object."""
+"""
+Tests for the dynamic (introspection) load path
+
+Two subjects share these fixtures: objects whose canonical path cannot be read
+off the runtime object, and the docstrings of PEP 695 type aliases.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +13,15 @@ from pathlib import Path
 
 import griffe as gf
 import pytest
+
+# Applied per-test rather than module-wide: the canonical-path tests below carry
+# no PEP 695 syntax and must keep running on 3.11.
+requires_pep695 = pytest.mark.skipif(
+    sys.version_info < (3, 12),
+    reason="PEP 695 `type` statement requires Python 3.12+",
+)
+
+BOILERPLATE = "Type aliases are created through the type statement"
 
 
 def _write_package(tmp_path: Path, name: str, files: dict[str, str]) -> Path:
@@ -139,3 +153,85 @@ def test_a_genuine_alias_cycle_still_raises(monkeypatch, tmp_path):
 
     with pytest.raises(gf.CyclicAliasError):
         _ = get_object("gdta_alias_cycle:x", dynamic=True).canonical_path
+
+
+@requires_pep695
+def test_documented_alias_keeps_the_author_docstring(monkeypatch, tmp_path):
+    from great_docs._apiref.introspect import get_object, replace_docstring
+
+    root = _write_package(
+        tmp_path,
+        "gdta_documented",
+        {
+            "__init__.py": '''
+                """Package."""
+                type Contract = int | str
+                """The author's own docstring."""
+            '''
+        },
+    )
+    _install(monkeypatch, root)
+
+    obj = get_object("gdta_documented:Contract")
+    replace_docstring(obj)
+
+    assert obj.docstring is not None
+    assert obj.docstring.value == "The author's own docstring."
+    assert BOILERPLATE not in obj.docstring.value
+
+
+@requires_pep695
+def test_undocumented_alias_gets_no_boilerplate(monkeypatch, tmp_path):
+    from great_docs._apiref.introspect import get_object, replace_docstring
+
+    root = _write_package(
+        tmp_path,
+        "gdta_undocumented",
+        {
+            "__init__.py": '''
+                """Package."""
+                type Contract = int | str
+            '''
+        },
+    )
+    _install(monkeypatch, root)
+
+    obj = get_object("gdta_undocumented:Contract")
+    replace_docstring(obj)
+
+    assert obj.docstring is None or BOILERPLATE not in obj.docstring.value
+
+
+@requires_pep695
+@pytest.mark.xfail(
+    reason=(
+        "Pre-existing bug unrelated to PEP 695: replace_docstring overwrites the "
+        "statically-parsed docstring of any attribute whose runtime value carries a "
+        "__doc__. Here `Contract: TypeAlias = int` picks up int.__doc__."
+    ),
+    strict=True,
+)
+def test_legacy_spelling_docstring_overwritten(monkeypatch, tmp_path):
+    """Pins the pre-existing overwrite bug for `X: TypeAlias = ...` until it is fixed"""
+    from great_docs._apiref.introspect import get_object, replace_docstring
+
+    root = _write_package(
+        tmp_path,
+        "gdta_legacy",
+        {
+            "__init__.py": '''
+                """Package."""
+                from typing import TypeAlias
+
+                Contract: TypeAlias = int
+                """Legacy docstring."""
+            '''
+        },
+    )
+    _install(monkeypatch, root)
+
+    obj = get_object("gdta_legacy:Contract")
+    replace_docstring(obj)
+
+    assert obj.docstring is not None
+    assert obj.docstring.value == "Legacy docstring."

--- a/tests/renderer/test_type_alias_introspection.py
+++ b/tests/renderer/test_type_alias_introspection.py
@@ -269,6 +269,45 @@ def test_facade_reexport_resolves_without_cyclic_alias(monkeypatch, tmp_path):
 
 
 @requires_pep695
+def test_class_nested_alias_is_not_shadowed_by_a_module_level_one(monkeypatch, tmp_path):
+    """A class-nested alias must resolve to itself, not to a same-named module-level alias
+
+    A `TypeAliasType` reports no `__qualname__`, so nothing about the runtime
+    object distinguishes the nested alias from the module-level one of the same
+    name. Only the enclosing-class walk does, which makes this the case that
+    catches a canonical path guessed from `__module__` + `__name__`.
+    """
+    from great_docs._apiref.introspect import get_object
+
+    root = _write_package(
+        tmp_path,
+        "gdta_shadow",
+        {
+            "__init__.py": '''
+                """Package."""
+                type Inner = str
+                """Module-level alias."""
+
+
+                class Holder:
+                    """A holder."""
+
+                    type Inner = int
+                    """Inner alias."""
+            '''
+        },
+    )
+    _install(monkeypatch, root)
+
+    obj = get_object("gdta_shadow:Holder.Inner", dynamic=True)
+
+    assert obj.canonical_path == "gdta_shadow.Holder.Inner"
+    assert str(obj.value) == "int"
+    assert obj.docstring is not None
+    assert obj.docstring.value == "Inner alias."
+
+
+@requires_pep695
 def test_plain_alias_still_resolves_dynamically(monkeypatch, tmp_path):
     """The plain, non-re-exported case keeps working"""
     from great_docs._apiref.introspect import get_object

--- a/tests/renderer/test_type_aliases.py
+++ b/tests/renderer/test_type_aliases.py
@@ -115,7 +115,7 @@ def test_reported_crash_no_longer_raises():
             "Contract",
             "[type]{.doc-type-alias-keyword .kw} [Contract]{.doc-parameter-name}"
             " [=]{.doc-parameter-default-sep .op}"
-            " [Literal['a', 'b']]{.doc-parameter-default}",
+            " [Literal[[&quot;a&quot;]{.st}, [&quot;b&quot;]{.st}]]{.doc-parameter-default}",
         ),
         (
             "type ListOrSet[T] = list[T] | set[T]\n",
@@ -173,7 +173,8 @@ def test_css_class_slug_is_hyphenated():
     assert "doc-type alias" not in qmd
 
 
-def test_label_class_reaches_existing_scss():
+def test_label_class_is_emitted():
+    """The label class matches the existing `.doc-label-typealias` scss rule."""
     qmd = _render_alias("type Contract = int | str\n", "Contract")
     assert "doc-label-typealias" in qmd
 
@@ -186,10 +187,31 @@ def test_docstring_is_rendered():
 def test_recursive_alias_renders():
     """Lazy evaluation means the value is never resolved, so this must not raise."""
     qmd = _render_alias("type Recursive = Recursive | None\n", "Recursive")
-    assert "Recursive" in qmd
+    assert "[Recursive | None]{.doc-parameter-default}" in qmd
 
 
 def test_forward_reference_alias_renders():
     """The static `.value` expression is unresolved, so an undefined name is fine."""
     qmd = _render_alias("type Broken = NotDefinedAnywhere\n", "Broken")
     assert "NotDefinedAnywhere" in qmd
+
+
+def test_valueless_alias_omits_default_clause():
+    """A `TypeAlias` with no `.value` must not render the literal string 'None'.
+
+    `type X = ...` always has a value when parsed from source, so this state
+    is constructed directly rather than via `_render_alias`.
+    """
+    import griffe as gf
+
+    from great_docs._apiref._render import get_render_type
+    from great_docs._apiref.content import Doc
+
+    obj = gf.TypeAlias(name="Empty", lineno=1)
+    assert obj.value is None
+
+    doc = Doc.from_griffe("Empty", obj)
+    qmd = str(get_render_type(doc)(doc, 1))
+
+    assert "None" not in qmd
+    assert "doc-parameter-default-sep" not in qmd

--- a/tests/renderer/test_type_aliases.py
+++ b/tests/renderer/test_type_aliases.py
@@ -10,6 +10,10 @@ pytestmark = pytest.mark.skipif(
     sys.version_info < (3, 12),
     reason="PEP 695 `type` statement requires Python 3.12+",
 )
+requires_pep696 = pytest.mark.skipif(
+    sys.version_info < (3, 13),
+    reason="PEP 696 type parameter defaults require Python 3.13+",
+)
 
 
 def _load_type_parameters(code: str, name: str):
@@ -29,7 +33,12 @@ def _load_type_parameters(code: str, name: str):
         ("type Constrained[S: (str, bytes)] = list[S]", "Constrained", "[S: (str, bytes)]"),
         ("type Variadic[T, *Ts] = tuple[T, *Ts]", "Variadic", "[T, *Ts]"),
         ("type Callback[**P] = dict[P, int]", "Callback", "[**P]"),
-        ("type WithDefault[T = int] = list[T]", "WithDefault", "[T = int]"),
+        pytest.param(
+            "type WithDefault[T = int] = list[T]",
+            "WithDefault",
+            "[T = int]",
+            marks=requires_pep696,
+        ),
     ],
 )
 def test_render_type_parameters(source: str, name: str, expected: str):
@@ -153,12 +162,13 @@ def test_reported_crash_no_longer_raises():
             " [=]{.doc-parameter-default-sep .op}"
             " [tuple[T, *Ts]]{.doc-parameter-default}",
         ),
-        (
+        pytest.param(
             "type WithDefault[T = int] = list[T]\n",
             "WithDefault",
             "[type]{.doc-type-alias-keyword .kw} [WithDefault[T = int]]{.doc-parameter-name}"
             " [=]{.doc-parameter-default-sep .op}"
             " [list[T]]{.doc-parameter-default}",
+            marks=requires_pep696,
         ),
     ],
 )

--- a/tests/renderer/test_type_aliases.py
+++ b/tests/renderer/test_type_aliases.py
@@ -329,6 +329,42 @@ def test_inventory_roles_never_contain_spaces():
         assert " " not in entry["role"]
 
 
+def test_api_reference_builds_with_a_type_alias(monkeypatch, tmp_path):
+    """The full issue #288 path: APIReference.build() over a package with an alias
+
+    `APIReference.build` writes to disk and returns `None` rather than handing
+    back pages, so the build is proven by the files it writes and by the
+    `type alias` kind showing up among the collected `items` — not by a
+    return value.
+    """
+    from great_docs._apiref.api_reference import APIReference
+
+    pkg = tmp_path / "gdta_build"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text(
+        "from typing import Literal\n\n"
+        'type Contract = Literal["a", "b"]\n'
+        '"""A contract kind."""\n\n\n'
+        "def f(c: Contract) -> None:\n"
+        '    """Do a thing."""\n'
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    ref = APIReference(
+        {
+            "package": "gdta_build",
+            "sections": [{"title": "All", "desc": "d", "contents": ["Contract", "f"]}],
+        }
+    )
+    ref.build()
+
+    assert (tmp_path / "reference" / "index.qmd").exists()
+    assert (tmp_path / "reference" / "Contract.qmd").exists()
+    kinds = {item.obj.kind.value for item in ref.items}
+    assert "type alias" in kinds
+
+
 def test_inventory_roles_unchanged_for_other_kinds():
     from great_docs._apiref.inventory import InventoryItem, _create_inventory_item
 

--- a/tests/renderer/test_type_aliases.py
+++ b/tests/renderer/test_type_aliases.py
@@ -176,6 +176,28 @@ def test_signature_rendering(source: str, name: str, expected: str):
     assert expected in _render_alias(source, name)
 
 
+def test_type_information_preserves_alias_name():
+    from unittest.mock import MagicMock, patch
+
+    import griffe as gf
+
+    from great_docs._apiref.typing_information import TypeInformation
+
+    api_ref = MagicMock()
+    api_ref.package = "package"
+    api_ref.settings.dir = "reference"
+
+    with (
+        gf.temporary_visited_package(
+            "package", {"__init__.py": "type Contract[T] = list[T]\n"}
+        ) as module,
+        patch("great_docs._apiref.typing_information.get_object", return_value=module),
+    ):
+        rendered = str(TypeInformation("package", api_ref))
+
+    assert "[Contract[T]]{.doc-parameter-name}" in rendered
+
+
 def test_css_class_slug_is_hyphenated():
     """A space in the class attribute would silently become two classes."""
     qmd = _render_alias("type Contract = int | str\n", "Contract")

--- a/tests/renderer/test_type_aliases.py
+++ b/tests/renderer/test_type_aliases.py
@@ -90,6 +90,14 @@ def test_label_plain_constant_still_works():
     assert get_label(_load_member("MAX: int = 3\n", "MAX")) == "constant"
 
 
+@pytest.mark.parametrize("annotation", ["TypeAliasRegistry", "MyTypeAlias"])
+def test_label_similarly_named_annotation_is_constant(annotation: str):
+    from great_docs._apiref._render._label import get_label
+
+    source = f"class {annotation}: pass\nvalue: {annotation}\n"
+    assert get_label(_load_member(source, "value")) == "constant"
+
+
 def test_from_griffe_builds_a_type_alias_node():
     from great_docs._apiref.content import Doc, DocTypeAlias
 

--- a/tests/renderer/test_type_aliases.py
+++ b/tests/renderer/test_type_aliases.py
@@ -67,11 +67,12 @@ def test_label_legacy_spelling():
     assert get_label(obj) == "typealias"
 
 
-def test_label_typevar_still_works():
+def test_label_bare_typevar_is_constant():
+    """A bare `T = TypeVar("T")` has no annotation, so it labels as a constant"""
     from great_docs._apiref._render._label import get_label
 
     code = 'from typing import TypeVar\nT = TypeVar("T")\n'
-    assert get_label(_load_member(code, "T")) == "typevar"
+    assert get_label(_load_member(code, "T")) == "constant"
 
 
 def test_label_plain_constant_still_works():

--- a/tests/renderer/test_type_aliases.py
+++ b/tests/renderer/test_type_aliases.py
@@ -215,3 +215,96 @@ def test_valueless_alias_omits_default_clause():
 
     assert "None" not in qmd
     assert "doc-parameter-default-sep" not in qmd
+
+
+def test_type_alias_group_renders_in_a_class():
+    """A type alias declared in a class must not be silently dropped"""
+    import textwrap
+
+    from great_docs._apiref._tools import render_code_variable
+
+    source = textwrap.dedent('''
+        class Holder:
+            """A holder."""
+
+            type Inner = int
+            """An inner alias."""
+
+            size: int = 3
+            """The size."""
+    ''')
+    qmd = render_code_variable(source, "Holder")
+
+    assert "Inner" in qmd
+    assert "An inner alias." in qmd
+
+
+def test_type_alias_group_has_its_own_heading():
+    import textwrap
+
+    from great_docs._apiref._tools import render_code_variable
+
+    source = textwrap.dedent('''
+        class Holder:
+            """A holder."""
+
+            type Inner = int
+            """An inner alias."""
+    ''')
+    qmd = render_code_variable(source, "Holder")
+
+    assert "Type Aliases" in qmd
+    assert "doc-type-aliases" in qmd
+
+
+def test_type_alias_group_precedes_attributes():
+    import textwrap
+
+    from great_docs._apiref._tools import render_code_variable
+
+    source = textwrap.dedent('''
+        class Holder:
+            """A holder."""
+
+            type Inner = int
+            """An inner alias."""
+
+            size: int = 3
+            """The size."""
+    ''')
+    qmd = render_code_variable(source, "Holder")
+
+    assert qmd.index("Type Aliases") < qmd.index("Attributes")
+
+
+def test_existing_group_headings_unchanged():
+    """The shared title expression must not alter the other groups' headings"""
+    import textwrap
+
+    from great_docs._apiref._tools import render_code_variable
+
+    source = textwrap.dedent('''
+        class Holder:
+            """A holder."""
+
+            size: int = 3
+            """The size."""
+
+            def go(self) -> None:
+                """Go."""
+    ''')
+    qmd = render_code_variable(source, "Holder")
+
+    assert "Attributes" in qmd
+    assert "Methods" in qmd
+    assert "Type Aliases" not in qmd
+
+
+def test_module_level_type_alias_group():
+    from great_docs._apiref._tools import render_code_variable
+
+    source = 'type Contract = int | str\n"""A contract."""\n'
+    qmd = render_code_variable(source, None)
+
+    assert "Type Aliases" in qmd
+    assert "Contract" in qmd

--- a/tests/renderer/test_type_aliases.py
+++ b/tests/renderer/test_type_aliases.py
@@ -42,3 +42,39 @@ def test_render_type_parameters_none():
     from great_docs._apiref._render._type_parameters import render_type_parameters
 
     assert render_type_parameters(None) == ""
+
+
+def _load_member(code: str, name: str):
+    """Load a single named member from a source snippet"""
+    import griffe as gf
+
+    with gf.temporary_visited_package("package", {"__init__.py": code}) as m:
+        return m[name]
+
+
+def test_label_pep695_spelling():
+    from great_docs._apiref._render._label import get_label
+
+    obj = _load_member('type Contract = int | str', "Contract")
+    assert get_label(obj) == "typealias"
+
+
+def test_label_legacy_spelling():
+    from great_docs._apiref._render._label import get_label
+
+    code = "from typing import TypeAlias\nContract: TypeAlias = int | str\n"
+    obj = _load_member(code, "Contract")
+    assert get_label(obj) == "typealias"
+
+
+def test_label_typevar_still_works():
+    from great_docs._apiref._render._label import get_label
+
+    code = 'from typing import TypeVar\nT = TypeVar("T")\n'
+    assert get_label(_load_member(code, "T")) == "typevar"
+
+
+def test_label_plain_constant_still_works():
+    from great_docs._apiref._render._label import get_label
+
+    assert get_label(_load_member("MAX: int = 3\n", "MAX")) == "constant"

--- a/tests/renderer/test_type_aliases.py
+++ b/tests/renderer/test_type_aliases.py
@@ -1,0 +1,44 @@
+"""Tests for PEP 695 type alias support (`type X = ...`)."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 12),
+    reason="PEP 695 `type` statement requires Python 3.12+",
+)
+
+
+def _load_type_parameters(code: str, name: str):
+    """Load the type parameters of the named alias from a source snippet"""
+    import griffe as gf
+
+    with gf.temporary_visited_package("package", {"__init__.py": code}) as m:
+        return m[name].type_parameters
+
+
+@pytest.mark.parametrize(
+    ("source", "name", "expected"),
+    [
+        ("type Simple = int | str", "Simple", ""),
+        ("type ListOrSet[T] = list[T] | set[T]", "ListOrSet", "[T]"),
+        ("type Bounded[T: str] = list[T]", "Bounded", "[T: str]"),
+        ("type Constrained[S: (str, bytes)] = list[S]", "Constrained", "[S: (str, bytes)]"),
+        ("type Variadic[T, *Ts] = tuple[T, *Ts]", "Variadic", "[T, *Ts]"),
+        ("type Callback[**P] = dict[P, int]", "Callback", "[**P]"),
+        ("type WithDefault[T = int] = list[T]", "WithDefault", "[T = int]"),
+    ],
+)
+def test_render_type_parameters(source: str, name: str, expected: str):
+    from great_docs._apiref._render._type_parameters import render_type_parameters
+
+    assert render_type_parameters(_load_type_parameters(source, name)) == expected
+
+
+def test_render_type_parameters_none():
+    from great_docs._apiref._render._type_parameters import render_type_parameters
+
+    assert render_type_parameters(None) == ""

--- a/tests/renderer/test_type_aliases.py
+++ b/tests/renderer/test_type_aliases.py
@@ -91,3 +91,105 @@ def test_from_griffe_builds_a_type_alias_node():
     assert doc.kind == "type alias"
     assert doc.name == "Contract"
     assert doc.anchor == "package.Contract"
+
+
+def _render_alias(source: str, name: str) -> str:
+    """Render the named alias from a source snippet to qmd"""
+    from great_docs._apiref._tools import render_code_variable
+
+    return render_code_variable(source, name)
+
+
+def test_reported_crash_no_longer_raises():
+    """The reproducer from issue #288."""
+    source = 'from typing import Literal\n\ntype Contract = Literal["a", "b"]\n'
+    qmd = _render_alias(source, "Contract")
+    assert "Contract" in qmd
+
+
+@pytest.mark.parametrize(
+    ("source", "name", "expected"),
+    [
+        (
+            'from typing import Literal\ntype Contract = Literal["a", "b"]\n',
+            "Contract",
+            "[type]{.doc-type-alias-keyword .kw} [Contract]{.doc-parameter-name}"
+            " [=]{.doc-parameter-default-sep .op}"
+            " [Literal['a', 'b']]{.doc-parameter-default}",
+        ),
+        (
+            "type ListOrSet[T] = list[T] | set[T]\n",
+            "ListOrSet",
+            "[type]{.doc-type-alias-keyword .kw} [ListOrSet[T]]{.doc-parameter-name}"
+            " [=]{.doc-parameter-default-sep .op}"
+            " [list[T] | set[T]]{.doc-parameter-default}",
+        ),
+        (
+            "from typing import Callable\ntype Callback[**P] = Callable[P, int]\n",
+            "Callback",
+            "[type]{.doc-type-alias-keyword .kw} [Callback[**P]]{.doc-parameter-name}"
+            " [=]{.doc-parameter-default-sep .op}"
+            " [Callable[P, int]]{.doc-parameter-default}",
+        ),
+        (
+            "type Bounded[T: str] = list[T]\n",
+            "Bounded",
+            "[type]{.doc-type-alias-keyword .kw} [Bounded[T: str]]{.doc-parameter-name}"
+            " [=]{.doc-parameter-default-sep .op}"
+            " [list[T]]{.doc-parameter-default}",
+        ),
+        (
+            "type Constrained[S: (str, bytes)] = list[S]\n",
+            "Constrained",
+            "[type]{.doc-type-alias-keyword .kw}"
+            " [Constrained[S: (str, bytes)]]{.doc-parameter-name}"
+            " [=]{.doc-parameter-default-sep .op}"
+            " [list[S]]{.doc-parameter-default}",
+        ),
+        (
+            "type Variadic[T, *Ts] = tuple[T, *Ts]\n",
+            "Variadic",
+            "[type]{.doc-type-alias-keyword .kw} [Variadic[T, *Ts]]{.doc-parameter-name}"
+            " [=]{.doc-parameter-default-sep .op}"
+            " [tuple[T, *Ts]]{.doc-parameter-default}",
+        ),
+        (
+            "type WithDefault[T = int] = list[T]\n",
+            "WithDefault",
+            "[type]{.doc-type-alias-keyword .kw} [WithDefault[T = int]]{.doc-parameter-name}"
+            " [=]{.doc-parameter-default-sep .op}"
+            " [list[T]]{.doc-parameter-default}",
+        ),
+    ],
+)
+def test_signature_rendering(source: str, name: str, expected: str):
+    assert expected in _render_alias(source, name)
+
+
+def test_css_class_slug_is_hyphenated():
+    """A space in the class attribute would silently become two classes."""
+    qmd = _render_alias("type Contract = int | str\n", "Contract")
+    assert "doc-type-alias" in qmd
+    assert "doc-type alias" not in qmd
+
+
+def test_label_class_reaches_existing_scss():
+    qmd = _render_alias("type Contract = int | str\n", "Contract")
+    assert "doc-label-typealias" in qmd
+
+
+def test_docstring_is_rendered():
+    source = 'type Contract = int | str\n"""A contract kind."""\n'
+    assert "A contract kind." in _render_alias(source, "Contract")
+
+
+def test_recursive_alias_renders():
+    """Lazy evaluation means the value is never resolved, so this must not raise."""
+    qmd = _render_alias("type Recursive = Recursive | None\n", "Recursive")
+    assert "Recursive" in qmd
+
+
+def test_forward_reference_alias_renders():
+    """The static `.value` expression is unresolved, so an undefined name is fine."""
+    qmd = _render_alias("type Broken = NotDefinedAnywhere\n", "Broken")
+    assert "NotDefinedAnywhere" in qmd

--- a/tests/renderer/test_type_aliases.py
+++ b/tests/renderer/test_type_aliases.py
@@ -308,3 +308,33 @@ def test_module_level_type_alias_group():
 
     assert "Type Aliases" in qmd
     assert "Contract" in qmd
+
+
+def test_inventory_role_for_type_alias():
+    from great_docs._apiref.inventory import InventoryItem, _create_inventory_item
+
+    obj = _load_member("type Contract = int | str\n", "Contract")
+    entry = _create_inventory_item(InventoryItem(obj=obj, name="package.Contract"))
+
+    assert entry["role"] == "type"
+
+
+def test_inventory_roles_never_contain_spaces():
+    from great_docs._apiref.inventory import InventoryItem, _create_inventory_item
+
+    code = "type Contract = int | str\ndef f(): ...\nclass C: ...\nMAX: int = 3\n"
+    for name in ("Contract", "f", "C", "MAX"):
+        obj = _load_member(code, name)
+        entry = _create_inventory_item(InventoryItem(obj=obj, name=name))
+        assert " " not in entry["role"]
+
+
+def test_inventory_roles_unchanged_for_other_kinds():
+    from great_docs._apiref.inventory import InventoryItem, _create_inventory_item
+
+    code = "def f(): ...\nclass C: ...\nMAX: int = 3\n"
+    expected = {"f": "function", "C": "class", "MAX": "attribute"}
+    for name, role in expected.items():
+        obj = _load_member(code, name)
+        entry = _create_inventory_item(InventoryItem(obj=obj, name=name))
+        assert entry["role"] == role

--- a/tests/renderer/test_type_aliases.py
+++ b/tests/renderer/test_type_aliases.py
@@ -360,7 +360,16 @@ def test_api_reference_builds_with_a_type_alias(monkeypatch, tmp_path):
     ref.build()
 
     assert (tmp_path / "reference" / "index.qmd").exists()
-    assert (tmp_path / "reference" / "Contract.qmd").exists()
+    contract_qmd = (tmp_path / "reference" / "Contract.qmd").read_text()
+    assert "A contract kind." in contract_qmd
+    assert "doc-type-alias" in contract_qmd
+    assert "doc-label-typealias" in contract_qmd
+    assert (
+        "[type]{.doc-type-alias-keyword .kw} [Contract]{.doc-parameter-name}"
+        " [=]{.doc-parameter-default-sep .op}"
+        " [Literal[[&quot;a&quot;]{.st}, [&quot;b&quot;]{.st}]]{.doc-parameter-default}"
+        in contract_qmd
+    )
     kinds = {item.obj.kind.value for item in ref.items}
     assert "type alias" in kinds
 

--- a/tests/renderer/test_type_aliases.py
+++ b/tests/renderer/test_type_aliases.py
@@ -55,7 +55,7 @@ def _load_member(code: str, name: str):
 def test_label_pep695_spelling():
     from great_docs._apiref._render._label import get_label
 
-    obj = _load_member('type Contract = int | str', "Contract")
+    obj = _load_member("type Contract = int | str", "Contract")
     assert get_label(obj) == "typealias"
 
 
@@ -79,3 +79,15 @@ def test_label_plain_constant_still_works():
     from great_docs._apiref._render._label import get_label
 
     assert get_label(_load_member("MAX: int = 3\n", "MAX")) == "constant"
+
+
+def test_from_griffe_builds_a_type_alias_node():
+    from great_docs._apiref.content import DocTypeAlias, Doc
+
+    obj = _load_member("type Contract = int | str", "Contract")
+    doc = Doc.from_griffe("Contract", obj)
+
+    assert isinstance(doc, DocTypeAlias)
+    assert doc.kind == "type alias"
+    assert doc.name == "Contract"
+    assert doc.anchor == "package.Contract"

--- a/tests/renderer/test_type_aliases.py
+++ b/tests/renderer/test_type_aliases.py
@@ -82,7 +82,7 @@ def test_label_plain_constant_still_works():
 
 
 def test_from_griffe_builds_a_type_alias_node():
-    from great_docs._apiref.content import DocTypeAlias, Doc
+    from great_docs._apiref.content import Doc, DocTypeAlias
 
     obj = _load_member("type Contract = int | str", "Contract")
     doc = Doc.from_griffe("Contract", obj)
@@ -255,6 +255,41 @@ def test_type_alias_group_has_its_own_heading():
 
     assert "Type Aliases" in qmd
     assert "doc-type-aliases" in qmd
+
+
+def test_exclude_type_aliases_removes_the_member_from_the_output():
+    """`exclude_type_aliases` must keep an excluded alias out of the rendered qmd"""
+    import textwrap
+
+    from great_docs._apiref._globals import EXCLUSIONS
+    from great_docs._apiref._render.extending import exclude_type_aliases
+    from great_docs._apiref._tools import render_code_variable
+
+    source = textwrap.dedent('''
+        class Holder:
+            """A holder."""
+
+            type Kept = str
+            """A kept alias."""
+
+            type Dropped = int
+            """A dropped alias."""
+    ''')
+
+    # Without the exclusion both aliases are rendered
+    assert "Dropped" in render_code_variable(source, "Holder")
+
+    original = dict(EXCLUSIONS.type_aliases)
+    try:
+        exclude_type_aliases({"package.Holder": "Dropped"})
+        qmd = render_code_variable(source, "Holder")
+    finally:
+        EXCLUSIONS.type_aliases.clear()
+        EXCLUSIONS.type_aliases.update(original)
+
+    assert "A kept alias." in qmd
+    assert "Dropped" not in qmd
+    assert "A dropped alias." not in qmd
 
 
 def test_type_alias_group_precedes_attributes():

--- a/tests/renderer/test_typing.py
+++ b/tests/renderer/test_typing.py
@@ -86,12 +86,18 @@ def test_any_docstring_section_union():
 
 
 def test_doc_type_union():
-    """DocType includes the four core Doc types."""
+    """DocType includes the five core Doc types."""
     from great_docs._apiref.typing import DocType
 
     args = get_args(DocType)
     type_names = {t.__name__ for t in args}
-    assert type_names == {"DocClass", "DocFunction", "DocAttribute", "DocModule"}
+    assert type_names == {
+        "DocClass",
+        "DocFunction",
+        "DocAttribute",
+        "DocTypeAlias",
+        "DocModule",
+    }
 
 
 def test_doc_member_type_union():

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -74,6 +74,7 @@ from great_docs._apiref._render.extending import (
     exclude_classes,
     exclude_functions,
     exclude_parameters,
+    exclude_type_aliases,
     extend_base_class,
     set_class_attr,
 )
@@ -30642,6 +30643,33 @@ def test_mixin_type_alias_member_pages_property():
     pages = render.type_alias_member_pages
     assert len(pages) == 1
     assert pages[0].path == "Inline"
+
+
+def test_mixin_type_alias_member_pages_honours_exclusions():
+    """exclude_type_aliases drops a type alias from type_alias_member_pages."""
+
+    cls_obj, doc_cls = _build_class_with_member_pages_and_type_alias()
+    render = RenderDocClass(doc_cls, level=1)
+
+    original = dict(EXCLUSIONS.type_aliases)
+    try:
+        exclude_type_aliases({cls_obj.path: "Inline"})
+        assert render.type_alias_member_pages == []
+    finally:
+        EXCLUSIONS.type_aliases.clear()
+        EXCLUSIONS.type_aliases.update(original)
+
+
+def test_exclude_type_aliases_updates_globals():
+    """exclude_type_aliases updates the EXCLUSIONS.type_aliases global dict."""
+
+    original = dict(EXCLUSIONS.type_aliases)
+    try:
+        exclude_type_aliases({"test.MyClass": "Contract"})
+        assert EXCLUSIONS.type_aliases["test.MyClass"] == "Contract"
+    finally:
+        EXCLUSIONS.type_aliases.clear()
+        EXCLUSIONS.type_aliases.update(original)
 
 
 def test_mixin_render_type_alias_member_pages():

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -30573,14 +30573,16 @@ def test_mixin_render_body_invalid_member_type_raises():
 
 
 def test_mixin_render_members_returns_groups():
-    """render_members returns [attributes, classes, functions] groups."""
+    """render_members returns [type aliases, attributes, classes, functions] groups."""
 
     _, doc_cls = _build_class_with_members()
     render = RenderDocClass(doc_cls, level=1)
 
     members = render.render_members()
-    assert len(members) == 3
-    for m in members:
+    assert len(members) == 4
+    # No type alias members in this fixture, so that slot is None.
+    assert members[0] is None
+    for m in members[1:]:
         assert isinstance(m, RenderedMembersGroup)
 
 
@@ -30595,14 +30597,16 @@ def test_mixin_render_members_show_members_false():
 
 
 def test_mixin_render_member_pages_returns_groups():
-    """render_member_pages returns [attributes, classes, functions] page groups."""
+    """render_member_pages returns [type aliases, attributes, classes, functions] page groups."""
 
     _, doc_cls = _build_class_with_member_pages()
     render = RenderDocClass(doc_cls, level=1)
 
     pages = render.render_member_pages()
-    assert len(pages) == 3
-    for p in pages:
+    assert len(pages) == 4
+    # No type alias members in this fixture, so that slot is None.
+    assert pages[0] is None
+    for p in pages[1:]:
         assert isinstance(p, RenderedMemberPagesGroup)
 
 
@@ -31131,7 +31135,7 @@ def test_mixin_render_members_module_uses_functions_slug():
     render = RenderDocModule(doc_mod, level=1)
 
     members = render.render_members()
-    assert len(members) == 3
+    assert len(members) == 4
     with patch.dict(os.environ, {}, clear=False):
         os.environ.pop("GITHUB_REPO_URL", None)
         body_str = str(render.render_body())

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -34113,7 +34113,7 @@ def test_type_sections_post_init_typevars_no_sig_name():
 
 
 def test_type_sections_post_init_typealiases_settings():
-    """TypeSections.__post_init__ sets show_signature_name=False and show_signature_annotation=False on typealiases."""
+    """TypeSections keeps alias names and hides redundant annotations."""
 
     ta_item = InventoryItem(name="MyAlias", obj=MagicMock())
 
@@ -34132,8 +34132,8 @@ def test_type_sections_post_init_typealiases_settings():
             typealiases_items=[ta_item],
         )
 
-    assert mock_render.show_signature_name is False
     assert mock_render.show_signature_annotation is False
+    assert "show_signature_name" not in ts.categories[2].render_flags
 
 
 def test_type_sections_render_body_protocols_section():

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -32350,14 +32350,46 @@ def test_get_label_attribute_constant():
     assert get_label(obj) == "constant"
 
 
-def test_attribute_label_typealias():
-    """_attribute_label returns 'typealias' for a type alias."""
+@pytest.mark.skipif(
+    sys.version_info < (3, 12),
+    reason="PEP 695 `type` statement requires Python 3.12+",
+)
+def test_get_label_typealias():
+    """get_label returns 'typealias' for a real PEP 695 alias."""
 
-    obj = MagicMock(spec=gf.Attribute)
-    obj.kind.value = "type alias"
-    obj.annotation = None
-    obj.labels = set()
-    assert _attribute_label(obj) == "typealias"
+    with gf.temporary_visited_package("pkg", {"__init__.py": "type Contract = int | str\n"}) as pkg:
+        assert get_label(pkg["Contract"]) == "typealias"
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 12),
+    reason="PEP 695 `type` statement requires Python 3.12+",
+)
+def test_get_label_typealias_reexported():
+    """A re-exported alias reaches get_label as an Alias proxy, not a raw TypeAlias.
+
+    This is the regression guard for a crash where `isinstance(obj, gf.TypeAlias)`
+    missed the proxy and fell through to code that reads `obj.annotation`, which
+    a type alias does not have.
+    """
+    with gf.temporary_visited_package(
+        "pkg",
+        {
+            "__init__.py": "from ._impl import Contract\n",
+            "_impl.py": "type Contract = int | str\n",
+        },
+    ) as pkg:
+        obj = pkg["Contract"]
+        assert isinstance(obj, gf.Alias)
+        assert get_label(obj) == "typealias"
+
+
+def test_get_label_typealias_legacy_spelling():
+    """get_label returns 'typealias' for the legacy `X: TypeAlias = ...` spelling."""
+
+    code = "from typing import TypeAlias\nContract: TypeAlias = int | str\n"
+    with gf.temporary_visited_package("pkg", {"__init__.py": code}) as pkg:
+        assert get_label(pkg["Contract"]) == "typealias"
 
 
 def test_attribute_label_typevar():
@@ -32855,13 +32887,17 @@ def test_label_unknown_kind_raises():
         get_label(obj)
 
 
-def test_attribute_label_typealias_kind():
-    """_attribute_label returns 'typealias' for type alias kind."""
+@pytest.mark.skipif(
+    sys.version_info < (3, 12),
+    reason="PEP 695 `type` statement requires Python 3.12+",
+)
+def test_get_label_typealias_kind():
+    """get_label returns 'typealias' for a real griffe TYPE_ALIAS-kind object."""
 
-    obj = gf.Attribute(name="MyType", lineno=1)
-    obj.kind = gf.Kind.TYPE_ALIAS
-
-    assert _attribute_label(obj) == "typealias"
+    with gf.temporary_visited_package("pkg", {"__init__.py": "type MyType = int\n"}) as pkg:
+        obj = pkg["MyType"]
+        assert obj.kind is gf.Kind.TYPE_ALIAS
+        assert get_label(obj) == "typealias"
 
 
 def test_attribute_label_typevar_annotation():

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -110,6 +110,7 @@ from great_docs._apiref.content import (
     DocClass,
     DocFunction,
     DocModule,
+    DocTypeAlias,
     Link,
     MemberPage,
     Page,
@@ -30618,6 +30619,62 @@ def test_mixin_render_member_pages_show_members_false():
     render.show_members = False
 
     assert render.render_member_pages() == []
+
+
+def _build_class_with_member_pages_and_type_alias():
+    """Build a griffe Class with MemberPage members, including a type alias."""
+    cls_obj, doc_cls = _build_class_with_member_pages()
+    alias_obj = gf.TypeAlias(name="Inline", value=gf.ExprName("int"), lineno=5)
+    cls_obj.set_member("Inline", alias_obj)
+
+    doc_alias = DocTypeAlias(name="Inline", obj=alias_obj)
+    page_alias = MemberPage(path="Inline", contents=[doc_alias])
+    doc_cls.members.append(page_alias)
+    return cls_obj, doc_cls
+
+
+def test_mixin_type_alias_member_pages_property():
+    """type_alias_member_pages filters MemberPage members by is_type_alias."""
+
+    _, doc_cls = _build_class_with_member_pages_and_type_alias()
+    render = RenderDocClass(doc_cls, level=1)
+
+    pages = render.type_alias_member_pages
+    assert len(pages) == 1
+    assert pages[0].path == "Inline"
+
+
+def test_mixin_render_type_alias_member_pages():
+    """render_type_alias_member_pages returns RenderedMemberPagesGroup."""
+
+    _, doc_cls = _build_class_with_member_pages_and_type_alias()
+    render = RenderDocClass(doc_cls, level=1)
+
+    result = render.render_type_alias_member_pages()
+    assert isinstance(result, RenderedMemberPagesGroup)
+    assert "Type Aliases" in str(result.title)
+
+
+def test_mixin_render_type_alias_member_pages_show_false():
+    """render_type_alias_member_pages returns None when show_type_aliases=False."""
+
+    _, doc_cls = _build_class_with_member_pages_and_type_alias()
+    render = RenderDocClass(doc_cls, level=1)
+    render.show_type_aliases = False
+
+    assert render.render_type_alias_member_pages() is None
+
+
+def test_mixin_render_member_pages_includes_type_alias_group():
+    """render_member_pages fills the type-alias slot when a MemberPage alias exists."""
+
+    _, doc_cls = _build_class_with_member_pages_and_type_alias()
+    render = RenderDocClass(doc_cls, level=1)
+
+    pages = render.render_member_pages()
+    assert len(pages) == 4
+    assert isinstance(pages[0], RenderedMemberPagesGroup)
+    assert "Type Aliases" in str(pages[0].title)
 
 
 def test_mixin_attributes_property():

--- a/tests/test_synthetic.py
+++ b/tests/test_synthetic.py
@@ -48,11 +48,20 @@ PHASE1_PACKAGES = [
 
 # Only parametrize over specs that actually exist on disk.
 # As more specs are added in later phases they'll automatically be picked up.
+#
+# A spec may declare `min_python`, for source it cannot express on older
+# interpreters. Such a package is left out entirely rather than skipped
+# per-test: griffe parses its source with the running interpreter, so below the
+# floor there is nothing to assert against.
 _AVAILABLE_PACKAGES = []
 for _name in ALL_PACKAGES:
     _spec_file = _SYNTHETIC_DIR / "synthetic" / "specs" / f"{_name}.py"
-    if _spec_file.exists():
-        _AVAILABLE_PACKAGES.append(_name)
+    if not _spec_file.exists():
+        continue
+    _min_python = get_spec(_name).get("min_python")
+    if _min_python is not None and sys.version_info < tuple(_min_python):
+        continue
+    _AVAILABLE_PACKAGES.append(_name)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
This PR makes Great Docs document Python 3.12+ PEP 695 type aliases. Before it, building docs for a package containing `type Contract = Literal["a", "b"]` aborted with

```
TypeError: Cannot document object of kind: Kind.TYPE_ALIAS.
```

PEP 695 elevates [generic type aliases](https://peps.python.org/pep-0695/#generic-type-alias) i.e. those defined with (`type`) to the same level as `class` and `def` (method/function) definitions. On an API page, these definitions are now grouped under _Type Aliases_ (similar to _Classes_, _Methods_, _Attributes_).

Old style type aliases e.g. `Contract: TypeAlias = Literal["a", "b"]` remain under _Attributes_.

Depends on PR #294
fixes #288
