### PR TITLE
feat: simplify CI step concerned with site previewing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,18 +40,7 @@ jobs:
 
       - name: How to preview this build locally
         if: github.event_name == 'pull_request'
-        run: |
-          echo "::notice title=Preview these docs locally::great-docs preview --run ${{ github.run_id }}"
-          echo ""
-          echo "  # this exact build:"
-          echo "  great-docs preview --run ${{ github.run_id }}"
-          echo ""
-          echo "  # or always the latest build for this PR:"
-          echo "  great-docs preview --pr ${{ github.event.number }}"
-          echo ""
-          echo "  Don't have it? pip install great-docs (or: pipx run / uvx great-docs preview ...)."
-          echo "  Auth: 'gh auth login' then add --use-gh, or set GITHUB_TOKEN (Actions:read)."
-          echo "  Tip: add --path reference/mcp/gd_config.html to jump straight to a page."
+        run: great-docs ci notice --run ${{ github.run_id }} --pr ${{ github.event.number }}
 
       - name: Upload build timings
         uses: actions/upload-artifact@v7
@@ -94,56 +83,22 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      # Post (and keep updated) a sticky comment telling reviewers how to fetch
-      # this build and view it locally — no preview host required. The command
-      # is pinned to this exact run so it reproduces the build being reviewed.
-      # Uses the first-party actions/github-script (no third-party action in the
-      # supply chain); continue-on-error so fork PRs (read-only GITHUB_TOKEN)
-      # don't fail the run — the "How to preview this build locally" log notice
-      # still covers those.
-      - name: Post preview instructions to the PR
-        uses: actions/github-script@v7
-        continue-on-error: true
-        env:
-          RUN_ID: ${{ github.run_id }}
-          PR_NUMBER: ${{ github.event.number }}
+      # Install the PR's own great-docs and let it post the sticky preview
+      # comment. Running the in-repo build (rather than a released version)
+      # means this job exercises the code under review. Kept as its own minimal
+      # job so the docs build — which runs PR-authored code — never holds a
+      # pull-requests:write token. continue-on-error so fork PRs (read-only
+      # token) don't fail the run; the build job's log notice still covers them.
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
-          script: |
-            const marker = '<!-- great-docs:docs-preview -->';
-            const body = [
-              marker,
-              "### 📚 Preview this PR's docs locally",
-              '',
-              'Fetch the just-built site and open it in your browser:',
-              '',
-              '```bash',
-              '# this exact build',
-              `great-docs preview --run ${process.env.RUN_ID}`,
-              '',
-              '# or always the latest build for this PR',
-              `great-docs preview --pr ${process.env.PR_NUMBER}`,
-              '```',
-              '',
-              '<details>',
-              '<summary>Auth &amp; tips</summary>',
-              '',
-              '- **Requires** `great-docs`: `pip install great-docs` (or run via `pipx`/`uvx`).',
-              '- **Auth:** run `gh auth login` then add `--use-gh`, or set `GITHUB_TOKEN` (needs *Actions: read*).',
-              '- **Jump to a page:** add `--path reference/index.html`.',
-              '- **Latest vs exact:** `--pr <n>` grabs the newest build; `--run <id>` pins this one.',
-              '- **Re-download:** `--refresh` ignores the local cache.',
-              '',
-              '</details>',
-            ].join('\n');
-
-            const { owner, repo } = context.repo;
-            const issue_number = context.issue.number;
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner, repo, issue_number, per_page: 100,
-            });
-            const existing = comments.find((c) => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
-            }
+          python-version: "3.11"
+      - name: Install great-docs
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .
+      - name: Post preview instructions to the PR
+        continue-on-error: true
+        run: great-docs ci pr-comment --run ${{ github.run_id }} --pr ${{ github.event.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/great_docs/_ci.py
+++ b/great_docs/_ci.py
@@ -1,0 +1,192 @@
+"""Helpers for `great-docs ci`: small utilities meant to run inside CI.
+
+These render (and post) the "preview this build locally" hints that tell reviewers how to open a
+PR's docs without a preview host. Keeping the message text here (rather than inline in workflow
+YAML) means it lives in one place, is unit-testable, and stays consistent between the log notice and
+the sticky PR comment. See `great_docs._pr_preview` for the `preview` command these hints point at.
+"""
+
+from __future__ import annotations
+
+import os
+
+from ._pr_preview import GITHUB_API, PreviewError, _parse_owner_repo, parse_github_url
+
+_TIMEOUT = 15
+
+# Hidden marker used to find (and update in place) our own PR comment.
+PREVIEW_COMMENT_MARKER = "<!-- great-docs:docs-preview -->"
+
+
+# ---------------------------------------------------------------------------
+# Message rendering (single source of truth for both the notice and the comment)
+# ---------------------------------------------------------------------------
+
+
+def render_preview_comment(run_id: int | str, pr: int | str) -> str:
+    """Render the sticky PR comment body (Markdown), including the hidden marker."""
+    lines = [
+        PREVIEW_COMMENT_MARKER,
+        "### 📚 Preview this PR's docs locally",
+        "",
+        "Fetch the just-built site and open it in your browser:",
+        "",
+        "```bash",
+        "# this exact build",
+        f"great-docs preview --run {run_id}",
+        "",
+        "# or always the latest build for this PR",
+        f"great-docs preview --pr {pr}",
+        "```",
+        "",
+        "<details>",
+        "<summary>Auth &amp; tips</summary>",
+        "",
+        "- **Requires** `great-docs`: `pip install great-docs` (or run via `pipx`/`uvx`).",
+        "- **Auth:** run `gh auth login` then add `--use-gh`, or set `GITHUB_TOKEN` "
+        "(needs *Actions: read*).",
+        "- **Jump to a page:** add `--path reference/index.html`.",
+        "- **Latest vs exact:** `--pr <n>` grabs the newest build; `--run <id>` pins this one.",
+        "- **Re-download:** `--refresh` ignores the local cache.",
+        "",
+        "</details>",
+    ]
+    return "\n".join(lines)
+
+
+def render_notice_lines(run_id: int | str, pr: int | str | None = None) -> list[str]:
+    """Render the workflow-log notice lines.
+
+    The first line is a GitHub Actions ``::notice::`` workflow command, so it
+    also surfaces in the run's annotations; the rest are plain log output.
+    """
+    lines = [
+        f"::notice title=Preview these docs locally::great-docs preview --run {run_id}",
+        "",
+        "  # this exact build:",
+        f"  great-docs preview --run {run_id}",
+    ]
+    if pr is not None:
+        lines += [
+            "",
+            "  # or always the latest build for this PR:",
+            f"  great-docs preview --pr {pr}",
+        ]
+    lines += [
+        "",
+        "  Don't have it? pip install great-docs (or: pipx run / uvx great-docs preview ...).",
+        "  Auth: 'gh auth login' then add --use-gh, or set GITHUB_TOKEN (Actions:read).",
+        "  Tip: add --path reference/index.html to jump straight to a page.",
+    ]
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Repo / token resolution (CI context)
+# ---------------------------------------------------------------------------
+
+
+def resolve_ci_repo(repo_override: str | None) -> tuple[str, str]:
+    """Determine `(owner, repo)` in a CI run.
+
+    Precedence: `--repo` -> `$GITHUB_REPOSITORY` (set by GitHub Actions) -> git remote / project
+    config.
+    """
+    if repo_override:
+        parsed = parse_github_url(repo_override) or _parse_owner_repo(repo_override)
+        if parsed:
+            return parsed
+        raise PreviewError(
+            f"Could not parse --repo '{repo_override}'. Expected 'owner/repo' or a GitHub URL."
+        )
+
+    env_repo = os.environ.get("GITHUB_REPOSITORY", "")
+    if "/" in env_repo:
+        owner, _, repo = env_repo.partition("/")
+        if owner and repo:
+            return owner, repo
+
+    from ._pr_preview import resolve_repo
+
+    return resolve_repo(None, None)
+
+
+def _github_token() -> str:
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token or not token.strip():
+        raise PreviewError(
+            "No GITHUB_TOKEN/GH_TOKEN in the environment. In GitHub Actions, pass "
+            "`env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` and grant "
+            "`permissions: pull-requests: write`."
+        )
+    return token.strip()
+
+
+# ---------------------------------------------------------------------------
+# Sticky PR comment upsert
+# ---------------------------------------------------------------------------
+
+
+def _find_existing_comment(owner: str, repo: str, pr: int, headers: dict[str, str]) -> int | None:
+    """Return the id of our previously-posted comment, following pagination."""
+    import requests
+
+    url: str | None = f"{GITHUB_API}/repos/{owner}/{repo}/issues/{pr}/comments?per_page=100"
+    while url:
+        resp = requests.get(url, headers=headers, timeout=_TIMEOUT)
+        if resp.status_code != 200:
+            raise PreviewError(f"Could not list PR comments (HTTP {resp.status_code}).")
+        for comment in resp.json():
+            if PREVIEW_COMMENT_MARKER in (comment.get("body") or ""):
+                return comment.get("id")
+        url = resp.links.get("next", {}).get("url")
+    return None
+
+
+def upsert_pr_comment(owner: str, repo: str, pr: int, body: str, token: str) -> str:
+    """Create or update the sticky preview comment. Returns "created" or "updated"."""
+    import requests
+
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Authorization": f"Bearer {token}",
+    }
+
+    existing_id = _find_existing_comment(owner, repo, pr, headers)
+    try:
+        if existing_id is not None:
+            resp = requests.patch(
+                f"{GITHUB_API}/repos/{owner}/{repo}/issues/comments/{existing_id}",
+                headers=headers,
+                json={"body": body},
+                timeout=_TIMEOUT,
+            )
+            action = "updated"
+        else:
+            resp = requests.post(
+                f"{GITHUB_API}/repos/{owner}/{repo}/issues/{pr}/comments",
+                headers=headers,
+                json={"body": body},
+                timeout=_TIMEOUT,
+            )
+            action = "created"
+    except requests.RequestException as exc:
+        raise PreviewError(f"Failed to post PR comment: {exc}") from exc
+
+    if resp.status_code not in (200, 201):
+        raise PreviewError(f"Failed to {action[:-1]} PR comment (HTTP {resp.status_code}).")
+    return action
+
+
+def post_preview_comment(
+    run_id: int | str,
+    pr: int,
+    repo_override: str | None = None,
+) -> tuple[str, str]:
+    """Render and upsert the preview comment. Returns `(action, "owner/repo")`."""
+    owner, repo = resolve_ci_repo(repo_override)
+    token = _github_token()
+    body = render_preview_comment(run_id, pr)
+    action = upsert_pr_comment(owner, repo, pr, body, token)
+    return action, f"{owner}/{repo}"

--- a/great_docs/assets/github-workflow-template.yml
+++ b/great_docs/assets/github-workflow-template.yml
@@ -38,17 +38,7 @@ jobs:
 
       - name: How to preview this build locally
         if: github.event_name == 'pull_request'
-        run: |
-          echo "::notice title=Preview these docs locally::great-docs preview --run ${{ github.run_id }}"
-          echo ""
-          echo "  # this exact build:"
-          echo "  great-docs preview --run ${{ github.run_id }}"
-          echo ""
-          echo "  # or always the latest build for this PR:"
-          echo "  great-docs preview --pr ${{ github.event.number }}"
-          echo ""
-          echo "  Don't have it? pip install great-docs (or: pipx run / uvx great-docs preview ...)."
-          echo "  Auth: 'gh auth login' then add --use-gh, or set GITHUB_TOKEN (Actions:read)."
+        run: great-docs ci notice --run ${{ github.run_id }} --pr ${{ github.event.number }}
 
       - name: Upload build timings
         uses: actions/upload-artifact@v7
@@ -91,54 +81,13 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      # Post (and keep updated) a sticky comment telling reviewers how to fetch
-      # this build and view it locally with `great-docs preview` — no preview
-      # host required. Pinned to this run so it reproduces the build under review.
-      # Uses the first-party actions/github-script (no third-party action);
-      # continue-on-error so fork PRs (read-only token) don't fail the run.
+      # Post (and keep updated) a sticky PR comment with the local-preview
+      # command, pinned to this run so it reproduces the build under review.
+      # Runs the released great-docs via pipx (no install step needed); kept as
+      # its own minimal job so the docs build never holds a pull-requests:write
+      # token. continue-on-error so fork PRs (read-only token) don't fail the run.
       - name: Post preview instructions to the PR
-        uses: actions/github-script@v7
         continue-on-error: true
+        run: pipx run great-docs ci pr-comment --run ${{ github.run_id }} --pr ${{ github.event.number }}
         env:
-          RUN_ID: ${{ github.run_id }}
-          PR_NUMBER: ${{ github.event.number }}
-        with:
-          script: |
-            const marker = '<!-- great-docs:docs-preview -->';
-            const body = [
-              marker,
-              "### 📚 Preview this PR's docs locally",
-              '',
-              'Fetch the just-built site and open it in your browser:',
-              '',
-              '```bash',
-              '# this exact build',
-              `great-docs preview --run ${process.env.RUN_ID}`,
-              '',
-              '# or always the latest build for this PR',
-              `great-docs preview --pr ${process.env.PR_NUMBER}`,
-              '```',
-              '',
-              '<details>',
-              '<summary>Auth &amp; tips</summary>',
-              '',
-              '- **Requires** `great-docs`: `pip install great-docs` (or run via `pipx`/`uvx`).',
-              '- **Auth:** run `gh auth login` then add `--use-gh`, or set `GITHUB_TOKEN` (needs *Actions: read*).',
-              '- **Jump to a page:** add `--path reference/index.html`.',
-              '- **Latest vs exact:** `--pr <n>` grabs the newest build; `--run <id>` pins this one.',
-              '- **Re-download:** `--refresh` ignores the local cache.',
-              '',
-              '</details>',
-            ].join('\n');
-
-            const { owner, repo } = context.repo;
-            const issue_number = context.issue.number;
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner, repo, issue_number, per_page: 100,
-            });
-            const existing = comments.find((c) => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
-            }
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/great_docs/cli.py
+++ b/great_docs/cli.py
@@ -591,12 +591,71 @@ def config(project_path: str | None, force: bool) -> None:
         sys.exit(1)
 
 
