### PR TITLE
Fix the duplicated site name in page titles

### DIFF
--- a/great_docs/assets/great-docs.default.yml
+++ b/great_docs/assets/great-docs.default.yml
@@ -712,7 +712,9 @@ seo:
     # Base URL (e.g. "https://example.github.io/pkg/"); auto-detected from
     # GitHub Pages when null.
     base_url: null
-  title_template: "{page_title} | {site_name}"   # supports {page_title} and {site_name}
+  # Supports {page_title} and {site_name}. Pages without their own title, such as
+  # the home page, show only the site name.
+  title_template: "{page_title} | {site_name}"
   structured_data:
     enabled: true              # Add JSON-LD to pages
     type: SoftwareSourceCode   # Schema.org type

--- a/great_docs/assets/great-docs.default.yml
+++ b/great_docs/assets/great-docs.default.yml
@@ -712,8 +712,9 @@ seo:
     # Base URL (e.g. "https://example.github.io/pkg/"); auto-detected from
     # GitHub Pages when null.
     base_url: null
-  # Supports {page_title} and {site_name}. Pages without their own title, such as
-  # the home page, show only the site name.
+  # Requires {page_title}; {site_name} is optional. Omit {site_name} to remove the
+  # site-name component from titled pages. Untitled pages, including the home
+  # page, show only the site name.
   title_template: "{page_title} | {site_name}"
   structured_data:
     enabled: true              # Add JSON-LD to pages

--- a/great_docs/assets/metadata.html
+++ b/great_docs/assets/metadata.html
@@ -1,0 +1,23 @@
+<meta charset="utf-8" />
+$if(quarto-version)$
+<meta name="generator" content="quarto-$quarto-version$" />
+$else$
+<meta name="generator" content="quarto" />
+$endif$
+
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+
+$for(author-meta)$
+<meta name="author" content="$author-meta$" />
+$endfor$
+$if(date-meta)$
+<meta name="dcterms.date" content="$date-meta$" />
+$endif$
+$if(keywords)$
+<meta name="keywords" content="$for(keywords)$$keywords$$sep$, $endfor$" />
+$endif$
+$if(description-meta)$
+<meta name="description" content="$description-meta$" />
+$endif$
+
+<title>$pagetitle$$if(title-prefix)$ – $title-prefix$$endif$</title>

--- a/great_docs/assets/post-render.py
+++ b/great_docs/assets/post-render.py
@@ -394,55 +394,6 @@ def inject_json_ld(html_content: str, page_path: str) -> str:
     return html_content
 
 
