### PR TITLE
fix: use details callouts in MCP index page

### DIFF
--- a/great_docs/_mcp_docs.py
+++ b/great_docs/_mcp_docs.py
@@ -654,7 +654,7 @@ def _generate_mcp_index_page(
     instructions = server_info.get("instructions")
     if instructions:
         instr_title = get_translation("mcp_server_instructions", language)
-        lines.append(f"::: {{.callout-note collapse='true' title='{instr_title}'}}")
+        lines.append(f'::: {{.details summary="{instr_title}" type="note"}}')
         lines.append("")
         lines.append("```text")
         lines.append(instructions)
@@ -666,7 +666,7 @@ def _generate_mcp_index_page(
     # Completions note (if enabled)
     if has_completions:
         comp_title = get_translation("mcp_completions", language)
-        lines.append(f"::: {{.callout-tip collapse='true' title='{comp_title}'}}")
+        lines.append(f'::: {{.details summary="{comp_title}" type="tip"}}')
         lines.append("")
         lines.append(get_translation("mcp_completions_desc", language))
         lines.append("")


### PR DESCRIPTION
This PR updates the formatting of callout sections in the generated MCP index documentation to restore them to a working condition. They use the internal details disclosure machinery and thus makes these callouts more consistent with the rest of a Great Docs site. In the Great Docs site, the callouts appear near the top of this page: https://posit-dev.github.io/great-docs/reference/mcp/index.html.