### PR TITLE
feat: navbar ordering

### DIFF
--- a/great_docs/assets/great-docs.default.yml
+++ b/great_docs/assets/great-docs.default.yml
@@ -458,6 +458,17 @@ navbar_style: null
 #   dark: "#60a5fa"
 navbar_color: null
 
+# Explicit ordering of navbar items by their display text. Items not listed
+# are appended after the listed ones, preserving their original order.
+# : null - (default) items appear in the order they are added during build
+# : type(list) - ordered list of navbar labels, e.g.:
+# navbar_order:
+#   - User Guide
+#   - Reference
+#   - Demos
+#   - Changelog
+navbar_order: null
+
 # Content-area gradient preset (same preset names as navbar_style); adds a
 # subtle radial glow at the top of the content area.
 # : type(str) - a preset name (sets `preset`)

--- a/great_docs/config.py
+++ b/great_docs/config.py
@@ -1275,6 +1275,17 @@ class Config:
         return None
 
     @property
+    def navbar_order(self) -> list[str] | None:
+        """Explicit ordering of navbar items by their display text."""
+        try:
+            raw = self["navbar_order"]
+        except KeyError:
+            return None
+        if isinstance(raw, list) and all(isinstance(item, str) for item in raw):
+            return raw
+        return None
+
+    @property
     def content_style(self) -> dict[str, str] | None:
         """The content-area gradient config, or None when no preset is set"""
         preset = self["content_style.preset"]

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -3587,6 +3587,34 @@ class GreatDocs:
 
         self._write_quarto_yml(quarto_yml, config)
 
+    def _reorder_navbar(self, config: dict) -> None:
+        """Reorder navbar items according to `navbar_order` in config."""
+        order = self._config.navbar_order
+        if not order:
+            return
+
+        navbar = config.get("website", {}).get("navbar", {})
+        left = navbar.get("left", [])
+        if not left:
+            return
+
+        by_text: dict[str, dict] = {}
+        for item in left:
+            if isinstance(item, dict) and "text" in item:
+                by_text[item["text"]] = item
+
+        ordered: list[dict] = []
+        for label in order:
+            if label in by_text:
+                ordered.append(by_text.pop(label))
+
+        for item in left:
+            if isinstance(item, dict) and item.get("text") in by_text:
+                ordered.append(item)
+                by_text.pop(item["text"], None)
+
+        navbar["left"] = ordered
+
     def _insert_before_reference(self, navbar_items: list, link: dict) -> None:
         """Insert a link before the 'Reference' navbar item, or append."""
         for i, item in enumerate(navbar_items):
@@ -4892,7 +4920,11 @@ class GreatDocs:
         navbar = config.get("website", {}).get("navbar", {})
         left = navbar.get("left", [])
         has_ref = any(
-            isinstance(item, dict) and item.get("text") in ("Reference", "CLI Reference")
+            isinstance(item, dict)
+            and (
+                item.get("text") in ("Reference", "CLI Reference")
+                or (item.get("href") or "").startswith("reference/")
+            )
             for item in left
         )
         if not has_ref:
@@ -13069,6 +13101,9 @@ anchor-sections: true
             config["filters"].append("details")
         if "gd-lightbox" not in config["filters"]:
             config["filters"].append("gd-lightbox")
+
+        # Apply explicit navbar ordering from config (if set)
+        self._reorder_navbar(config)
 
         # Write back to file
         self._write_quarto_yml(quarto_yml, config)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1028,6 +1028,27 @@ class TestNavbarColor:
         assert cfg.navbar_color is None
 
 
+class TestNavbarOrder:
+    def test_default_none(self, tmp_project: Path):
+        assert Config(tmp_project).navbar_order is None
+
+    def test_list(self, tmp_project: Path):
+        cfg = _make_config(
+            tmp_project,
+            "navbar_order:\n  - User Guide\n  - Reference\n  - Demos\n",
+        )
+        assert cfg.navbar_order == ["User Guide", "Reference", "Demos"]
+
+    def test_non_list_returns_none(self, tmp_project: Path):
+        cfg = _make_config(tmp_project, "navbar_order: User Guide\n")
+        assert cfg.navbar_order is None
+
+    def test_non_string_items_returns_none(self, tmp_project: Path):
+        cfg = Config(tmp_project)
+        cfg._config["navbar_order"] = [1, 2, 3]
+        assert cfg.navbar_order is None
+
+
 class TestContentStyle:
     def test_default_none(self, tmp_project: Path):
         assert Config(tmp_project).content_style is None