-def apply_title_template(html_content: str, page_path: str) -> str:
-    """
-    Apply page title template for better SEO.
-
-    Parameters
-    ----------
-    html_content
-        The HTML content to modify.
-    page_path
-        The page path relative to the site root.
-
-    Returns
-    -------
-    str
-        The modified HTML with templated title.
-    """
-    if not _gd_options.get("seo_enabled", False):
-        return html_content
-
-    template = _gd_options.get("title_template", "{page_title} | {site_name}")
-    site_name = _gd_options.get("site_name", "")
-
-    if not site_name or not template:
-        return html_content
-
-    # Extract current page title
-    title_match = re.search(r"<title>([^<]*)</title>", html_content)
-    if not title_match:
-        return html_content
-
-    current_title = title_match.group(1).strip()
-
-    # Skip if already has a pipe (already templated)
-    if " | " in current_title or " - " in current_title:
-        # Check if it ends with site name already
-        if current_title.endswith(site_name):
-            return html_content
-
-    # Build new title from template
-    new_title = template.replace("{page_title}", current_title).replace("{site_name}", site_name)
-
-    # Replace title tag
-    html_content = html_content.replace(
-        f"<title>{title_match.group(1)}</title>", f"<title>{new_title}</title>"
-    )
-
-    return html_content
-
-
 def inject_noindex_meta(html_content: str, page_path: str) -> str:
     """
     Inject noindex/nofollow meta tags for internal or draft pages.
@@ -624,7 +575,6 @@ def apply_seo_processing(html_content: str, page_path: str) -> str:
     html_content = inject_canonical_url(html_content, page_path)
     html_content = inject_meta_description(html_content, page_path)
     html_content = inject_json_ld(html_content, page_path)
-    html_content = apply_title_template(html_content, page_path)
     html_content = inject_noindex_meta(html_content, page_path)
     html_content = inject_social_cards(html_content, page_path)
     return html_content

--- a/great_docs/cli.py
+++ b/great_docs/cli.py
@@ -2342,7 +2342,12 @@ def seo(project_path: str | None, fix: bool, json_output: bool) -> None:
         images_missing_alt = 0
 
         canonical_base = docs._get_canonical_base_url()
+
+        # The audit requires the site name only when `{site_name}` appears in the
+        # configured template. A template without the placeholder excludes the name.
         site_name = docs._get_site_name()
+        if "{site_name}" not in docs._config.seo_title_template:
+            site_name = ""
 
         for html_file in html_files:
             rel_path = html_file.relative_to(site_dir).as_posix()
@@ -2401,9 +2406,7 @@ def seo(project_path: str | None, fix: bool, json_output: bool) -> None:
             info.append("✅ All pages have meta descriptions")
 
         if pages_missing_site_name > 0:
-            warnings.append(
-                f"⚠️  {pages_missing_site_name} pages have titles without the site name"
-            )
+            warnings.append(f"⚠️  {pages_missing_site_name} pages have titles without the site name")
 
         if pages_with_json_ld > 0:
             info.append(f"✅ {pages_with_json_ld} pages have JSON-LD structured data")

--- a/great_docs/cli.py
+++ b/great_docs/cli.py
@@ -2343,10 +2343,12 @@ def seo(project_path: str | None, fix: bool, json_output: bool) -> None:
 
         canonical_base = docs._get_canonical_base_url()
 
-        # The audit requires the site name only when `{site_name}` appears in the
-        # configured template. A template without the placeholder excludes the name.
+        # The audit requires the site name only when a string template contains
+        # `{site_name}`. A missing placeholder or non-string value skips this
+        # check.
+        title_template = docs._config.seo_title_template
         site_name = docs._get_site_name()
-        if "{site_name}" not in docs._config.seo_title_template:
+        if not isinstance(title_template, str) or "{site_name}" not in title_template:
             site_name = ""
 
         for html_file in html_files:

--- a/great_docs/cli.py
+++ b/great_docs/cli.py
@@ -2279,6 +2279,7 @@ def seo(project_path: str | None, fix: bool, json_output: bool) -> None:
       great-docs seo --fix                  # Fix issues where possible
       great-docs seo --json                 # JSON output for CI
     """
+    import html
     import json
     import xml.etree.ElementTree as ET
 
@@ -2336,11 +2337,12 @@ def seo(project_path: str | None, fix: bool, json_output: bool) -> None:
         pages_checked = 0
         pages_missing_canonical = 0
         pages_missing_description = 0
-        pages_missing_title_template = 0
+        pages_missing_site_name = 0
         pages_with_json_ld = 0
         images_missing_alt = 0
 
         canonical_base = docs._get_canonical_base_url()
+        site_name = docs._get_site_name()
 
         for html_file in html_files:
             rel_path = html_file.relative_to(site_dir).as_posix()
@@ -2360,12 +2362,14 @@ def seo(project_path: str | None, fix: bool, json_output: bool) -> None:
             if not re.search(r'<meta\s+name="description"', content):
                 pages_missing_description += 1
 
-            # Check title template (should have | or -)
+            # Require the site name in ordinary page titles. Exempt the home page,
+            # which uses only that name, and redirect stubs, which immediately
+            # send readers elsewhere.
             title_match = re.search(r"<title>([^<]+)</title>", content)
-            if title_match:
-                title = title_match.group(1)
-                if " | " not in title and " - " not in title:
-                    pages_missing_title_template += 1
+            is_redirect = 'http-equiv="refresh"' in content
+            if site_name and title_match and rel_path != "index.html" and not is_redirect:
+                if site_name not in html.unescape(title_match.group(1)):
+                    pages_missing_site_name += 1
 
             # Check JSON-LD
             if "application/ld+json" in content:
@@ -2396,10 +2400,9 @@ def seo(project_path: str | None, fix: bool, json_output: bool) -> None:
         else:
             info.append("✅ All pages have meta descriptions")
 
