### PR TITLE
fix: preserve source order for sidebar subsections

### DIFF
--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -3466,7 +3466,11 @@ class GreatDocs:
             # Add subdirectory groups as section headers
             if dir_titles is None:
                 dir_titles = {}
-            for subdir in sorted(subdir_groups_dict.keys()):
+            # Preserve source discovery order rather than sorting the keys. The
+            # source file list is sorted with numeric prefixes intact, so first
+            # encounter order already reflects the author's intended ordering.
+            # Sorting here would use the prefix-stripped names and lose it.
+            for subdir in subdir_groups_dict:
                 clean_subdir = self._strip_numeric_prefix(subdir)  # pragma: no cover
                 section_title = dir_titles.get(  # pragma: no cover
                     clean_subdir,

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -10010,6 +10010,36 @@ def test_add_section_sidebar_strips_numeric_prefix_from_subdirs():
         assert "02 Advanced" not in section_titles
 
 
+def test_add_section_sidebar_preserves_subdir_order():
+    """_add_section_sidebar orders subsections by source order, not stripped name."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        docs = GreatDocs(project_path=tmp_dir)
+        quarto_yml = docs.project_path / "_quarto.yml"
+        docs.project_path.mkdir(parents=True, exist_ok=True)
+
+        config = {"website": {"sidebar": [], "navbar": {"left": []}}}
+        with open(quarto_yml, "w") as f:
+            write_yaml(config, f)
+
+        # Numeric prefixes are stripped before this point, so the pages arrive
+        # in source order with clean names that do not sort alphabetically.
+        pages = [
+            {"filename": "foundations/page.qmd", "title": "Foundations Page"},
+            {"filename": "effect-estimation/page.qmd", "title": "Effect Page"},
+            {"filename": "applied-models/page.qmd", "title": "Applied Page"},
+        ]
+        docs._add_section_sidebar("Examples", "examples", pages, has_user_index=True)
+
+        with open(quarto_yml) as f:
+            result = read_yaml(f)
+
+        sidebar = result["website"]["sidebar"]
+        sections = [c for c in sidebar[0]["contents"] if isinstance(c, dict) and "section" in c]
+        section_titles = [s["section"] for s in sections]
+
+        assert section_titles == ["Foundations", "Effect Estimation", "Applied Models"]
+
+
 def test_add_section_sidebar_dir_titles_override():
     """_add_section_sidebar uses dir_titles mapping to override sidebar section titles."""
     with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
# Summary

Custom sections with numeric-prefixed subdirectories rendered their sidebar subsections alphabetically instead of in the intended numeric order.

`_copy_section_files` strips numeric prefixes from subdirectory path components, so `_add_section_sidebar`'s `sorted(subdir_groups_dict.keys())` sorted the *stripped* names — `applied-models` before `foundations` — discarding the author's ordering. The source file list is already sorted with prefixes intact, so the grouping dict's insertion order is the intended order; iterating the dict directly preserves it.

# Related GitHub Issues and PRs

- Ref: #295

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [x] I have added **pytest** unit tests for any new functionality.

Closes #295

`test_add_section_sidebar_preserves_subdir_order` was added beside the existing sidebar tests in `tests/test_great_docs.py`; it fails on `main` and passes with this change. This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