--- a/tests/test_config_defaults.py
+++ b/tests/test_config_defaults.py
@@ -91,6 +91,7 @@ FROZEN_DEFAULT_CONFIG: dict[str, Any] = {
     "accent_color": None,
     "navbar_style": None,
     "navbar_color": None,
+    "navbar_order": None,
     "content_style": {"preset": None, "pages": "all"},
     "scale_to_fit": None,
     "scale_to_fit_min_scale": None,

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -5058,6 +5058,99 @@ def test_add_changelog_to_navbar_idempotent_double_call():
         assert len(changelog_items) == 1
 
 
+def test_reorder_navbar_applies_configured_order():
+    """Test that _reorder_navbar reorders items to match navbar_order config."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        (project_path / "great-docs.yml").write_text(
+            "navbar_order:\n"
+            "  - User Guide\n"
+            "  - Reference\n"
+            "  - Demos\n"
+            "  - Changelog\n"
+        )
+        build_dir = project_path / "great-docs"
+        build_dir.mkdir()
+        (build_dir / "_quarto.yml").write_text("")
+
+        docs = GreatDocs(project_path=tmp_dir)
+        config = {
+            "website": {
+                "navbar": {
+                    "left": [
+                        {"text": "Reference", "href": "reference/index.qmd"},
+                        {"text": "Changelog", "href": "changelog.qmd"},
+                        {"text": "User Guide", "href": "user-guide/index.qmd"},
+                        {"text": "Demos", "href": "examples/index.qmd"},
+                    ]
+                }
+            }
+        }
+
+        docs._reorder_navbar(config)
+
+        labels = [item["text"] for item in config["website"]["navbar"]["left"]]
+        assert labels == ["User Guide", "Reference", "Demos", "Changelog"]
+
+
+def test_reorder_navbar_preserves_unlisted_items():
+    """Items not in navbar_order are appended at the end."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        (project_path / "great-docs.yml").write_text(
+            "navbar_order:\n  - User Guide\n  - Reference\n"
+        )
+        build_dir = project_path / "great-docs"
+        build_dir.mkdir()
+        (build_dir / "_quarto.yml").write_text("")
+
+        docs = GreatDocs(project_path=tmp_dir)
+        config = {
+            "website": {
+                "navbar": {
+                    "left": [
+                        {"text": "Reference", "href": "reference/index.qmd"},
+                        {"text": "Changelog", "href": "changelog.qmd"},
+                        {"text": "User Guide", "href": "user-guide/index.qmd"},
+                        {"text": "Demos", "href": "examples/index.qmd"},
+                    ]
+                }
+            }
+        }
+
+        docs._reorder_navbar(config)
+
+        labels = [item["text"] for item in config["website"]["navbar"]["left"]]
+        assert labels == ["User Guide", "Reference", "Changelog", "Demos"]
+
+
+def test_reorder_navbar_noop_without_config():
+    """Without navbar_order, items stay in their original order."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        project_path = Path(tmp_dir)
+        (project_path / "great-docs.yml").write_text("")
+        build_dir = project_path / "great-docs"
+        build_dir.mkdir()
+        (build_dir / "_quarto.yml").write_text("")
+
+        docs = GreatDocs(project_path=tmp_dir)
+        config = {
+            "website": {
+                "navbar": {
+                    "left": [
+                        {"text": "Reference", "href": "reference/index.qmd"},
+                        {"text": "Changelog", "href": "changelog.qmd"},
+                    ]
+                }
+            }
+        }
+
+        docs._reorder_navbar(config)
+
+        labels = [item["text"] for item in config["website"]["navbar"]["left"]]
+        assert labels == ["Reference", "Changelog"]
+
+
 def test_changelog_config_defaults():
     """Test default changelog configuration values."""
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/user_guide/05-configuration.qmd
+++ b/user_guide/05-configuration.qmd
@@ -639,6 +639,23 @@ descriptions.
 
 See [Custom Sections](custom-sections.qmd) and [Blog](blog.qmd) for full details.
 
+## Navbar Order
+
+By default, navbar items appear in the order they are added during the build (Reference, Changelog,
+User Guide, custom sections). Use `navbar_order` to set an explicit ordering:
+
+```{.yaml filename="great-docs.yml"}
+navbar_order:
+  - User Guide
+  - Reference
+  - Demos
+  - Changelog
+```
+
+Items are matched by their display text. Any navbar items not listed are appended at the end in
+their original order. This is useful when you want a specific item (like the User Guide) to appear
+first.
+
 ## Author Information
 
 Customize author display in the landing page sidebar:
@@ -977,6 +994,14 @@ sections:
   - title: Blog
     dir: blog
     type: blog
+
+# Navbar Order
+navbar_order:
+  - User Guide
+  - Reference
+  - Examples
+  - Tutorials
+  - Changelog
 
 # API Reference Structure
 reference:


### PR DESCRIPTION
This PR introduces support for explicit ordering of navbar items in the documentation site via a new `navbar_order` configuration option. It includes updates to the configuration schema, core logic for reordering, comprehensive tests, and documentation to help users control navbar item order.