+@click.group(cls=OrderedGroup)
+def ci() -> None:
+    """Helpers meant to run inside CI (GitHub Actions).
+
+    These emit the "preview this build locally" hints that let reviewers open a
+    pull request's docs without a preview host: a workflow log notice and a
+    sticky PR comment, both pointing at 'great-docs preview'.
+
+    \b
+    Examples:
+      great-docs ci notice --run "$GITHUB_RUN_ID" --pr 302
+      great-docs ci pr-comment --run "$GITHUB_RUN_ID" --pr 302
+    """
+
+
+@click.command(name="pr-comment")
+@click.option(
+    "--run", "run_id", type=int, required=True, help="Workflow run id that built the site."
+)
+@click.option("--pr", type=int, required=True, help="Pull request number to comment on.")
+@click.option(
+    "--repo",
+    default=None,
+    help="GitHub repo as 'owner/repo' (default: $GITHUB_REPOSITORY, then git remote).",
+)
+def ci_pr_comment(run_id: int, pr: int, repo: str | None) -> None:
+    """Post or refresh a sticky PR comment with the local-preview command.
+
+    Reads the token from GITHUB_TOKEN / GH_TOKEN and needs 'pull-requests: write'.
+    """
+    from ._ci import post_preview_comment
+    from ._pr_preview import PreviewError
+
+    try:
+        action, repo_slug = post_preview_comment(run_id=run_id, pr=pr, repo_override=repo)
+        click.echo(f"✓ {action.capitalize()} preview comment on {repo_slug}#{pr}")
+    except PreviewError as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+
+@click.command(name="notice")
+@click.option(
+    "--run", "run_id", type=int, required=True, help="Workflow run id that built the site."
+)
+@click.option("--pr", type=int, default=None, help="Pull request number (adds the --pr hint).")
+def ci_notice(run_id: int, pr: int | None) -> None:
+    """Print a workflow log notice with the local-preview command."""
+    from ._ci import render_notice_lines
+
+    for line in render_notice_lines(run_id, pr):
+        click.echo(line)
+
+
+ci.add_command(ci_pr_comment)
+ci.add_command(ci_notice)
+
+
 # Register commands in the desired order
 cli.add_command(init)
 cli.add_command(build)
 cli.add_command(preview)
 cli.add_command(uninstall)
 cli.add_command(config)
