### PR TITLE
docs: add GD upgrade instructions (for maintainers) to published skill and to User Guide 

### DIFF
--- a/skills/great-docs/SKILL.md
+++ b/skills/great-docs/SKILL.md
@@ -161,6 +161,39 @@ options.
 **Step 5**: Check the site at `http://localhost:3000`. If errors
 occur, see [references/common-errors.md](references/common-errors.md).
 
+### Upgrading Great Docs
+
+```
+Task Progress:
+- [ ] Step 1: Upgrade the package
+- [ ] Step 2: Verify version
+- [ ] Step 3: Review changelog
+- [ ] Step 4: Rebuild site
+```
+
+**Step 1**: Upgrade using whichever tool manages the environment:
+
+| Tool | Command                               |
+| ---- | ------------------------------------- |
+| pip  | `pip install --upgrade great-docs`    |
+| uv   | `uv pip install --upgrade great-docs` |
+| pipx | `pipx upgrade great-docs`             |
+
+If the project declares `great-docs` in `pyproject.toml` dependencies,
+update the version constraint there and run `uv sync` instead.
+
+**Step 2**: Run `great-docs --version` and confirm it shows the
+expected version.
+
+**Step 3**: Check the [release notes](https://github.com/posit-dev/great-docs/releases)
+for breaking changes or new configuration options.
+
+**Step 4**: Run `great-docs build` to pick up pipeline, template, or
+default-config changes. **Do not re-execute user guide notebooks** —
+`great-docs build` regenerates reference pages and templates without
+running notebook code, and notebook execution can be very
+time-consuming.
+
 ### Adding content
 
 **User guide page**: Create `user_guide/NN-title.qmd` with a
@@ -280,6 +313,10 @@ annotated options. Copy it as `great-docs.yml` and customize.
    fails at step 13.
 7. **Package must be importable.** In dynamic mode, run
    `pip install -e .` before building.
+8. **Don't re-execute notebooks after upgrading.** A plain
+   `great-docs build` is enough — it regenerates reference pages and
+   templates without running notebook code. Notebook execution is
+   time-consuming and is not required for upgrades.
 
 ## Capabilities and boundaries
 

--- a/user_guide/01-installation.qmd
+++ b/user_guide/01-installation.qmd
@@ -17,7 +17,8 @@ Before installing Great Docs, ensure you have:
 
 ### Installing Quarto
 
-Great Docs uses Quarto to render documentation. Install it from [quarto.org](https://quarto.org/docs/get-started/):
+Great Docs uses Quarto to render documentation. Install it from
+[quarto.org](https://quarto.org/docs/get-started/):
 
 ::: {.panel-tabset}
 
@@ -126,6 +127,56 @@ quarto --version
 ```
 
 You should see the Great Docs help message and the Quarto version number.
+
+## Upgrading Great Docs
+
+When a new version of Great Docs is released, upgrade using the same tool you used to install it:
+
+::: {.panel-tabset}
+
+## pip
+
+```{.bash filename="Terminal"}
+pip install --upgrade great-docs
+```
+
+## uv
+
+```{.bash filename="Terminal"}
+uv pip install --upgrade great-docs
+```
+
+If Great Docs is declared in your `pyproject.toml` dependencies, update the version constraint there
+and run `uv sync` instead.
+
+## pipx
+
+```{.bash filename="Terminal"}
+pipx upgrade great-docs
+```
+
+:::
+
+### After upgrading
+
+1. **Verify the new version**
+
+   ```{.bash filename="Terminal"}
+   great-docs --version
+   ```
+
+2. **Review the changelog** — Check the
+   [release notes](https://github.com/posit-dev/great-docs/releases) for breaking changes,
+   new configuration options, or deprecated features that may affect your site.
+
+3. **Rebuild your site** — Run `great-docs build` to pick up any changes in the build pipeline,
+   templates, or default configuration.
+
+::: {.callout-tip}
+You do **not** need to re-execute user guide notebooks after upgrading. A plain `great-docs build`
+is sufficient as it regenerates reference pages and templates without re-running notebook code
+(which can be time-consuming).
+:::
 
 ## Next Steps
 


### PR DESCRIPTION
This PR adds upgrade instructions for Great Docs to both the skill documentation (`SKILL.md`) and the user guide (`01-installation.qmd`). It clarifies the recommended upgrade workflow, including which commands to use with different package managers, steps to verify the upgrade, and emphasizes that notebooks do not need to be re-executed after upgrading. These improvements make the upgrade process clearer and help users avoid unnecessary work.

Fixes: https://github.com/posit-dev/great-docs/issues/293