-        if pages_missing_title_template > 0:
+        if pages_missing_site_name > 0:
             warnings.append(
-                f"⚠️  {pages_missing_title_template} pages have plain titles "
-                "(consider adding site name)"
+                f"⚠️  {pages_missing_site_name} pages have titles without the site name"
             )
 
         if pages_with_json_ld > 0:

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -15005,6 +15005,33 @@ anchor-sections: true
         # Fallback to site-relative path (works for most crawlers)
         return source.name  # pragma: no cover
 
+    def _get_site_name(self) -> str:
+        """
+        Resolve the site name used in page titles
+
+        Read `website.title` from the generated `_quarto.yml` first because
+        Quarto uses this value. Otherwise, use the configured display name or
+        detected package name.
+
+        Returns
+        -------
+        :
+            The site name, or an empty string if none is available.
+        """
+        quarto_yml = self.project_path / "_quarto.yml"
+        if quarto_yml.exists():
+            try:
+                with open(quarto_yml, "r") as f:
+                    config = read_yaml(f) or {}
+            except (OSError, ValueError):
+                config = {}
+            website = config.get("website")
+            if isinstance(website, dict):
+                title = website.get("title")
+                if isinstance(title, str) and title:
+                    return title
+        return self._config.display_name or self._detect_package_name() or ""
+
     def _build_title_template_line(self, template: str) -> str | None:
         """
         Convert the configured page-title template to Pandoc syntax
@@ -15157,7 +15184,7 @@ anchor-sections: true
             "package_license": metadata.get("license", ""),
             "package_version": metadata.get("version", ""),
             "repo_url": metadata.get("urls", {}).get("Repository", ""),
-            "site_name": self._config.display_name or self._detect_package_name() or "",
+            "site_name": self._get_site_name(),
             # Social cards
             "social_cards_enabled": self._config.social_cards_enabled,
             "social_cards_image": social_image_url,

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -15041,17 +15041,20 @@ anchor-sections: true
         site name once. Keep `$pagetitle$` outside the conditional so Quarto
         resolves each page's title.
 
+        A template without `{site_name}` omits the site-name component from
+        titled pages.
+
         Parameters
         ----------
         template
-            Value of `seo.title_template`, written with `{page_title}` and
-            `{site_name}`.
+            Value of `seo.title_template`, written with `{page_title}` and an
+            optional `{site_name}`.
 
         Returns
         -------
         :
-            The `<title>` element, or `None` if the template omits a required
-            placeholder or contains `$`.
+            The `<title>` element, or `None` if the template contains `$` or
+            omits `{page_title}`.
         """
         page_key = "{page_title}"
         site_key = "{site_name}"
@@ -15061,9 +15064,14 @@ anchor-sections: true
             return None
 
         page_at = template.find(page_key)
-        site_at = template.find(site_key)
-        if page_at == -1 or site_at == -1:
+        if page_at == -1:
             return None
+
+        site_at = template.find(site_key)
+        if site_at == -1:
+            head = template[:page_at]
+            tail = template[page_at + len(page_key) :]
+            return f"<title>{head}$pagetitle${tail}</title>"
 
         if page_at < site_at:
             head = template[:page_at]
@@ -15103,8 +15111,8 @@ anchor-sections: true
         title_line = self._build_title_template_line(self._config.seo_title_template)
         if title_line is None:
             print(
-                "Warning: seo.title_template must contain {page_title} and {site_name}, "
-                "and cannot contain '$'. Keeping Quarto's default page titles."
+                "Warning: seo.title_template must contain {page_title} and must not "
+                "contain '$'. Using Quarto's default page titles."
             )
             return
 

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -15082,12 +15082,12 @@ anchor-sections: true
 
     def _write_title_partial(self, config: dict) -> None:
         """
-        Write a Quarto metadata partial that defines each page title
+        Write a Quarto metadata partial with the configured page title
 
-        Copy Quarto's installed partial and replace only its `<title>` element.
-        This preserves every other tag from the installed version. Leave
-        Quarto's default title unchanged if the title template is unsupported,
-        HTML configuration is unavailable, or the partial cannot be found.
+        Replace the bundled partial's `<title>` element and preserve its other
+        tags. The bundled copy keeps the metadata independent of the installed
+        Quarto version. Leave Quarto's default title unchanged if the template
+        is unsupported or the HTML configuration is unavailable.
 
         Parameters
         ----------
@@ -15100,8 +15100,6 @@ anchor-sections: true
         :
             Nothing.
         """
