### PR TITLE
fix: fix: load dark images on initial state

### DIFF
--- a/great_docs/assets/_extensions/gd-lightbox/gd-lightbox.js
+++ b/great_docs/assets/_extensions/gd-lightbox/gd-lightbox.js
@@ -1374,6 +1374,7 @@
     if (allItems.length === 0) return;
 
     allItems.forEach(bindClick);
+    swapThumbnails();
     setupDarkModeObserver();
 
     // Global keyboard handler


### PR DESCRIPTION
# Summary

This fixes the dark mode display of `{.lightbox}` images with two variants.

# Related GitHub Issues and PRs

- Ref: #297 

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [ ] I have added **pytest** unit tests for any new functionality. 

I found no framework to test `.js` content.
