### PR TITLE
fix: avoid navigation bar logos with size 0

### DIFF
--- a/great_docs/assets/great-docs.scss
+++ b/great_docs/assets/great-docs.scss
@@ -1327,12 +1327,12 @@ div.sidebar-item-container {
 
 /* logo in the navbar title */
 .navbar-logo {
-  height: 24px;
-  width: auto;
-  max-width: 100%;
-  padding-right: 4px;
-  display: block;
-  flex-shrink: 0;
+    height: 24px;
+    width: auto;
+    max-width: 100%;
+    padding-right: 4px;
+    display: block;
+    flex-shrink: 0;
 }
 
 /* Version badge in navbar title */
@@ -4895,7 +4895,7 @@ main.content.page-columns.page-full > * {
    Scope to html[...] so Quarto's nav[data-bs-theme="dark"] (dark navbar
    background in the flatly theme) doesn't trigger these rules in light mode. */
 html[data-bs-theme="dark"] .navbar-logo.light-content { display: none !important; }
-html[data-bs-theme="dark"] .navbar-logo.dark-content  { display: inline !important; }
+html[data-bs-theme="dark"] .navbar-logo.dark-content  { display: block !important; }
 
 /* Reduce top margin on first heading after hero */
 .gd-hero + section.level1 > h1:first-child,

--- a/great_docs/assets/great-docs.scss
+++ b/great_docs/assets/great-docs.scss
@@ -1325,6 +1325,16 @@ div.sidebar-item-container {
     padding-bottom: 4px;
 }
 
+/* logo in the navbar title */
+.navbar-logo {
+  height: 24px;
+  width: auto;
+  max-width: 100%;
+  padding-right: 4px;
+  display: block;
+  flex-shrink: 0;
+}
+
 /* Version badge in navbar title */
 .version-badge {
     font-size: 0.65em;


### PR DESCRIPTION
# Summary

If logos with relative sizes in the svg file are used (`width="100%" height="100%"`), the logo is rendered in the navigation bar with size 0. This PR fixes this behavior and uses a fixed height of 24px. 

# Related GitHub Issues and PRs

- Ref: #276 

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [ ] I have added **pytest** unit tests for any new functionality.

-- no new functionality --