-        import subprocess
-
         title_line = self._build_title_template_line(self._config.seo_title_template)
         if title_line is None:
             print(
@@ -15114,36 +15112,11 @@ anchor-sections: true
         if not isinstance(html_config, dict):
             return
 
-        source = None
-        if shutil.which("quarto") is not None:
-            try:
-                result = subprocess.run(
-                    ["quarto", "--paths"],
-                    capture_output=True,
-                    check=False,
-                    **TEXT_MODE_KWARGS,
-                )
-            except OSError:
-                result = None
-            if result is not None and result.returncode == 0:
-                for line in result.stdout.splitlines():
-                    candidate = Path(line.strip()) / "formats" / "html" / "pandoc" / "metadata.html"
-                    if candidate.is_file():
-                        source = candidate
-                        break
-
-        if source is None:
-            print(
-                "Warning: could not find Quarto's metadata.html. "
-                "Keeping Quarto's default page titles."
-            )
-            return
-
         # Use a callable replacement so backslashes and `$` remain literal.
         partial = re.sub(
             r"<title>.*</title>",
             lambda _match: title_line,
-            source.read_text(encoding="utf-8"),
+            (self.assets_path / "metadata.html").read_text(encoding="utf-8"),
         )
         (self.project_path / "metadata.html").write_text(partial, encoding="utf-8")
 

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -15036,13 +15036,10 @@ anchor-sections: true
         """
         Convert the configured page-title template to Pandoc syntax
 
-        Wrap the site-name portion in `$if(title-prefix)$`. Quarto leaves
-        `$title-prefix$` unset when a page has no title, so the page shows the
-        site name once. Keep `$pagetitle$` outside the conditional so Quarto
-        resolves each page's title.
-
-        A template without `{site_name}` omits the site-name component from
-        titled pages.
+        Apply the template only to titled pages. For untitled pages, including
+        the home page, Quarto leaves `$title-prefix$` unset and sets
+        `$pagetitle$` to the site name. These pages therefore show only the site
+        name.
 
         Parameters
         ----------
@@ -15060,33 +15057,11 @@ anchor-sections: true
         site_key = "{site_name}"
 
         # `$` opens a Pandoc template expression and would corrupt the partial.
-        if "$" in template:
+        if "$" in template or page_key not in template:
             return None
 
-        page_at = template.find(page_key)
-        if page_at == -1:
-            return None
-
-        site_at = template.find(site_key)
-        if site_at == -1:
-            head = template[:page_at]
-            tail = template[page_at + len(page_key) :]
-            return f"<title>{head}$pagetitle${tail}</title>"
-
-        if page_at < site_at:
-            head = template[:page_at]
-            joiner = template[page_at + len(page_key) : site_at]
-            tail = template[site_at + len(site_key) :]
-            optional = f"{joiner}$title-prefix${tail}"
-            body = f"{head}$pagetitle$$if(title-prefix)${optional}$endif$"
-        else:
-            head = template[:site_at]
-            joiner = template[site_at + len(site_key) : page_at]
-            tail = template[page_at + len(page_key) :]
-            optional = f"{head}$title-prefix${joiner}"
-            body = f"$if(title-prefix)${optional}$endif$$pagetitle${tail}"
-
-        return f"<title>{body}</title>"
+        titled = template.replace(page_key, "$pagetitle$").replace(site_key, "$title-prefix$")
+        return f"<title>$if(title-prefix)${titled}$else$$pagetitle$$endif$</title>"
 
     def _write_title_partial(self, config: dict) -> None:
         """

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -15094,8 +15094,9 @@ anchor-sections: true
 
         Replace the bundled partial's `<title>` element and preserve its other
         tags. The bundled copy keeps the metadata independent of the installed
-        Quarto version. Leave Quarto's default title unchanged if the template
-        is unsupported or the HTML configuration is unavailable.
+        Quarto version. Leave Quarto's default title unchanged when SEO is
+        disabled, when the template is unsupported, or when the HTML
+        configuration is unavailable.
 
         Parameters
         ----------
@@ -15108,6 +15109,9 @@ anchor-sections: true
         :
             Nothing.
         """
+        if not self._config.seo_enabled:
+            return
+
         title_line = self._build_title_template_line(self._config.seo_title_template)
         if title_line is None:
             print(

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -15032,7 +15032,7 @@ anchor-sections: true
                     return title
         return self._config.display_name or self._detect_package_name() or ""
 
-    def _build_title_template_line(self, template: str) -> str | None:
+    def _build_title_template_line(self, template: object) -> str | None:
         """
         Convert the configured page-title template to Pandoc syntax
 
@@ -15045,16 +15045,20 @@ anchor-sections: true
         ----------
         template
             Value of `seo.title_template`, written with `{page_title}` and an
-            optional `{site_name}`.
+            optional `{site_name}`. Configuration values may have any type, but
+            this method supports only strings.
 
         Returns
         -------
         :
-            The `<title>` element, or `None` if the template contains `$` or
-            omits `{page_title}`.
+            The `<title>` element, or `None` unless the template is a string
+            that contains `{page_title}` and excludes `$`.
         """
         page_key = "{page_title}"
         site_key = "{site_name}"
+
+        if not isinstance(template, str):
+            return None
 
         # `$` opens a Pandoc template expression and would corrupt the partial.
         if "$" in template or page_key not in template:
@@ -15090,8 +15094,8 @@ anchor-sections: true
         title_line = self._build_title_template_line(self._config.seo_title_template)
         if title_line is None:
             print(
-                "Warning: seo.title_template must contain {page_title} and must not "
-                "contain '$'. Using Quarto's default page titles."
+                "Warning: seo.title_template must be a string containing "
+                "{page_title} but no '$'. Using Quarto's default page titles."
             )
             return
 

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -13331,6 +13331,9 @@ anchor-sections: true
         if "gd-lightbox" not in config["filters"]:
             config["filters"].append("gd-lightbox")
 
+        # Compose each page's browser title during Quarto rendering.
+        self._write_title_partial(config)
+
         # Apply explicit navbar ordering from config (if set)
         self._reorder_navbar(config)
 
@@ -15002,6 +15005,128 @@ anchor-sections: true
         # Fallback to site-relative path (works for most crawlers)
         return source.name  # pragma: no cover
 
+    def _build_title_template_line(self, template: str) -> str | None:
+        """
+        Convert the configured page-title template to Pandoc syntax
+
+        Wrap the site-name portion in `$if(title-prefix)$`. Quarto leaves
+        `$title-prefix$` unset when a page has no title, so the page shows the
+        site name once. Keep `$pagetitle$` outside the conditional so Quarto
+        resolves each page's title.
+
+        Parameters
+        ----------
+        template
+            Value of `seo.title_template`, written with `{page_title}` and
+            `{site_name}`.
+
+        Returns
+        -------
+        :
+            The `<title>` element, or `None` if the template omits a required
+            placeholder or contains `$`.
+        """
+        page_key = "{page_title}"
+        site_key = "{site_name}"
+
+        # `$` opens a Pandoc template expression and would corrupt the partial.
+        if "$" in template:
+            return None
+
+        page_at = template.find(page_key)
+        site_at = template.find(site_key)
+        if page_at == -1 or site_at == -1:
+            return None
+
+        if page_at < site_at:
+            head = template[:page_at]
+            joiner = template[page_at + len(page_key) : site_at]
+            tail = template[site_at + len(site_key) :]
+            optional = f"{joiner}$title-prefix${tail}"
+            body = f"{head}$pagetitle$$if(title-prefix)${optional}$endif$"
+        else:
+            head = template[:site_at]
+            joiner = template[site_at + len(site_key) : page_at]
+            tail = template[page_at + len(page_key) :]
+            optional = f"{head}$title-prefix${joiner}"
+            body = f"$if(title-prefix)${optional}$endif$$pagetitle${tail}"
+
+        return f"<title>{body}</title>"
+
+    def _write_title_partial(self, config: dict) -> None:
+        """
+        Write a Quarto metadata partial that defines each page title
+
+        Copy Quarto's installed partial and replace only its `<title>` element.
+        This preserves every other tag from the installed version. Leave
+        Quarto's default title unchanged if the title template is unsupported,
+        HTML configuration is unavailable, or the partial cannot be found.
+
+        Parameters
+        ----------
+        config
+            Contents of `_quarto.yml`. The method registers the partial in this
+            mapping.
+
+        Returns
+        -------
+        :
+            Nothing.
+        """
+        import subprocess
+
+        title_line = self._build_title_template_line(self._config.seo_title_template)
+        if title_line is None:
+            print(
+                "Warning: seo.title_template must contain {page_title} and {site_name}, "
+                "and cannot contain '$'. Keeping Quarto's default page titles."
+            )
+            return
+
+        html_config = config.get("format", {}).get("html")
+        if not isinstance(html_config, dict):
+            return
+
+        source = None
+        if shutil.which("quarto") is not None:
+            try:
+                result = subprocess.run(
+                    ["quarto", "--paths"],
+                    capture_output=True,
+                    check=False,
+                    **TEXT_MODE_KWARGS,
+                )
+            except OSError:
+                result = None
+            if result is not None and result.returncode == 0:
+                for line in result.stdout.splitlines():
+                    candidate = Path(line.strip()) / "formats" / "html" / "pandoc" / "metadata.html"
+                    if candidate.is_file():
+                        source = candidate
+                        break
+
+        if source is None:
+            print(
+                "Warning: could not find Quarto's metadata.html. "
+                "Keeping Quarto's default page titles."
+            )
+            return
+
+        # Use a callable replacement so backslashes and `$` remain literal.
+        partial = re.sub(
+            r"<title>.*</title>",
+            lambda _match: title_line,
+            source.read_text(encoding="utf-8"),
+        )
+        (self.project_path / "metadata.html").write_text(partial, encoding="utf-8")
+
+        partials = html_config.get("template-partials", [])
+        if isinstance(partials, str):
+            partials = [partials]
+        if "metadata.html" not in partials:
+            partials.append("metadata.html")
+        html_config["template-partials"] = partials
+
     def _get_seo_options(self) -> dict:
         """
         Get SEO options for the post-render script.
@@ -15022,7 +15147,6 @@ anchor-sections: true
             "seo_enabled": self._config.seo_enabled,
             "canonical_enabled": self._config.canonical_enabled,
             "canonical_base_url": self._get_canonical_base_url(),
-            "title_template": self._config.seo_title_template,
             "structured_data_enabled": self._config.structured_data_enabled,
             "structured_data_type": self._config.structured_data_type,
             "default_description": (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3615,8 +3615,7 @@ class TestSeoSkipInternalFiles:
 
         runner = CliRunner()
         result = runner.invoke(cli, ["seo", "--project-path", str(tmp_path)])
-        # Should analyze only the normal page (1 page checked)
-        assert "Analyzed 1 page" in result.output or "1 page" in result.output
+        assert "Analyzed 1 HTML pages" in result.output
 
 
 

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -40262,7 +40262,6 @@ seo:
         assert options["seo_enabled"] is True
         assert options["canonical_enabled"] is True
         assert options["canonical_base_url"] == "https://example.com/docs/"
-        assert options["title_template"] == "{page_title} | {site_name}"
         assert options["structured_data_enabled"] is True
         assert options["site_name"] == "Test Package"
         assert options["package_description"] == "A test package"

--- a/tests/test_title_partial.py
+++ b/tests/test_title_partial.py
@@ -1,0 +1,92 @@
+"""Tests for the bundled Quarto metadata partial used for page titles"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import great_docs
+
+VENDORED = Path(great_docs.__file__).parent / "assets" / "metadata.html"
+
+# `quarto --paths` returns roots that contain this relative path.
+UPSTREAM_RELATIVE = Path("formats") / "html" / "pandoc" / "metadata.html"
+
+
+def _quarto_partial() -> Path | None:
+    """
+    Locate the metadata partial of the installed Quarto
+
+    Returns
+    -------
+    :
+        Path to Quarto's installed copy, or `None` if Quarto is unavailable or
+        does not report the file.
+    """
+    if shutil.which("quarto") is None:
+        return None
+
+    try:
+        result = subprocess.run(
+            ["quarto", "--paths"],
+            capture_output=True,
+            check=False,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+    except OSError:
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    for line in result.stdout.splitlines():
+        candidate = Path(line.strip()) / UPSTREAM_RELATIVE
+        if candidate.is_file():
+            return candidate
+
+    return None
+
+
+def _without_title(content: str) -> list[str]:
+    """
+    Remove the title element from a metadata partial
+
+    Parameters
+    ----------
+    content
+        Contents of a metadata partial.
+
+    Returns
+    -------
+    :
+        Lines that do not contain `<title>`.
+    """
+    return [line for line in content.splitlines() if "<title>" not in line]
+
+
+def test_bundled_partial_contains_title_element():
+    """Confirm that the bundled title element remains available for replacement"""
+    assert "<title>" in VENDORED.read_text(encoding="utf-8")
+
+
+@pytest.mark.skipif(
+    _quarto_partial() is None,
+    reason="Quarto metadata partial is unavailable",
+)
+def test_bundled_partial_matches_quarto_except_for_title():
+    """
+    Keep the bundled metadata tags aligned with Quarto
+
+    The build replaces the title element, so this comparison excludes that
+    line. If the remaining lines differ, copy them from the installed partial
+    without changing the bundled title element.
+    """
+    theirs = _quarto_partial()
+    assert theirs is not None
+
+    assert _without_title(VENDORED.read_text(encoding="utf-8")) == _without_title(
+        theirs.read_text(encoding="utf-8")
+    ), f"Bundled metadata tags differ from {theirs}"

--- a/tests/test_title_partial.py
+++ b/tests/test_title_partial.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 import great_docs
+from great_docs.core import GreatDocs
 
 VENDORED = Path(great_docs.__file__).parent / "assets" / "metadata.html"
 
@@ -90,3 +91,31 @@ def test_bundled_partial_matches_quarto_except_for_title():
     assert _without_title(VENDORED.read_text(encoding="utf-8")) == _without_title(
         theirs.read_text(encoding="utf-8")
     ), f"Bundled metadata tags differ from {theirs}"
+
+
+@pytest.mark.parametrize(
+    ("template", "titled"),
+    [
+        ("{page_title} | {site_name}", "$pagetitle$ | $title-prefix$"),
+        ("{site_name} - {page_title}", "$title-prefix$ - $pagetitle$"),
+        ("Docs: {page_title}", "Docs: $pagetitle$"),
+        ("{page_title}", "$pagetitle$"),
+    ],
+)
+def test_title_line_applies_template_only_to_titled_pages(template: str, titled: str):
+    """
+    Preserve Quarto's title for untitled pages
+
+    Quarto leaves `title-prefix` unset on untitled pages and uses the site
+    name as `pagetitle`. The conditional therefore excludes surrounding
+    template text from those pages.
+    """
+    line = GreatDocs._build_title_template_line(None, template)  # type: ignore[arg-type]
+
+    assert line == f"<title>$if(title-prefix)${titled}$else$$pagetitle$$endif$</title>"
+
+
+@pytest.mark.parametrize("template", ["{site_name}", "$pagetitle$", "{page_title} $ {site_name}"])
+def test_title_line_rejects_missing_page_placeholder_or_dollar(template: str):
+    """Reject templates that omit `{page_title}` or contain `$`"""
+    assert GreatDocs._build_title_template_line(None, template) is None  # type: ignore[arg-type]

--- a/tests/test_title_partial.py
+++ b/tests/test_title_partial.py
@@ -119,3 +119,14 @@ def test_title_line_applies_template_only_to_titled_pages(template: str, titled:
 def test_title_line_rejects_missing_page_placeholder_or_dollar(template: str):
     """Reject templates that omit `{page_title}` or contain `$`"""
     assert GreatDocs._build_title_template_line(None, template) is None  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("template", [None, False, 42, ["{page_title}"]])
+def test_title_line_rejects_non_string_templates(template: object):
+    """
+    Handle non-string page-title templates
+
+    YAML parses an empty `title_template:` as `None`. Treat every non-string
+    value as unsupported so the build keeps Quarto's titles.
+    """
+    assert GreatDocs._build_title_template_line(None, template) is None  # type: ignore[arg-type]


### PR DESCRIPTION
This PR composes page titles during the Quarto render instead of rewriting them afterwards, so the site name is added once. Great Docs now bundles a `metadata.html` template partial and writes it into the build directory at build time.

Fixes #327