### PR TITLE
Fix documenting attributes when dynamic=True

### DIFF
--- a/great_docs/_apiref/introspect.py
+++ b/great_docs/_apiref/introspect.py
@@ -16,6 +16,7 @@ from copy import copy
 from dataclasses import dataclass
 from types import ModuleType
 from typing import TYPE_CHECKING, Callable, cast
+from weakref import WeakKeyDictionary
 
 import griffe as gf
 
@@ -25,6 +26,10 @@ if TYPE_CHECKING:
 # Parser defaults ==============================================================
 
 DEFAULT_OPTIONS: dict[str, dict[str, object]] = {}
+
+_AUTHORED_DOCSTRINGS: WeakKeyDictionary[gf.GriffeLoader, dict[str, gf.Docstring]] = (
+    WeakKeyDictionary()
+)
 
 
 def get_parser_defaults(name: str) -> dict[str, object]:
@@ -717,7 +722,9 @@ def _load_documenting_object(
             own = _reexpose_class(home.obj, located, loader)
             return _Documented(own, located.access_path, authored)
 
-    return _Documented(get_object(located.access_path, loader=loader), located.access_path)
+    obj = get_object(located.access_path, loader=loader)
+    override = authored if inspect.isroutine(located.value) else None
+    return _Documented(obj, located.access_path, override)
 
 
 def _reexpose_class(
@@ -801,6 +808,10 @@ def _authored_docstring(
     """
     Read the docstring the author wrote under the assignment at `access_path`
 
+    The first read is remembered per loader, so the docstring outlives the
+    attribute it was read from: documenting the name replaces that attribute
+    with a function or class node, which no longer carries it.
+
     Parameters
     ----------
     access_path :
@@ -815,6 +826,11 @@ def _authored_docstring(
         attribute, carries a bare assignment, or is absent from the static
         model.
     """
+    if loader is not None:
+        authored = _AUTHORED_DOCSTRINGS.get(loader, {}).get(access_path)
+        if authored is not None:
+            return authored
+
     try:
         obj = get_object(access_path, loader=loader)
     except (KeyError, ModuleNotFoundError, ImportError):
@@ -823,7 +839,10 @@ def _authored_docstring(
     if not isinstance(obj, (gf.Attribute, gf.TypeAlias)):
         return None
 
-    return obj.docstring
+    authored = obj.docstring
+    if authored is not None and loader is not None:
+        _AUTHORED_DOCSTRINGS.setdefault(loader, {})[access_path] = authored
+    return authored
 
 
 def _alias_into_parent(

--- a/great_docs/_apiref/introspect.py
+++ b/great_docs/_apiref/introspect.py
@@ -564,9 +564,13 @@ def dynamic_alias(
 
     documented = _load_documenting_object(located, loader)
     replace_docstring(documented.obj, located.value)
-    if documented.override is not None:
-        documented.obj.docstring = documented.override
     obj = _member_now_at(documented.obj)
+    if documented.override is not None:
+        obj.docstring = _clone_docstring(
+            documented.override,
+            documented.override.value,
+            cast("gf.Object", obj),
+        )
 
     if _same_path(documented.path, located.access_path):
         return obj

--- a/great_docs/_apiref/introspect.py
+++ b/great_docs/_apiref/introspect.py
@@ -9,11 +9,10 @@ mode).
 
 from __future__ import annotations
 
-import enum
 import importlib
 import inspect
-import sys
 import warnings
+from copy import copy
 from dataclasses import dataclass
 from types import ModuleType
 from typing import TYPE_CHECKING, Callable, cast
@@ -22,11 +21,6 @@ import griffe as gf
 
 if TYPE_CHECKING:
     from griffe import DocstringOptions
-
-if sys.version_info >= (3, 12):
-    from typing import TypeAliasType
-else:  # Python 3.11 has no PEP 695 runtime support
-    TypeAliasType = None
 
 # Parser defaults ==============================================================
 
@@ -248,8 +242,10 @@ def replace_docstring(obj: gf.Object | gf.Alias, runtime_obj: object = None) -> 
     """
     Replace the griffe object's docstring in place with the imported runtime docstring
 
-    Callable attributes (the `method = some_function` pattern) are also
-    promoted to functions so they render with a signature.
+    An attribute holding a function (the `method = some_function` pattern) is
+    also promoted to one, so it renders with a signature. What stays an
+    attribute keeps the docstring written beneath it, since a runtime `__doc__`
+    reached through a name usually belongs to the value rather than the name.
 
     Parameters
     ----------
@@ -271,38 +267,29 @@ def replace_docstring(obj: gf.Object | gf.Alias, runtime_obj: object = None) -> 
         if runtime_obj is None:
             return
 
-    # A PEP 695 alias inherits `__doc__` from the `TypeAliasType` class, so the
-    # runtime docstring is CPython's prose about the `type` statement rather
-    # than the author's. Keep griffe's statically-parsed docstring; when there
-    # is none the alias correctly shows no docstring rather than boilerplate.
-    if TypeAliasType is not None and isinstance(runtime_obj, TypeAliasType):
+    doc: str | None = getattr(runtime_obj, "__doc__", None)
+
+    # A name holding a function is a function, whatever griffe's static analysis
+    # made of the assignment, so `method = some_function` renders with a
+    # signature. The kind follows the value alone; an absent runtime docstring is
+    # nothing for it to depend on.
+    if isinstance(obj, gf.Attribute) and inspect.isroutine(runtime_obj) and obj.parent is not None:
+        # A docstring under the assignment is the author writing about the name,
+        # so it outranks the function's own even though the promotion stands.
+        authored = obj.docstring.value if obj.docstring is not None else doc
+        _promote_callable_attribute(obj, runtime_obj, authored)
         return
 
-    if getattr(runtime_obj, "__doc__", None) is None:
+    if doc is None:
         return
 
-    doc: str = runtime_obj.__doc__  # type: ignore[assignment]
-
-    # Enum members inherit __doc__ from the enum class. Skip the
-    # replacement so griffe's statically-parsed per-member docstring
-    # (if any) is preserved; when there is none the member correctly
-    # shows no docstring rather than the class-level one.
-    if isinstance(runtime_obj, enum.Enum):
-        parent_cls = type(runtime_obj)
-        if doc == parent_cls.__doc__:
-            return
-
-    # Reclassify callable attributes as functions.
-    # When a class uses `method = some_function` pattern, griffe sees it as
-    # Kind.ATTRIBUTE. If the runtime value is actually a function, promote it
-    # to a Function object so it gets proper function-style rendering.
-    if (
-        isinstance(obj, gf.Attribute)
-        and callable(runtime_obj)
-        and hasattr(runtime_obj, "__code__")
-        and obj.parent is not None
-    ):
-        _promote_callable_attribute(obj, runtime_obj, doc)
+    # Python discards a variable's docstring at runtime, so an attribute's
+    # runtime `__doc__` is its value's and never the author's. Keep griffe's
+    # statically-parsed docstring unless the value owns a `__doc__` of its own,
+    # which is a deliberate assignment and so documents the attribute. This also
+    # covers a PEP 695 alias (whose `__doc__` is CPython's prose about the
+    # `type` statement) and an enum member (whose `__doc__` is its class's).
+    if isinstance(obj, (gf.Attribute, gf.TypeAlias)) and not _owns_its_docstring(runtime_obj):
         return
 
     old = obj.docstring
@@ -353,7 +340,7 @@ def _locate_runtime_object(obj: gf.Object) -> object | None:
         return None
 
 
-def _promote_callable_attribute(obj: gf.Attribute, f: object, doc: str) -> None:
+def _promote_callable_attribute(obj: gf.Attribute, f: object, doc: str | None) -> None:
     """
     Re-register the attribute on its parent as a `gf.Function`
 
@@ -368,7 +355,8 @@ def _promote_callable_attribute(obj: gf.Attribute, f: object, doc: str) -> None:
         The runtime callable the attribute holds. Its signature is copied when
         `inspect` can read it, and omitted when it cannot.
     doc :
-        Docstring for the replacement function.
+        Docstring for the replacement function, or `None` to leave it
+        undocumented.
     """
     assert obj.parent is not None
 
@@ -397,7 +385,8 @@ def _promote_callable_attribute(obj: gf.Attribute, f: object, doc: str) -> None:
     except (ValueError, TypeError):
         pass
 
-    func_obj.docstring = _clone_docstring(obj.docstring, doc, func_obj)
+    if doc is not None:
+        func_obj.docstring = _clone_docstring(obj.docstring, doc, func_obj)
     obj.parent.set_member(obj.name, func_obj)
 
 
@@ -432,6 +421,38 @@ def _clone_docstring(
     )
 
 
+def _owns_its_docstring(value: object) -> bool:
+    """
+    Whether `value` carries a `__doc__` of its own rather than one inherited from its type
+
+    A class and a module both keep `__doc__` in their own `__dict__`, but it
+    documents them — not the name they were assigned to — so both are excluded.
+
+    Parameters
+    ----------
+    value :
+        The runtime value held by an attribute.
+
+    Returns
+    -------
+    :
+        True when the docstring belongs to this value alone, which is the only
+        case where it documents the attribute it was assigned to.
+    """
+    if isinstance(value, (type, ModuleType)):
+        return False
+
+    # `object.__getattribute__` rather than `getattr` so that a value which
+    # forwards unknown attributes elsewhere cannot answer for its target: a
+    # `types.GenericAlias` such as `list[int]` hands `__dict__` to `list`, and a
+    # proxy hands it to whatever it wraps.
+    try:
+        own = object.__getattribute__(value, "__dict__")
+    except AttributeError:
+        return False
+    return "__doc__" in own
+
+
 @dataclass(frozen=True)
 class _LocatedAttr:
     """
@@ -456,10 +477,16 @@ class _DeclarationOnly:
 
 @dataclass(frozen=True)
 class _Documented:
-    """The griffe object documenting an attribute, and the path it was loaded from"""
+    """
+    The griffe object documenting an attribute, and the path it was loaded from
+
+    `override` is the docstring written under the assignment when that is newer
+    than the one the object came with, and `None` when the object's own stands.
+    """
 
     obj: gf.Object | gf.Alias
     path: str
+    override: gf.Docstring | None = None
 
 
 def _same_path(one: str, other: str) -> bool:
@@ -477,6 +504,29 @@ def _same_path(one: str, other: str) -> bool:
         True when both name the same object.
     """
     return one.replace(":", ".") == other.replace(":", ".")
+
+
+def _member_now_at(obj: gf.Object | gf.Alias) -> gf.Object | gf.Alias:
+    """
+    The node the parent currently holds under `obj`'s name
+
+    `replace_docstring` promotes a callable attribute by registering a
+    `gf.Function` in its place, which leaves the attribute it was handed stale.
+    Only an attribute can be replaced that way, so nothing else is re-read.
+
+    Parameters
+    ----------
+    obj :
+        The node handed to `replace_docstring`.
+
+    Returns
+    -------
+    :
+        The replacement when there is one, otherwise `obj` itself.
+    """
+    if not isinstance(obj, gf.Attribute) or obj.parent is None:
+        return obj
+    return obj.parent.members.get(obj.name, obj)
 
 
 def dynamic_alias(
@@ -509,10 +559,13 @@ def dynamic_alias(
 
     documented = _load_documenting_object(located, loader)
     replace_docstring(documented.obj, located.value)
+    if documented.override is not None:
+        documented.obj.docstring = documented.override
+    obj = _member_now_at(documented.obj)
 
     if _same_path(documented.path, located.access_path):
-        return documented.obj
-    return _alias_into_parent(located, documented.obj, loader)
+        return obj
+    return _alias_into_parent(located, obj, loader)
 
 
 def _locate_runtime_attr(
@@ -628,11 +681,13 @@ def _load_documenting_object(
     """
     Load the griffe object that documents `located`
 
-    Prefers the attribute's canonical home, falling back to the path it was
-    accessed by. The fallback covers both an attribute that cannot report a
-    home and one whose `__module__` names a module that cannot be imported,
-    typical of PyO3 classes whose Rust `#[pyclass]` lacks `module = "..."` so
-    `__module__` defaults to `"builtins"`.
+    A class or a function is documented by the value's own node, wherever it is
+    defined, so `Widget = _W` keeps the class's members. A docstring written
+    under the assignment earns the name a node of its own instead — a class
+    sharing the original's members, a function rebuilt from the runtime
+    signature — which is what keeps what an author wrote about one name off the
+    other's page. Every other value, an instance or a module or a typing
+    construct, is documented as the attribute it was found at.
 
     Parameters
     ----------
@@ -644,19 +699,131 @@ def _load_documenting_object(
     Returns
     -------
     :
-        The node that documents the attribute, and the path it was read from.
-        Callers compare that path against the access path to decide whether the
-        attribute still needs re-exposing.
+        The node that documents the attribute, the path it was read from, and
+        the docstring to override its own with. Callers compare that path
+        against the access path to decide whether the attribute still needs
+        re-exposing.
     """
-    if located.canonical_path is not None:
-        try:
-            obj = get_object(located.canonical_path, loader=loader)
-        except (KeyError, ModuleNotFoundError, ImportError):
-            pass
-        else:
-            return _Documented(obj, located.canonical_path)
+    authored = _authored_docstring(located.access_path, loader)
+
+    # A documented function is left to the access path, where `replace_docstring`
+    # rebuilds it from the runtime signature. A class is copied here instead,
+    # since its members cannot be rebuilt from the runtime object.
+    if isinstance(located.value, type) or (inspect.isroutine(located.value) and authored is None):
+        home = _canonical_home(located, loader)
+        if home is not None:
+            if authored is None:
+                return home
+            own = _reexpose_class(home.obj, located, loader)
+            return _Documented(own, located.access_path, authored)
 
     return _Documented(get_object(located.access_path, loader=loader), located.access_path)
+
+
+def _reexpose_class(
+    obj: gf.Object | gf.Alias,
+    located: _LocatedAttr,
+    loader: gf.GriffeLoader | None,
+) -> gf.Object:
+    """
+    Register a second node for `obj`'s class under the name it was accessed by
+
+    The two nodes share their members, so the re-exported name documents the
+    same methods; each carries its own docstring, so what an author wrote about
+    one name never shows up on the other's page.
+
+    Parameters
+    ----------
+    obj :
+        The class as its defining module models it.
+    located :
+        The attribute the class was reached as. Its name becomes the new node's.
+    loader :
+        Loader to read the accessing module or class through.
+
+    Returns
+    -------
+    :
+        The new node, already a member of the module or class the name was
+        reached through.
+    """
+    own = copy(resolve_alias(obj))
+    own.name = located.name
+    # Only the definition's own re-exports point at the definition.
+    own.aliases = {}
+
+    parent = _access_parent(located, loader)
+    if isinstance(parent, (gf.Module, gf.Class)):
+        parent.set_member(located.name, own)
+    return own
+
+
+def _canonical_home(
+    located: _LocatedAttr,
+    loader: gf.GriffeLoader | None,
+) -> _Documented | None:
+    """
+    Load the griffe object at the path `located` reports it was defined at
+
+    `None` when that path is unreadable, which covers both a value that cannot
+    report a home and one whose `__module__` names a module that cannot be
+    imported, typical of PyO3 classes whose Rust `#[pyclass]` lacks
+    `module = "..."` so `__module__` defaults to `"builtins"`.
+
+    Parameters
+    ----------
+    located :
+        The attribute whose reported home is wanted.
+    loader :
+        Loader to read the static model through.
+
+    Returns
+    -------
+    :
+        The node at the canonical path and that path, or `None` when nothing
+        can be read there.
+    """
+    if located.canonical_path is None:
+        return None
+
+    try:
+        obj = get_object(located.canonical_path, loader=loader)
+    except (KeyError, ModuleNotFoundError, ImportError):
+        return None
+
+    return _Documented(obj, located.canonical_path)
+
+
+def _authored_docstring(
+    access_path: str,
+    loader: gf.GriffeLoader | None,
+) -> gf.Docstring | None:
+    """
+    Read the docstring the author wrote under the assignment at `access_path`
+
+    Parameters
+    ----------
+    access_path :
+        Path the attribute was reached by.
+    loader :
+        Loader to read the static model through.
+
+    Returns
+    -------
+    :
+        The docstring, or `None` when the path names something other than an
+        attribute, carries a bare assignment, or is absent from the static
+        model.
+    """
+    try:
+        obj = get_object(access_path, loader=loader)
+    except (KeyError, ModuleNotFoundError, ImportError):
+        return None
+
+    if not isinstance(obj, (gf.Attribute, gf.TypeAlias)):
+        return None
+
+    return obj.docstring
 
 
 def _alias_into_parent(
@@ -687,6 +854,32 @@ def _alias_into_parent(
         class it was reached through. It is left unparented when the access path
         names something that cannot hold members.
     """
+    parent = _access_parent(located, loader)
+    if isinstance(parent, (gf.Module, gf.Class, gf.Alias)):
+        return gf.Alias(located.name, obj, parent=parent)
+    return gf.Alias(located.name, obj)
+
+
+def _access_parent(
+    located: _LocatedAttr,
+    loader: gf.GriffeLoader | None,
+) -> gf.Object | gf.Alias:
+    """
+    Load the module or class that `located` was reached through
+
+    Parameters
+    ----------
+    located :
+        The attribute as it was reached, whose access path names the parent.
+    loader :
+        Loader to read the parent through.
+
+    Returns
+    -------
+    :
+        The node one level up the access path, which is not necessarily
+        something that can hold members.
+    """
     module_path, object_path = _split_path(located.access_path)
 
     if object_path is None:
@@ -696,10 +889,7 @@ def _alias_into_parent(
     else:
         parent_path = module_path
 
-    parent = get_object(parent_path, loader=loader, dynamic=True)
-    if isinstance(parent, (gf.Module, gf.Class, gf.Alias)):
-        return gf.Alias(located.name, obj, parent=parent)
-    return gf.Alias(located.name, obj)
+    return get_object(parent_path, loader=loader, dynamic=True)
 
 
 def _canonical_path(current_part: object, qualname: str) -> str | None:

--- a/tests/renderer/test_type_alias_introspection.py
+++ b/tests/renderer/test_type_alias_introspection.py
@@ -202,17 +202,8 @@ def test_undocumented_alias_gets_no_boilerplate(monkeypatch, tmp_path):
     assert obj.docstring is None or BOILERPLATE not in obj.docstring.value
 
 
-@requires_pep695
-@pytest.mark.xfail(
-    reason=(
-        "Pre-existing bug unrelated to PEP 695: replace_docstring overwrites the "
-        "statically-parsed docstring of any attribute whose runtime value carries a "
-        "__doc__. Here `Contract: TypeAlias = int` picks up int.__doc__."
-    ),
-    strict=True,
-)
-def test_legacy_spelling_docstring_overwritten(monkeypatch, tmp_path):
-    """Pins the pre-existing overwrite bug for `X: TypeAlias = ...` until it is fixed"""
+def test_legacy_spelling_keeps_the_author_docstring(monkeypatch, tmp_path):
+    """`X: TypeAlias = ...` keeps its own docstring rather than its value's"""
     from great_docs._apiref.introspect import get_object, replace_docstring
 
     root = _write_package(
@@ -235,6 +226,416 @@ def test_legacy_spelling_docstring_overwritten(monkeypatch, tmp_path):
 
     assert obj.docstring is not None
     assert obj.docstring.value == "Legacy docstring."
+
+
+def test_subscripted_generic_keeps_the_author_docstring(monkeypatch, tmp_path):
+    """`X: TypeAlias = list[int]` keeps its own docstring rather than `list`'s
+
+    A `types.GenericAlias` forwards unknown attributes to its origin, so asking
+    it for `__dict__` answers with `list.__dict__` — which does carry a
+    `__doc__`. Both load paths must see through that.
+    """
+    from great_docs._apiref.introspect import get_object, replace_docstring
+
+    root = _write_package(
+        tmp_path,
+        "gdta_subscripted",
+        {
+            "__init__.py": '''
+                """Package."""
+                from typing import TypeAlias
+
+                Row: TypeAlias = list[int]
+                """One row of counts."""
+
+                Table: TypeAlias = dict[str, int]
+                """Counts by name."""
+            '''
+        },
+    )
+    _install(monkeypatch, root)
+
+    static = get_object("gdta_subscripted:Row")
+    replace_docstring(static)
+    assert static.docstring is not None
+    assert static.docstring.value == "One row of counts."
+
+    dynamic = get_object("gdta_subscripted:Row", dynamic=True)
+    assert dynamic.docstring is not None
+    assert dynamic.docstring.value == "One row of counts."
+
+    mapping = get_object("gdta_subscripted:Table", dynamic=True)
+    assert mapping.docstring is not None
+    assert mapping.docstring.value == "Counts by name."
+
+
+def test_annotated_scalar_keeps_its_own_docstring(monkeypatch, tmp_path):
+    """`count: int = 1` documents the count, not `int`'s constructor
+
+    Only dynamic loading can get this wrong: reaching `count` at run time yields
+    the value `1`, whose `__doc__` is `int`'s, while the static model reads the
+    docstring under the declaration and nothing else.
+    """
+    from great_docs._apiref.introspect import get_object
+
+    root = _write_package(
+        tmp_path,
+        "gdta_annotated_scalar",
+        {
+            "__init__.py": '''
+                """Package."""
+
+                count: int = 1
+                """The count"""
+            '''
+        },
+    )
+    _install(monkeypatch, root)
+
+    obj = get_object("gdta_annotated_scalar:count", dynamic=True)
+
+    assert obj.kind.value == "attribute"
+    assert obj.docstring is not None
+    assert obj.docstring.value == "The count"
+
+
+def test_attribute_holding_a_module_keeps_the_author_docstring(monkeypatch, tmp_path):
+    """`parser = json` documented by its author keeps that docstring, not the module's"""
+    from great_docs._apiref.introspect import get_object, replace_docstring
+
+    root = _write_package(
+        tmp_path,
+        "gdta_module_value",
+        {
+            "__init__.py": '''
+                """Package."""
+                import json
+
+                parser = json
+                """The JSON parser we standardised on."""
+            '''
+        },
+    )
+    _install(monkeypatch, root)
+
+    static = get_object("gdta_module_value:parser")
+    replace_docstring(static)
+    assert static.docstring is not None
+    assert static.docstring.value == "The JSON parser we standardised on."
+
+    dynamic = get_object("gdta_module_value:parser", dynamic=True)
+    assert dynamic.docstring is not None
+    assert dynamic.docstring.value == "The JSON parser we standardised on."
+
+
+def test_documented_callable_alias_is_one_consistent_node(monkeypatch, tmp_path):
+    """A documented `g = f` renders as a function carrying the author's docstring
+
+    The attribute is still promoted so it gets a signature, but the docstring
+    the author wrote under the assignment outranks `f`'s own, and the parent's
+    member is the promoted function rather than the attribute it replaced.
+    """
+    from great_docs._apiref.introspect import get_object
+
+    root = _write_package(
+        tmp_path,
+        "gdta_callable_alias",
+        {
+            "__init__.py": '''
+                """Package."""
+
+
+                def f(x, y=1):
+                    """The real f."""
+
+
+                g = f
+                """The g alias."""
+            '''
+        },
+    )
+    _install(monkeypatch, root)
+
+    obj = get_object("gdta_callable_alias:g", dynamic=True)
+
+    assert obj.kind.value == "function"
+    assert obj.docstring is not None
+    assert obj.docstring.value == "The g alias."
+    assert [p.name for p in obj.parameters] == ["x", "y"]
+
+    # The promotion re-registers the member on the parent; returning the
+    # attribute it replaced would leave the module listing disagreeing with the
+    # per-object page.
+    assert obj.parent is not None
+    assert obj.parent.members["g"] is obj
+
+
+def test_documented_alias_to_an_undocumented_function_is_still_promoted(monkeypatch, tmp_path):
+    """`g = f` renders as a function even when `f` carries no docstring of its own
+
+    The kind follows the value, so an absent runtime docstring is nothing for
+    the promotion to depend on.
+    """
+    from great_docs._apiref.introspect import get_object
+
+    root = _write_package(
+        tmp_path,
+        "gdta_undocumented_callable",
+        {
+            "__init__.py": '''
+                """Package."""
+
+
+                def f(x, y=1): ...
+
+
+                g = f
+                """The g alias."""
+            '''
+        },
+    )
+    _install(monkeypatch, root)
+
+    obj = get_object("gdta_undocumented_callable:g", dynamic=True)
+
+    assert obj.kind.value == "function"
+    assert [p.name for p in obj.parameters] == ["x", "y"]
+    assert obj.docstring is not None
+    assert obj.docstring.value == "The g alias."
+
+
+def test_promoting_an_alias_leaves_the_function_it_points_at_alone(monkeypatch, tmp_path):
+    """Documenting `g = f` must not rewrite what `f`'s own page says
+
+    The promotion registers a separate node for `g`, which is what keeps the
+    author's words about one name off the other's page.
+    """
+    from great_docs._apiref.introspect import get_object, make_loader
+
+    root = _write_package(
+        tmp_path,
+        "gdta_no_docstring_leak",
+        {
+            "__init__.py": '''
+                """Package."""
+
+
+                def f(x):
+                    """The real f."""
+
+
+                g = f
+                """The g alias."""
+            '''
+        },
+    )
+    _install(monkeypatch, root)
+
+    # One loader, so both reads share the static model a leak would show up in.
+    loader = make_loader()
+    g = get_object("gdta_no_docstring_leak:g", dynamic=True, loader=loader)
+    f = get_object("gdta_no_docstring_leak:f", dynamic=True, loader=loader)
+
+    assert g.docstring is not None
+    assert g.docstring.value == "The g alias."
+    assert f.docstring is not None
+    assert f.docstring.value == "The real f."
+
+
+def test_documenting_a_reexport_leaves_the_class_it_points_at_alone(monkeypatch, tmp_path):
+    """Documenting `Widget = Thing` must not rewrite what `Thing`'s own page says
+
+    Both names are documented here, so a docstring written for one of them
+    landing on the other would make each page depend on which was read last.
+    """
+    from great_docs._apiref.introspect import get_object, make_loader
+
+    root = _write_package(
+        tmp_path,
+        "gdta_class_docstring_leak",
+        {
+            "__init__.py": '''
+                """Package."""
+
+
+                class Thing:
+                    """The implementation class."""
+
+                    def press(self):
+                        """Press it."""
+
+
+                Widget = Thing
+                """Our widget."""
+            '''
+        },
+    )
+    _install(monkeypatch, root)
+
+    # One loader, so both reads share the static model a leak would show up in.
+    loader = make_loader()
+    widget = get_object("gdta_class_docstring_leak:Widget", dynamic=True, loader=loader)
+    thing = get_object("gdta_class_docstring_leak:Thing", dynamic=True, loader=loader)
+
+    assert thing.docstring is not None
+    assert thing.docstring.value == "The implementation class."
+    assert widget.docstring is not None
+    assert widget.docstring.value == "Our widget."
+    assert "press" in widget.members
+
+
+def test_documented_class_reexport_documents_the_class(monkeypatch, tmp_path):
+    """A documented `Widget = _W` documents the class under the name and docstring given it
+
+    The value decides the kind, so the class's members survive the re-export;
+    the docstring written under the assignment is the newer of the two and wins,
+    and the name it documents is the one the reader reaches the class by.
+    """
+    from great_docs._apiref.introspect import get_object
+
+    root = _write_package(
+        tmp_path,
+        "gdta_documented_reexport",
+        {
+            "__init__.py": '''
+                """Package."""
+
+
+                class _W:
+                    """The implementation class."""
+
+                    def press(self):
+                        """Press it."""
+
+
+                Widget = _W
+                """Our widget."""
+            '''
+        },
+    )
+    _install(monkeypatch, root)
+
+    obj = get_object("gdta_documented_reexport:Widget", dynamic=True)
+
+    assert obj.kind.value == "class"
+    assert obj.canonical_path == "gdta_documented_reexport.Widget"
+    assert "press" in obj.members
+    assert obj.docstring is not None
+    assert obj.docstring.value == "Our widget."
+
+
+def test_module_level_value_that_owns_its_docstring_is_used(monkeypatch, tmp_path):
+    """A module attribute whose value sets its own `__doc__` documents that value's docstring"""
+    from great_docs._apiref.introspect import get_object, replace_docstring
+
+    root = _write_package(
+        tmp_path,
+        "gdta_owned_module",
+        {
+            "__init__.py": '''
+                """Package."""
+
+
+                class Holder:
+                    """A holder."""
+
+                    def __init__(self, doc):
+                        self.__doc__ = doc
+
+
+                setting = Holder("Set at import time.")
+                """Static docstring."""
+            '''
+        },
+    )
+    _install(monkeypatch, root)
+
+    obj = get_object("gdta_owned_module:setting")
+    replace_docstring(obj)
+
+    assert obj.docstring is not None
+    assert obj.docstring.value == "Set at import time."
+
+
+def test_class_attribute_value_that_owns_its_docstring_is_used(monkeypatch, tmp_path):
+    """A class attribute holding a plain instance with its own `__doc__` uses it"""
+    from great_docs._apiref.introspect import get_object, replace_docstring
+
+    root = _write_package(
+        tmp_path,
+        "gdta_owned_class",
+        {
+            "__init__.py": '''
+                """Package."""
+
+
+                class Holder:
+                    """A holder."""
+
+                    def __init__(self, doc):
+                        self.__doc__ = doc
+
+
+                class Client:
+                    """A client."""
+
+                    handler = Holder("Set at class-body time.")
+                    """Static docstring."""
+            '''
+        },
+    )
+    _install(monkeypatch, root)
+
+    obj = get_object("gdta_owned_class:Client.handler")
+    replace_docstring(obj)
+
+    assert obj.docstring is not None
+    assert obj.docstring.value == "Set at class-body time."
+
+
+def test_class_level_descriptor_keeps_the_static_docstring(monkeypatch, tmp_path):
+    """A descriptor's computed value must not document the attribute
+
+    `_locate_runtime_object` reaches the attribute with plain `getattr`, which
+    invokes `__get__`, so the runtime object is the computed value (an `int`
+    here) and never the descriptor. The author's docstring is the only truthful
+    source in that case.
+    """
+    from great_docs._apiref.introspect import get_object, replace_docstring
+
+    root = _write_package(
+        tmp_path,
+        "gdta_descriptor",
+        {
+            "__init__.py": '''
+                """Package."""
+
+
+                class DocProperty:
+                    """A descriptor."""
+
+                    def __init__(self, doc):
+                        self.__doc__ = doc
+
+                    def __get__(self, obj, cls=None):
+                        return 42
+
+
+                class Client:
+                    """A client."""
+
+                    retries = DocProperty("Runtime docstring.")
+                    """How many times a failed request is retried."""
+            '''
+        },
+    )
+    _install(monkeypatch, root)
+
+    obj = get_object("gdta_descriptor:Client.retries")
+    replace_docstring(obj)
+
+    assert obj.docstring is not None
+    assert obj.docstring.value == "How many times a failed request is retried."
 
 
 @requires_pep695
@@ -337,3 +738,82 @@ def test_non_alias_canonical_paths_unchanged():
 
     assert _canonical_path(len, "") == "builtins:len"
     assert _canonical_path(42, "") is None
+
+
+def test_documented_legacy_alias_is_not_swapped_for_its_value(monkeypatch, tmp_path):
+    """A documented `X: TypeAlias = ...` documents the name, not the typing object"""
+    from great_docs._apiref.introspect import get_object
+
+    root = _write_package(
+        tmp_path,
+        "gdta_swap_documented",
+        {
+            "__init__.py": '''
+                """Package."""
+                from typing import Literal, TypeAlias
+
+                Mode: TypeAlias = Literal["r", "w"]
+                """How the file is opened."""
+            '''
+        },
+    )
+    _install(monkeypatch, root)
+
+    obj = get_object("gdta_swap_documented:Mode", dynamic=True)
+
+    assert obj.canonical_path == "gdta_swap_documented.Mode"
+    assert obj.kind.value == "attribute"
+    assert obj.docstring is not None
+    assert obj.docstring.value == "How the file is opened."
+
+
+def test_annotated_alias_is_not_swapped_when_undocumented(monkeypatch, tmp_path):
+    """A typing construct is neither a class nor a function, so the name keeps documenting itself"""
+    from great_docs._apiref.introspect import get_object
+
+    root = _write_package(
+        tmp_path,
+        "gdta_swap_annotated",
+        {
+            "__init__.py": '''
+                """Package."""
+                from typing import Literal, TypeAlias
+
+                Mode: TypeAlias = Literal["r", "w"]
+            '''
+        },
+    )
+    _install(monkeypatch, root)
+
+    obj = get_object("gdta_swap_annotated:Mode", dynamic=True)
+
+    assert obj.canonical_path == "gdta_swap_annotated.Mode"
+    assert obj.kind.value == "attribute"
+    assert obj.docstring is None
+
+
+def test_bare_assignment_still_documents_its_value(monkeypatch, tmp_path):
+    """A bare `Handler = dict` documents the class, as any name holding a class does
+
+    Documented or not, a class-valued name resolves to the class; here there is
+    no docstring of the author's for it to carry over.
+    """
+    from great_docs._apiref.introspect import get_object
+
+    root = _write_package(
+        tmp_path,
+        "gdta_swap_bare",
+        {
+            "__init__.py": '''
+                """Package."""
+
+                Handler = dict
+            '''
+        },
+    )
+    _install(monkeypatch, root)
+
+    obj = get_object("gdta_swap_bare:Handler", dynamic=True)
+
+    assert obj.canonical_path == "builtins.dict"
+    assert obj.kind.value == "class"

--- a/tests/renderer/test_type_alias_introspection.py
+++ b/tests/renderer/test_type_alias_introspection.py
@@ -335,7 +335,7 @@ def test_documented_callable_alias_is_one_consistent_node(monkeypatch, tmp_path)
     the author wrote under the assignment outranks `f`'s own, and the parent's
     member is the promoted function rather than the attribute it replaced.
     """
-    from great_docs._apiref.introspect import get_object
+    from great_docs._apiref.introspect import get_object, make_loader
 
     root = _write_package(
         tmp_path,
@@ -356,12 +356,15 @@ def test_documented_callable_alias_is_one_consistent_node(monkeypatch, tmp_path)
     )
     _install(monkeypatch, root)
 
-    obj = get_object("gdta_callable_alias:g", dynamic=True)
+    loader = make_loader()
+    obj = get_object("gdta_callable_alias:g", dynamic=True, loader=loader)
+    again = get_object("gdta_callable_alias:g", dynamic=True, loader=loader)
 
-    assert obj.kind.value == "function"
-    assert obj.docstring is not None
-    assert obj.docstring.value == "The g alias."
-    assert [p.name for p in obj.parameters] == ["x", "y"]
+    for resolved in (obj, again):
+        assert resolved.kind.value == "function"
+        assert resolved.docstring is not None
+        assert resolved.docstring.value == "The g alias."
+        assert [p.name for p in resolved.parameters] == ["x", "y"]
 
     # The promotion re-registers the member on the parent; returning the
     # attribute it replaced would leave the module listing disagreeing with the
@@ -491,7 +494,7 @@ def test_documented_class_reexport_documents_the_class(monkeypatch, tmp_path):
     the docstring written under the assignment is the newer of the two and wins,
     and the name it documents is the one the reader reaches the class by.
     """
-    from great_docs._apiref.introspect import get_object
+    from great_docs._apiref.introspect import get_object, make_loader
 
     root = _write_package(
         tmp_path,
@@ -515,13 +518,16 @@ def test_documented_class_reexport_documents_the_class(monkeypatch, tmp_path):
     )
     _install(monkeypatch, root)
 
-    obj = get_object("gdta_documented_reexport:Widget", dynamic=True)
+    loader = make_loader()
+    obj = get_object("gdta_documented_reexport:Widget", dynamic=True, loader=loader)
+    again = get_object("gdta_documented_reexport:Widget", dynamic=True, loader=loader)
 
-    assert obj.kind.value == "class"
-    assert obj.canonical_path == "gdta_documented_reexport.Widget"
-    assert "press" in obj.members
-    assert obj.docstring is not None
-    assert obj.docstring.value == "Our widget."
+    for resolved in (obj, again):
+        assert resolved.kind.value == "class"
+        assert resolved.canonical_path == "gdta_documented_reexport.Widget"
+        assert "press" in resolved.members
+        assert resolved.docstring is not None
+        assert resolved.docstring.value == "Our widget."
 
 
 def test_module_level_value_that_owns_its_docstring_is_used(monkeypatch, tmp_path):

--- a/tests/renderer/test_type_alias_introspection.py
+++ b/tests/renderer/test_type_alias_introspection.py
@@ -528,6 +528,7 @@ def test_documented_class_reexport_documents_the_class(monkeypatch, tmp_path):
         assert "press" in resolved.members
         assert resolved.docstring is not None
         assert resolved.docstring.value == "Our widget."
+        assert resolved.docstring.parent is resolved
 
 
 def test_module_level_value_that_owns_its_docstring_is_used(monkeypatch, tmp_path):


### PR DESCRIPTION
This PR fixes the case where an attribute that has been dynamically loaded takes on acquires the docstring of it's value. e.g.

```python
count: int = 1
"""The count"""
```

was being rendered with `int`'a constructor signature — "int([x]) -> integer".
The static path was never affected.

It also documents a name by the kind of value it holds using the 3 rules:

  1. **The value decides the kind.** A name holding a class is documented as that class; one holding a function or method as a function, carrying the runtime signature. Everything else stays an attribute — scalars, instances, typing constructs, `functools.partial`, callable instances, and modules. Neither an annotation nor a docstring on the declaration changes the kind.
  2. **The docstring written under the assignment outranks the value's own.** Python discards a variable's docstring, so at run time only the value's is left to find — and it says nothing about the name it was assigned to.
  3. **Unless the value carries a `__doc__` of its own.** i.e. After init, the code had `self.__doc__ = ...`. So under `dynamic: true` it is the most specific description available and outranks the docstring under the declaration.

