### PR TITLE
Suppress Type Aliases sections in docstrings

### DIFF
--- a/great_docs/_apiref/_render/doc.py
+++ b/great_docs/_apiref/_render/doc.py
@@ -567,10 +567,11 @@ class __RenderDoc(RenderBase):
     @render_docstring_section.register(gf.DocstringSectionFunctions)
     @render_docstring_section.register(gf.DocstringSectionClasses)
     @render_docstring_section.register(gf.DocstringSectionModules)
+    @render_docstring_section.register(gf.DocstringSectionTypeAliases)
     def _(self, el):
         """
         Suppress collection-style sections (Methods, Functions, Classes, Modules,
-        Attributes) emitted by the numpy parser
+        Type Aliases) emitted by the numpy parser
 
         These sections are hand-written summaries of class/module members (e.g.,
         `Methods\\n-------\\nfoo(x)\\n    Description.`). Great Docs already auto-generates the same

--- a/tests/renderer/test_type_aliases.py
+++ b/tests/renderer/test_type_aliases.py
@@ -385,6 +385,36 @@ def test_module_level_type_alias_group():
     assert "Contract" in qmd
 
 
+def test_docstring_type_aliases_section_is_suppressed():
+    """
+    A hand-written `Type Aliases` section is a member summary, so it is dropped
+
+    Great Docs generates the alias group from the real members, exactly as it does
+    for `Methods`. Rendering the docstring version would duplicate that group, and
+    the unhandled section previously leaked `DocstringTypeAlias` object reprs.
+    """
+    import textwrap
+
+    from great_docs._apiref._tools import render_code_variable
+
+    source = textwrap.dedent('''
+        class Holder:
+            """A holder.
+
+            Type Aliases
+            ------------
+            Handwritten : int | str
+                A hand-written summary.
+            """
+    ''')
+    qmd = render_code_variable(source, "Holder")
+
+    assert "A holder." in qmd
+    assert "Handwritten" not in qmd
+    assert "A hand-written summary." not in qmd
+    assert "DocstringTypeAlias object at" not in qmd
+
+
 def test_inventory_role_for_type_alias():
     from great_docs._apiref.inventory import InventoryItem, _create_inventory_item
 


### PR DESCRIPTION
This PR makes great-docs drop a numpydoc _Type Aliases_ section written inside a docstring, rather than rendering it.

Type aliases are members, exactly like methods. Nobody hand-writes a _Methods_ section in a docstring because the documentation system generates it from the real members, and the same reasoning applies to _Type Aliases_ — great-docs already builds that group from the actual aliases. 