+cli.add_command(ci)
 
 
 @click.command()

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -1,0 +1,193 @@
+"""Tests for the `great-docs ci` helpers (log notice + sticky PR comment)."""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from great_docs import _ci
+from great_docs._pr_preview import PreviewError
+from great_docs.cli import cli
+
+# ---------------------------------------------------------------------------
+# Message rendering
+# ---------------------------------------------------------------------------
+
+
+def test_render_preview_comment_structure():
+    body = _ci.render_preview_comment(123, 302)
+    assert body.startswith(_ci.PREVIEW_COMMENT_MARKER)
+    assert "great-docs preview --run 123" in body
+    assert "great-docs preview --pr 302" in body
+    assert "<details>" in body and "</details>" in body
+    assert "<summary>Auth &amp; tips</summary>" in body
+
+
+def test_render_notice_lines_with_pr():
+    lines = _ci.render_notice_lines(123, 302)
+    assert lines[0].startswith("::notice title=Preview these docs locally::")
+    joined = "\n".join(lines)
+    assert "great-docs preview --run 123" in joined
+    assert "great-docs preview --pr 302" in joined
+
+
+def test_render_notice_lines_without_pr():
+    joined = "\n".join(_ci.render_notice_lines(123, None))
+    assert "great-docs preview --run 123" in joined
+    assert "--pr" not in joined
+
+
+# ---------------------------------------------------------------------------
+# Repo / token resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_ci_repo_override():
+    assert _ci.resolve_ci_repo("posit-dev/great-docs") == ("posit-dev", "great-docs")
+
+
+def test_resolve_ci_repo_from_env(monkeypatch):
+    monkeypatch.setenv("GITHUB_REPOSITORY", "posit-dev/great-docs")
+    assert _ci.resolve_ci_repo(None) == ("posit-dev", "great-docs")
+
+
+def test_github_token_missing_raises(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    with pytest.raises(PreviewError, match="GITHUB_TOKEN"):
+        _ci._github_token()
+
+
+# ---------------------------------------------------------------------------
+# Sticky comment upsert (mocked requests)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, status_code=200, payload=None, links=None):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else []
+        self.links = links or {}
+
+    def json(self):
+        return self._payload
+
+
+def test_upsert_creates_when_absent(monkeypatch):
+    calls = {}
+
+    def fake_get(url, headers=None, timeout=None):
+        return _FakeResp(200, payload=[{"id": 1, "body": "unrelated"}])
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        calls["post"] = (url, json)
+        return _FakeResp(201)
+
+    def fake_patch(url, headers=None, json=None, timeout=None):
+        calls["patch"] = True
+        return _FakeResp(200)
+
+    import requests
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(requests, "patch", fake_patch)
+
+    action = _ci.upsert_pr_comment("o", "r", 302, "hello", "tok")
+    assert action == "created"
+    assert "post" in calls and "patch" not in calls
+    assert "/issues/302/comments" in calls["post"][0]
+
+
+def test_upsert_updates_when_present(monkeypatch):
+    calls = {}
+    existing = [{"id": 99, "body": f"prev {_ci.PREVIEW_COMMENT_MARKER}"}]
+
+    def fake_get(url, headers=None, timeout=None):
+        return _FakeResp(200, payload=existing)
+
+    def fake_patch(url, headers=None, json=None, timeout=None):
+        calls["patch"] = url
+        return _FakeResp(200)
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        calls["post"] = url
+        return _FakeResp(201)
+
+    import requests
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    monkeypatch.setattr(requests, "patch", fake_patch)
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    action = _ci.upsert_pr_comment("o", "r", 302, "hello", "tok")
+    assert action == "updated"
+    assert "post" not in calls
+    assert "/issues/comments/99" in calls["patch"]
+
+
+def test_upsert_follows_pagination(monkeypatch):
+    # First page has no marker but a next link; second page has the marker.
+    page1 = _FakeResp(
+        200,
+        payload=[{"id": 1, "body": "nope"}],
+        links={"next": {"url": "https://api.github.com/next-page"}},
+    )
+    page2 = _FakeResp(200, payload=[{"id": 42, "body": _ci.PREVIEW_COMMENT_MARKER}])
+    responses = iter([page1, page2])
+    patched = {}
+
+    def fake_get(url, headers=None, timeout=None):
+        return next(responses)
+
+    def fake_patch(url, headers=None, json=None, timeout=None):
+        patched["url"] = url
+        return _FakeResp(200)
+
+    import requests
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    monkeypatch.setattr(requests, "patch", fake_patch)
+
+    action = _ci.upsert_pr_comment("o", "r", 302, "hello", "tok")
+    assert action == "updated"
+    assert "/issues/comments/42" in patched["url"]
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring
+# ---------------------------------------------------------------------------
+
+
+def test_cli_ci_notice_outputs_commands():
+    result = CliRunner().invoke(cli, ["ci", "notice", "--run", "123", "--pr", "302"])
+    assert result.exit_code == 0
+    assert "::notice" in result.output
+    assert "great-docs preview --run 123" in result.output
+    assert "great-docs preview --pr 302" in result.output
+
+
+def test_cli_ci_pr_comment_dispatch(monkeypatch):
+    captured = {}
+
+    def fake_post(run_id, pr, repo_override=None):
+        captured.update(run_id=run_id, pr=pr, repo=repo_override)
+        return "created", "posit-dev/great-docs"
+
+    monkeypatch.setattr(_ci, "post_preview_comment", fake_post)
+    result = CliRunner().invoke(
+        cli, ["ci", "pr-comment", "--run", "123", "--pr", "302", "--repo", "posit-dev/great-docs"]
+    )
+    assert result.exit_code == 0, result.output
+    assert captured == {"run_id": 123, "pr": 302, "repo": "posit-dev/great-docs"}
+    assert "Created preview comment on posit-dev/great-docs#302" in result.output
+
+
+def test_cli_ci_pr_comment_error_exits(monkeypatch):
+    def boom(run_id, pr, repo_override=None):
+        raise PreviewError("no token")
+
+    monkeypatch.setattr(_ci, "post_preview_comment", boom)
+    result = CliRunner().invoke(cli, ["ci", "pr-comment", "--run", "1", "--pr", "2"])
+    assert result.exit_code == 1
+    assert "no token" in result.output

--- a/user_guide/13-building.qmd
+++ b/user_guide/13-building.qmd
@@ -271,17 +271,22 @@ If you scaffolded your CI with [`great-docs setup-github-pages`](14-deployment.q
 already wired up: on every pull request the workflow prints a log notice **and** posts a
 sticky PR comment with the exact `great-docs preview` command, pinned to that run.
 
-To add it to a hand-maintained workflow, print the command after uploading the artifact. Pin
-it to the run that produced the build with `--run ${{ github.run_id }}` (rather than `--pr`,
-which always resolves to the newest build) so a reviewer reproduces exactly the build they're
-looking at:
+To add it to a hand-maintained workflow, use the `great-docs ci` helpers. `ci notice` prints
+a log annotation; `ci pr-comment` posts (and keeps updated) a sticky comment on the pull
+request. Both pin the command to the run that produced the build with `--run`, so a reviewer
+reproduces exactly the build they're looking at:
 
 ```{.yaml filename=".github/workflows/docs.yml"}
+      # In the build job (great-docs is already installed):
       - name: How to preview this build locally
         if: github.event_name == 'pull_request'
-        run: |
-          echo "::notice title=Preview these docs locally::great-docs preview --run ${{ github.run_id }}"
-          echo "  great-docs preview --run ${{ github.run_id }}"
+        run: great-docs ci notice --run ${{ github.run_id }} --pr ${{ github.event.number }}
+
+      # In a separate job with 'permissions: pull-requests: write':
+      - name: Post preview instructions to the PR
+        run: pipx run great-docs ci pr-comment --run ${{ github.run_id }} --pr ${{ github.event.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 :::
 


### PR DESCRIPTION
This PR introduces a new `great-docs ci` command group that centralizes and standardizes the logic for posting "preview this build locally" instructions in CI environments (specifically GHA). It replaces the previous inline shell and JavaScript implementations in workflow YAML files with reusable (and tested) Python code. The new approach ensures consistent messaging between workflow log notices and sticky PR comments. And it makes it easier to maintain and test these features.
