### PR TITLE
Strip the trailing newline from format_str output

### DIFF
--- a/great_docs/_apiref/_format.py
+++ b/great_docs/_apiref/_format.py
@@ -296,9 +296,20 @@ def _stdin_filename() -> str:
 @lru_cache(maxsize=2048)
 def format_str(source: str) -> str:
     """
-    Format Python source code using Ruff
+    Format Python source code with ruff
 
-    This analogous to black.format_str.
+    Parameters
+    ----------
+    source
+        Python code to format. This is a snippet, e.g. an expression,
+        rather than the contents of a file.
+
+    Returns
+    -------
+    :
+        Formatted code, with no trailing newline. Only a file needs a
+        newline to terminate it, and `ruff format` adds one because it
+        reads and writes whole files.
     """
     if not HAS_RUFF:
         return source
@@ -319,7 +330,7 @@ def format_str(source: str) -> str:
     if proc.returncode != 0:
         raise RuntimeError(proc.stderr.strip())
 
-    return proc.stdout
+    return proc.stdout.removesuffix("\n")
 
 
 def format_value(value: str | gf.Expr | None = None) -> str:

--- a/tests/renderer/test_format.py
+++ b/tests/renderer/test_format.py
@@ -37,6 +37,29 @@ class TestRenderFormattedExpr:
         assert "int" in result
         assert "None" in result
 
+    def test_no_trailing_break_in_short_annotation(self):
+        """A short annotation must not pick up a trailing <br>."""
+        expr = self._make_expr("dict[str, int]")
+        result = render_formatted_expr(expr)
+
+        assert not result.endswith("<br>")
+
+    def test_no_trailing_break_in_wrapped_annotation(self):
+        """A wrapped annotation keeps its internal <br>s but gains no trailing one."""
+        from great_docs._apiref._format import HAS_RUFF
+
+        if not HAS_RUFF:
+            pytest.skip("ruff is required to wrap the annotation")
+
+        # Long enough to exceed any plausible ruff line-length, so that ruff
+        # puts one member per line
+        members = ", ".join(f'"{c * 10}"' for c in "abcdefghijklmnop")
+        expr = self._make_expr(f"Literal[{members}]")
+        result = render_formatted_expr(expr)
+
+        assert "<br>" in result
+        assert not result.endswith("<br>")
+
     def test_whitespace_encoded(self):
         """Spaces and newlines should be encoded for HTML inline display."""
         from great_docs._apiref._format import pretty_code


### PR DESCRIPTION
This PR removes a spurious `<br>` that great-docs emitted at the end of every ruff-formatted expression in rendered API reference output.
