### PR TITLE
feat: typer CLI support

### DIFF
--- a/great_docs/_api_diff.py
+++ b/great_docs/_api_diff.py
@@ -870,10 +870,7 @@ def _import_cli_from_source(
     import importlib
     import sys
 
-    try:
-        import click
-    except ImportError:
-        return None
+    from ._typer_cli import to_click_command
 
     str_dir = str(tmp_dir)
     sys.path.insert(0, str_dir)
@@ -886,11 +883,11 @@ def _import_cli_from_source(
 
         module = importlib.import_module(cli_module)
 
-        # Find Click command/group
+        # Find a Click command/group or Typer app
         cli_obj = None
         for attr_name in ["cli", "main", "app", "command"]:
-            obj = getattr(module, attr_name, None)
-            if isinstance(obj, (click.Command, click.Group)):
+            obj = to_click_command(getattr(module, attr_name, None))
+            if obj is not None:
                 cli_obj = obj
                 break
 
@@ -898,8 +895,8 @@ def _import_cli_from_source(
             for attr_name in dir(module):
                 if attr_name.startswith("_"):
                     continue
-                obj = getattr(module, attr_name)
-                if isinstance(obj, (click.Command, click.Group)):
+                obj = to_click_command(getattr(module, attr_name))
+                if obj is not None:
                     cli_obj = obj
                     break
 
@@ -1331,37 +1328,43 @@ def snapshot_cli_from_click(cli_obj: object) -> CliCommandInfo | None:
     Parameters
     ----------
     cli_obj
-        A `click.BaseCommand` instance (Command or Group).
+        A `click.BaseCommand` instance (Command or Group), or a `typer.Typer`
+        app (which is converted to its underlying Click command).
 
     Returns
     -------
     CliCommandInfo or None
-        The CLI snapshot, or `None` if `cli_obj` is not a Click command.
+        The CLI snapshot, or `None` if `cli_obj` is not a Click command or
+        Typer app.
     """
-    try:
-        import click
-    except ImportError:  # pragma: no cover
-        return None  # pragma: no cover
+    from ._typer_cli import to_click_command
 
-    if not isinstance(cli_obj, (click.Command, click.Group)):
+    cmd = to_click_command(cli_obj)
+    if cmd is None:
         return None
 
-    return _snapshot_click_command(cli_obj)
+    return _snapshot_click_command(cmd)
 
 
 def _snapshot_click_command(cmd: object) -> CliCommandInfo:
-    """Recursively snapshot a Click command tree."""
-    import click
+    """Recursively snapshot a Click command tree.
+
+    Parameters are classified with duck-typing (`param_type_name` / a dict-like `commands` mapping)
+    rather than `isinstance` so this handles both plain Click commands and Typer's vendored-Click
+    commands.
+    """
+    from ._typer_cli import is_cli_group, param_kind
 
     name = getattr(cmd, "name", "") or ""
     help_text = getattr(cmd, "help", "") or ""
     hidden = getattr(cmd, "hidden", False)
     deprecated = getattr(cmd, "deprecated", False)
-    is_group = isinstance(cmd, click.Group)
+    is_group = is_cli_group(cmd)
 
     options: list[CliOptionInfo] = []
     for param in getattr(cmd, "params", []):
-        if isinstance(param, click.Option):
+        kind = param_kind(param)
+        if kind == "option":
             # Use the longest option name (e.g. --verbose over -v)
             opt_name = max(param.opts, key=len) if param.opts else param.name or ""
             options.append(
@@ -1374,7 +1377,7 @@ def _snapshot_click_command(cmd: object) -> CliCommandInfo:
                     help=param.help,
                 )
             )
-        elif isinstance(param, click.Argument):
+        elif kind == "argument":
             options.append(
                 CliOptionInfo(
                     name=param.name or "",

--- a/great_docs/_typer_cli.py
+++ b/great_docs/_typer_cli.py
@@ -1,0 +1,102 @@
+"""Typer CLI support for the Python (Click) CLI reference generator.
+
+Typer is a Python CLI framework that is built on top of Click: a `typer.Typer` app is not itself a
+`click.Command`/`click.Group`, but it can be turned into one with `typer.main.get_command`. Once
+converted, the resulting object is an ordinary Click command tree, so all of the existing Click
+introspection in `core.py` (options, arguments, subcommands, `--help` text) and `_api_diff.py` (CLI
+snapshots) works unchanged.
+
+These helpers are the single place that knows about Typer. Discovery code should detect candidates
+with `is_cli_command()` and normalize them to a Click object with `to_click_command()` before
+introspecting. Both degrade gracefully when Typer (or even Click) is not installed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def is_typer_app(obj: Any) -> bool:
+    """Return `True` when *obj* is a `typer.Typer` application instance.
+
+    Returns `False` (rather than raising) when Typer is not installed.
+    """
+    try:
+        import typer
+    except ImportError:
+        return False
+    return isinstance(obj, typer.Typer)
+
+
+def to_click_command(obj: Any) -> Any | None:
+    """Coerce *obj* into a Click command, converting Typer apps.
+
+    Parameters
+    ----------
+    obj
+        A candidate CLI object. Already-Click `Command`/`Group` instances are returned unchanged.
+        `typer.Typer` apps are converted to their underlying Click command via
+        `typer.main.get_command`.
+
+    Returns
+    -------
+    click.Command | None
+        The Click command for *obj*, or `None` when *obj* is neither a Click command nor a Typer app
+        (or when the required libraries are missing).
+    """
+    try:
+        import click
+    except ImportError:  # pragma: no cover - Click is a hard dependency
+        return None
+
+    if isinstance(obj, (click.Command, click.Group)):
+        return obj
+
+    try:
+        import typer
+        from typer.main import get_command
+    except ImportError:
+        return None
+
+    if isinstance(obj, typer.Typer):
+        try:
+            return get_command(obj)
+        except Exception:  # pragma: no cover - defensive (malformed Typer app)
+            return None
+
+    return None
+
+
+def is_cli_command(obj: Any) -> bool:
+    """Return `True` when *obj* is a documentable CLI (Click command or Typer app)."""
+    return to_click_command(obj) is not None
+
+
+# ---------------------------------------------------------------------------
+# Duck-typed introspection helpers
+#
+# Typer vendors its own copy of Click, so a command returned by `typer.main.get_command` is *not* an
+# instance of the top-level `click` package's `Command`/`Group`/`Option`/`Argument` classes. These
+# helpers introspect commands structurally instead of with `isinstance` against a specific Click, so
+# the same extraction code works for both plain Click CLIs and Typer apps (and any future Click
+# variant).
+# ---------------------------------------------------------------------------
+
+
+def is_cli_group(cmd: Any) -> bool:
+    """Return `True` when *cmd* is a command group (has named subcommands).
+
+    Works for both `click.Group` and Typer's vendored group, which both expose a dict-like
+    `commands` mapping. Leaf commands have no such mapping.
+    """
+    commands = getattr(cmd, "commands", None)
+    return commands is not None and hasattr(commands, "items")
+
+
+def param_kind(param: Any) -> str:
+    """Return `"option"`, `"argument"`, or `""` for a Click/Typer parameter.
+
+    Uses Click's `param_type_name` attribute, which both plain Click and Typer's vendored Click set
+    on every parameter.
+    """
+    return getattr(param, "param_type_name", "") or ""

--- a/great_docs/assets/great-docs.default.yml
+++ b/great_docs/assets/great-docs.default.yml
@@ -99,33 +99,34 @@ site_url: null
 # Source Link Configuration
 # -------------------------
 source:
-  enabled: true              # Enable/disable source links (default: true)
-  branch: null               # Git branch/tag to link to (default: auto-detect)
-  path: null                 # Custom source path for monorepos (default: auto-detect)
-  placement: usage           # Where to place the link: "usage" (default) or "title"
+  enabled: true # Enable/disable source links (default: true)
+  branch: null # Git branch/tag to link to (default: auto-detect)
+  path: null # Custom source path for monorepos (default: auto-detect)
+  placement: usage # Where to place the link: "usage" (default) or "title"
 
 # Sidebar Filter
 # --------------
 sidebar_filter:
-  enabled: true              # Enable/disable filter (default: true)
-  min_items: 20              # Minimum items before showing filter (default: 20)
+  enabled: true # Enable/disable filter (default: true)
+  min_items: 20 # Minimum items before showing filter (default: 20)
 
 # Marimo Notebooks
 # ----------------
 # Embed interactive WASM notebooks via marimo islands. `marimo: true` is
 # shorthand for `enabled: true`.
 marimo:
-  enabled: false             # Enable marimo island notebooks
-  version: null              # @marimo-team/islands CDN version; defaults to the installed marimo version
+  enabled: false # Enable marimo island notebooks
+  version: null # @marimo-team/islands CDN version; defaults to the installed marimo version
 
 # CLI Documentation
 # -----------------
+# Documents Python CLIs built with Click or Typer.
 cli:
-  enabled: false        # Enable CLI documentation
-  module: null          # e.g. my_package.cli; auto-detected
-  name: null            # Click command object; auto-detected
-  title: null           # Optional index page + sidebar title
-  desc: null            # Optional intro paragraph atop the index page
+  enabled: false # Enable CLI documentation
+  module: null # e.g. my_package.cli; auto-detected
+  name: null # Click command / Typer app variable; auto-detected
+  title: null # Optional index page + sidebar title
+  desc: null # Optional intro paragraph atop the index page
   # sections: explicit grouping/ordering (omit = auto by code order). Example:
   #   sections:
   #     - title: "Project setup"
@@ -140,7 +141,7 @@ cli:
 # Builds the Go binary and extracts its command tree via --help. Works with any
 # Go CLI (Cobra, urfave/cli, ...) whose subcommands support --help.
 go_cli:
-  enabled: false   # Enable Go CLI documentation (default: false)
+  enabled: false # Enable Go CLI documentation (default: false)
 
 # Rust CLI Documentation
 # ----------------------
@@ -148,17 +149,17 @@ go_cli:
 # Works with any Rust CLI (clap, structopt, argh, ...) whose subcommands
 # support --help.
 rust_cli:
-  enabled: false   # Enable Rust CLI documentation (default: false)
+  enabled: false # Enable Rust CLI documentation (default: false)
 
 # MCP Server Documentation
 # ------------------------
 # Auto-generates reference pages from an MCP server's tool/resource/prompt
 # definitions.
 mcp:
-  enabled: true          # Enable MCP server documentation
-  module: null           # Importable module path (e.g. "sweet.mcp")
-  server_var: null       # Variable name of the Server instance; auto-detected when null
-  name: null             # Display name override; defaults to the server name
+  enabled: true # Enable MCP server documentation
+  module: null # Importable module path (e.g. "sweet.mcp")
+  server_var: null # Variable name of the Server instance; auto-detected when null
+  name: null # Display name override; defaults to the server name
   # Manual tool categories (grouping on the index page). Example:
   #   categories:
   #     "Data tools": [load, save]
@@ -206,10 +207,10 @@ funding: null
 # are top-level keys below; setting them under `site` still works and is
 # lifted automatically.
 site:
-  theme: flatly            # Quarto theme
-  toc: true                # Show table of contents
-  toc-depth: 2             # TOC heading depth
-  html-math-method: katex  # HTML math renderer (e.g. mathjax)
+  theme: flatly # Quarto theme
+  toc: true # Show table of contents
+  toc-depth: 2 # TOC heading depth
+  html-math-method: katex # HTML math renderer (e.g. mathjax)
 
 # Page Metadata
 # -------------
@@ -242,8 +243,8 @@ team_author: null
 # ---------------------------
 # Auto-generate a Changelog page from GitHub Releases.
 changelog:
-  enabled: true              # Enable/disable changelog (default: true)
-  max_releases: 50           # Max releases to include (default: 50)
+  enabled: true # Enable/disable changelog (default: true)
+  max_releases: 50 # Max releases to include (default: 50)
 
 # Custom Sections
 # ---------------
@@ -365,9 +366,9 @@ inline_methods: 5
 # : type(str) - a single file used in both light and dark mode
 # : type(map) - (default) light/dark variants, as below
 logo:
-  light: null            # null = no logo
-  dark: null             # dark-mode variant; falls back to `light` when null
-  show_title: false      # keep the text title alongside the logo
+  light: null # null = no logo
+  dark: null # dark-mode variant; falls back to `light` when null
+  show_title: false # keep the text title alongside the logo
 
 # Favicon.
 # : null - (default) auto-generate from the logo, else skip
@@ -386,13 +387,13 @@ favicon: null
 # : false - force disable
 # : type(map) - (default) set the fields explicitly, as below
 hero:
-  enabled: null          # null = auto (on when a logo is set)
-  logo: null             # hero-specific logo; falls back to the navbar logo
-  logo_height: 200px     # max-height CSS value
-  name: null             # defaults to display_name; false hides it
-  tagline: null          # false hides it
-  badges: auto           # "auto" (from README), a list, or false
-  starfield: false       # interactive starfield animation
+  enabled: null # null = auto (on when a logo is set)
+  logo: null # hero-specific logo; falls back to the navbar logo
+  logo_height: 200px # max-height CSS value
+  name: null # defaults to display_name; false hides it
+  tagline: null # false hides it
+  badges: auto # "auto" (from README), a list, or false
+  starfield: false # interactive starfield animation
 
 # Markdown Pages
 # --------------
@@ -401,8 +402,8 @@ hero:
 # : false - disable both
 # : type(map) - (default) set the fields explicitly, as below
 markdown_pages:
-  enabled: true   # Generate .md companions for every HTML page (default: true)
-  widget: true    # Show the copy/view-as-Markdown widget (requires enabled)
+  enabled: true # Generate .md companions for every HTML page (default: true)
+  widget: true # Show the copy/view-as-Markdown widget (requires enabled)
 
 # Announcement Banner
 # -------------------
@@ -410,11 +411,11 @@ markdown_pages:
 # : type(str) - the banner text (sets `content`)
 # : type(map) - (default) set the fields explicitly, as below
 announcement:
-  content: null          # null = no banner; else the banner text (supports basic Markdown)
-  type: info             # "info" | "warning" | "success" | "danger"
-  dismissable: true      # Allow visitors to dismiss the banner
-  url: null              # Optional link the banner text points to
-  style: null            # Optional gradient preset (same names as navbar_style)
+  content: null # null = no banner; else the banner text (supports basic Markdown)
+  type: info # "info" | "warning" | "success" | "danger"
+  dismissable: true # Allow visitors to dismiss the banner
+  url: null # Optional link the banner text points to
+  style: null # Optional gradient preset (same names as navbar_style)
   position: above-navbar # "above-navbar" (default) | "below-navbar"
 
 # Versioning
@@ -430,16 +431,16 @@ versions: []
 
 # Version selector widget (enabled automatically when `versions` is non-empty).
 version_selector:
-  enabled: true             # Master switch for the widget
-  placement: navbar-right   # "navbar-right" | "navbar-left" | "sidebar-top"
-  show_eol: true            # Include end-of-life versions in the dropdown
-  warning_banner: true      # Show a banner on non-latest versions
+  enabled: true # Master switch for the widget
+  placement: navbar-right # "navbar-right" | "navbar-left" | "sidebar-top"
+  show_eol: true # Include end-of-life versions in the dropdown
+  warning_banner: true # Show a banner on non-latest versions
 
 # Floating version aliases.
 version_aliases:
-  latest: true   # /v/latest/ -> latest stable version
-  stable: true   # /v/stable/ -> same as latest
-  dev: true      # /v/dev/ -> prerelease version, if any
+  latest: true # /v/latest/ -> latest stable version
+  stable: true # /v/stable/ -> same as latest
+  dev: true # /v/dev/ -> prerelease version, if any
 
 # Badge "new" expiry
 # -----------------
@@ -491,8 +492,8 @@ navbar_order: null
 # : type(str) - a preset name (sets `preset`)
 # : type(map) - (default) set the fields explicitly, as below
 content_style:
-  preset: null   # null = disabled; else a gradient preset name
-  pages: all     # "all" or "homepage"
+  preset: null # null = disabled; else a gradient preset name
+  pages: all # "all" or "homepage"
 
 # Scale to Fit
 # ------------
@@ -582,9 +583,9 @@ pre_render: []
 # Emits a SKILL.md conforming to the Agent Skills spec (https://agentskills.io/)
 # so coding agents can learn the package.
 skill:
-  enabled: true       # Emit a SKILL.md for this package (default: true)
-  file: null          # Path to a hand-written SKILL.md (overrides auto-generation)
-  well_known: true    # Also serve at /.well-known/agent-skills/{name}/SKILL.md + index.json
+  enabled: true # Emit a SKILL.md for this package (default: true)
+  file: null # Path to a hand-written SKILL.md (overrides auto-generation)
+  well_known: true # Also serve at /.well-known/agent-skills/{name}/SKILL.md + index.json
   # Strings for the Gotchas section.
   gotchas: []
   # Strings for the Best Practices section.
@@ -594,7 +595,7 @@ skill:
   #     - need: "Parse a file"
   #       use: read_yaml()
   decision_table: []
-  extra_body: null    # Path to extra Markdown appended to the generated body
+  extra_body: null # Path to extra Markdown appended to the generated body
   # Multiple named skills (overrides 'file' when set):
   # skills:
   #   - name: my-package
@@ -615,19 +616,19 @@ skill:
 #   twitter_site: "@myhandle"       # Twitter/X site @handle
 #   twitter_card: summary_large_image  # "summary" or "summary_large_image"
 social_cards:
-  enabled: true          # Auto-generate social preview meta tags (default: true)
-  image: null            # Default og:image for all pages; omitted from meta tags when null
-  twitter_card: null     # "summary" or "summary_large_image"
-  twitter_site: null     # Twitter/X site @handle (e.g. "@myhandle")
+  enabled: true # Auto-generate social preview meta tags (default: true)
+  image: null # Default og:image for all pages; omitted from meta tags when null
+  twitter_card: null # "summary" or "summary_large_image"
+  twitter_site: null # Twitter/X site @handle (e.g. "@myhandle")
 
 # Page Status Badges
 # ------------------
 # Lifecycle indicators in sidebar navigation. Pages opt in via frontmatter
 # (`status: new`, `deprecated`, ...).
 page_status:
-  enabled: false            # Master switch for page status badges
-  show_in_sidebar: true     # Show badges next to sidebar navigation links
-  show_on_pages: true       # Show a status indicator below page titles (like tags)
+  enabled: false # Master switch for page status badges
+  show_in_sidebar: true # Show badges next to sidebar navigation links
+  show_on_pages: true # Show a status indicator below page titles (like tags)
   # Built-in status definitions (extend or override).
   statuses:
     new:
@@ -666,10 +667,10 @@ page_status:
 # Categorize pages for discoverability via frontmatter
 # (`tags: [Python, Testing, API]`).
 tags:
-  enabled: false         # Master switch for page tags
-  index_page: true       # Auto-generate a tags index page listing all tags and their pages
-  show_on_pages: true    # Render tag pills above page titles, linked to the tag index
-  hierarchical: true     # Support hierarchical tags with "/" (e.g. "Python/Testing")
+  enabled: false # Master switch for page tags
+  index_page: true # Auto-generate a tags index page listing all tags and their pages
+  show_on_pages: true # Render tag pills above page titles, linked to the tag index
+  hierarchical: true # Support hierarchical tags with "/" (e.g. "Python/Testing")
   # Optional tag icons (tag name -> Lucide icon). Example:
   #   icons:
   #     Python: code
@@ -677,16 +678,16 @@ tags:
   # Shadow tags: names hidden from public view (internal organization only).
   # Shadow-tagged pages are indexed but their tags are not rendered.
   shadow: []
-  scoped: false          # Show a tag cloud scoped to the section on section pages
-  location: top          # Default tag pill placement: "top" or "bottom"
+  scoped: false # Show a tag cloud scoped to the section on section pages
+  location: top # Default tag pill placement: "top" or "bottom"
 
 # SEO
 # ---
 # Generates sitemap.xml, robots.txt, and discoverability metadata.
 seo:
-  enabled: true            # Master switch for all SEO features
+  enabled: true # Master switch for all SEO features
   sitemap:
-    enabled: true          # Generate sitemap.xml
+    enabled: true # Generate sitemap.xml
     # Change frequency by page type (always|hourly|daily|weekly|monthly|yearly|never).
     changefreq:
       homepage: weekly
@@ -702,13 +703,13 @@ seo:
       changelog: 0.6
       default: 0.5
   robots:
-    enabled: true          # Generate robots.txt
-    allow_all: true        # Allow all crawlers by default
-    disallow: []           # Paths to disallow, e.g. ["/drafts/", "/_internal/"]
-    crawl_delay: null      # Optional crawl delay in seconds
-    extra_rules: []        # Extra raw lines, e.g. ["User-agent: GPTBot", "Disallow: /"]
+    enabled: true # Generate robots.txt
+    allow_all: true # Allow all crawlers by default
+    disallow: [] # Paths to disallow, e.g. ["/drafts/", "/_internal/"]
+    crawl_delay: null # Optional crawl delay in seconds
+    extra_rules: [] # Extra raw lines, e.g. ["User-agent: GPTBot", "Disallow: /"]
   canonical:
-    enabled: true          # Add canonical URLs to pages
+    enabled: true # Add canonical URLs to pages
     # Base URL (e.g. "https://example.github.io/pkg/"); auto-detected from
     # GitHub Pages when null.
     base_url: null
@@ -717,6 +718,6 @@ seo:
   # page, show only the site name.
   title_template: "{page_title} | {site_name}"
   structured_data:
-    enabled: true              # Add JSON-LD to pages
-    type: SoftwareSourceCode   # Schema.org type
-  default_description: null   # Falls back to the package description when null
+    enabled: true # Add JSON-LD to pages
+    type: SoftwareSourceCode # Schema.org type
+  default_description: null # Falls back to the package description when null

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -11,6 +11,7 @@ from typing import Any
 from yaml12 import format_yaml, parse_yaml, read_yaml, write_yaml
 
 from ._subprocess import TEXT_MODE_KWARGS
+from ._typer_cli import is_cli_command, is_cli_group, param_kind, to_click_command
 from ._utils import QUARTO_YML_HEADER, is_great_docs_build_dir
 from .config import Config, create_default_config
 
@@ -1714,7 +1715,9 @@ class GreatDocs:
                                         entry["extras"] = sorted(req.extras)
                                     group_deps.append(entry)
                                 except Exception:  # pragma: no cover
-                                    group_deps.append({"name": dep_str, "specifier": ""})  # pragma: no cover
+                                    group_deps.append(
+                                        {"name": dep_str, "specifier": ""}
+                                    )  # pragma: no cover
                         opt_deps_full[group] = group_deps
                     metadata["optional_dependencies_full"] = opt_deps_full
 
@@ -4058,7 +4061,7 @@ class GreatDocs:
             return None
 
         try:
-            import click
+            import click  # noqa: F401  (availability guard; converters handle the rest)
         except ImportError:  # pragma: no cover
             print("Click not installed, skipping CLI documentation")  # pragma: no cover
             return None  # pragma: no cover
@@ -4083,10 +4086,10 @@ class GreatDocs:
                     import importlib
 
                     module = importlib.import_module(module_path)
-                    # Look for Click command/group in module
+                    # Look for a Click command/group or Typer app in the module
                     for attr_name in dir(module):
                         attr = getattr(module, attr_name)
-                        if isinstance(attr, (click.Command, click.Group)):
+                        if is_cli_command(attr):
                             cli_module_path = module_path
                             break
                     if cli_module_path:
@@ -4114,25 +4117,29 @@ class GreatDocs:
         if cli_name:
             cli_obj = getattr(module, cli_name, None)
 
-        # Otherwise, search for Click commands/groups
+        # Otherwise, search for Click commands/groups (or Typer apps)
         if not cli_obj:
             for attr_name in ["cli", "main", "app", "command", importable_name]:
                 attr = getattr(module, attr_name, None)
-                if isinstance(attr, (click.Command, click.Group)):
+                if is_cli_command(attr):
                     cli_obj = attr
                     cli_name = attr_name
                     break
 
-        # If still not found, look for any Click command/group
+        # If still not found, look for any Click command/group or Typer app
         if not cli_obj:
             for attr_name in dir(module):
                 if attr_name.startswith("_"):
                     continue
                 attr = getattr(module, attr_name)
-                if isinstance(attr, (click.Command, click.Group)):
+                if is_cli_command(attr):
                     cli_obj = attr
                     cli_name = attr_name
                     break
+
+        # Normalize to a Click command so the extraction below can introspect
+        # params/subcommands uniformly (Typer apps are converted here).
+        cli_obj = to_click_command(cli_obj)
 
         if not cli_obj:
             print(f"No Click command/group found in {cli_module_path}")
@@ -4157,7 +4164,7 @@ class GreatDocs:
         if not metadata.get("cli_enabled", False):
             return None
         try:
-            import click
+            import click  # noqa: F401  (availability guard; converters handle the rest)
         except ImportError:
             return None
 
@@ -4173,10 +4180,7 @@ class GreatDocs:
                     import importlib
 
                     m = importlib.import_module(mod)
-                    if any(
-                        isinstance(getattr(m, a, None), (click.Command, click.Group))
-                        for a in dir(m)
-                    ):
+                    if any(is_cli_command(getattr(m, a, None)) for a in dir(m)):
                         cli_module_path = mod
                         break
                 except ImportError:
@@ -4192,20 +4196,20 @@ class GreatDocs:
 
         cli_name = metadata.get("cli_name")
         if cli_name:
-            obj = getattr(module, cli_name, None)
-            if isinstance(obj, (click.Command, click.Group)):
+            obj = to_click_command(getattr(module, cli_name, None))
+            if obj is not None:
                 return obj
 
         for attr_name in ["cli", "main", "app", "command", importable_name]:
-            obj = getattr(module, attr_name, None)
-            if isinstance(obj, (click.Command, click.Group)):
+            obj = to_click_command(getattr(module, attr_name, None))
+            if obj is not None:
                 return obj
 
         for attr_name in dir(module):
             if attr_name.startswith("_"):
                 continue
-            obj = getattr(module, attr_name)
-            if isinstance(obj, (click.Command, click.Group)):
+            obj = to_click_command(getattr(module, attr_name))
+            if obj is not None:
                 return obj
         return None
 
@@ -4271,22 +4275,23 @@ class GreatDocs:
             Dictionary containing command information including options, arguments, and parsed
             examples.
         """
-        import click
-
         full_path = f"{parent_path} {name}".strip() if parent_path else name
 
         # Get the actual --help output from Click
         help_text = self._get_click_help_text(cmd, full_path)
 
-        # Extract options and arguments from Click params
+        # Extract options and arguments from the params. Parameters are classified
+        # by Click's `param_type_name` rather than `isinstance` so this works
+        # for Typer's vendored-Click parameters too (see `_typer_cli`).
         options = []
         arguments = []
         for param in cmd.params:
-            if isinstance(param, click.Option):
+            kind = param_kind(param)
+            if kind == "option":
                 opt_info = self._extract_click_option(param)
                 if opt_info:
                     options.append(opt_info)
-            elif isinstance(param, click.Argument):
+            elif kind == "argument":
                 arg_info = self._extract_click_argument(param)
                 if arg_info:
                     arguments.append(arg_info)
@@ -4309,7 +4314,7 @@ class GreatDocs:
             "deprecated": getattr(cmd, "deprecated", False),
             "hidden": getattr(cmd, "hidden", False),
             "commands": [],
-            "is_group": isinstance(cmd, click.Group),
+            "is_group": is_cli_group(cmd),
             "options": options,
             "arguments": arguments,
             "description": description,
@@ -4317,7 +4322,7 @@ class GreatDocs:
         }
 
         # Extract subcommands if this is a group
-        if isinstance(cmd, click.Group):
+        if is_cli_group(cmd):
             for subcmd_name, subcmd in cmd.commands.items():
                 if not getattr(subcmd, "hidden", False):
                     subcmd_info = self._extract_click_command(subcmd, subcmd_name, full_path)
@@ -4345,11 +4350,16 @@ class GreatDocs:
         ):
             default = None
 
+        # Flags have no meaningful value type. Plain Click reports the type name
+        # "BOOL" for these; Typer's vendored Click reports "boolean" instead, so
+        # suppress the type for any flag rather than relying on the name.
+        opt_type = None if param.is_flag or type_name.upper() == "BOOL" else type_name.upper()
+
         return {
             "names": names,
             "name_display": ", ".join(names),
             "help": param.help or "",
-            "type": type_name.upper() if type_name != "BOOL" else None,
+            "type": opt_type,
             "default": default,
             "required": param.required,
             "is_flag": param.is_flag,
@@ -4489,10 +4499,10 @@ class GreatDocs:
         str
             The formatted help text as it would appear from `--help`.
         """
-        import click
-
-        # Create a context to get the help text
-        ctx = click.Context(cmd, info_name=full_path)
+        # Build the context from the command's own `context_class` so the help
+        # is rendered by the same Click the command belongs to. This matters for
+        # Typer, which vendors its own Click (see `_typer_cli`).
+        ctx = cmd.context_class(cmd, info_name=full_path)
         return cmd.get_help(ctx)
 
     def _generate_cli_reference_pages(self, cli_info: dict) -> list[str | dict]:
@@ -6286,7 +6296,9 @@ class GreatDocs:
                 if root_index_file:  # pragma: no cover
                     href = get_clean_href(root_index_file)  # pragma: no cover
                     if root_index_file.get("title"):  # pragma: no cover
-                        contents.append({"text": root_index_file["title"], "href": href})  # pragma: no cover
+                        contents.append(
+                            {"text": root_index_file["title"], "href": href}
+                        )  # pragma: no cover
                     else:
                         contents.append(href)  # pragma: no cover
 
@@ -9661,7 +9673,9 @@ class GreatDocs:
                     lines.append(f"        members: false  # {method_count} methods listed below")
                     large_classes.append(class_name)
                 elif method_count > 0:  # pragma: no cover
-                    lines.append(f"      - {class_name}  # {method_count} method(s)")  # pragma: no cover
+                    lines.append(
+                        f"      - {class_name}  # {method_count} method(s)"
+                    )  # pragma: no cover
                 else:
                     lines.append(f"      - {class_name}")
             has_prev_section = True
@@ -10251,7 +10265,9 @@ class GreatDocs:
             if not _curated_skill:
                 pkg_name = self._detect_package_name() or ""
                 for cand in [pkg_name.replace("_", "-"), pkg_name]:  # pragma: no cover
-                    if cand and (package_root / "skills" / cand / "SKILL.md").exists():  # pragma: no cover
+                    if (
+                        cand and (package_root / "skills" / cand / "SKILL.md").exists()
+                    ):  # pragma: no cover
                         _curated_skill = True  # pragma: no cover
                         break  # pragma: no cover
 
@@ -14640,7 +14656,9 @@ anchor-sections: true
             name = entry.get("name")
             file_path = entry.get("file")
             if not name or not file_path:  # pragma: no cover
-                print(f"Warning: skill.skills[{i}] missing 'name' or 'file', skipping")  # pragma: no cover
+                print(
+                    f"Warning: skill.skills[{i}] missing 'name' or 'file', skipping"
+                )  # pragma: no cover
                 continue  # pragma: no cover
 
             src = package_root / file_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dev = [
     "polars>=0.20",
     "pyarrow>=12.0",
     "mcp>=1.0.0",
+    "typer>=0.12.0",
 ]
 docs = [
     "jupyter>=1.0.0",

--- a/test-packages/synthetic/catalog.py
+++ b/test-packages/synthetic/catalog.py
@@ -69,6 +69,7 @@ ALL_PACKAGES: list[str] = [
     # 46–47: CLI documentation
     "gdtest_cli_click",  # 46
     "gdtest_cli_nested",  # 47
+    "gdtest_cli_typer",  # 46b (Typer CLI; vendors Click)
     # 48–50: Config-driven features
     "gdtest_explicit_ref",  # 48
     "gdtest_kitchen_sink",  # 49
@@ -962,6 +963,13 @@ PACKAGE_DESCRIPTIONS: dict[str, str] = {
         "and config group (show, set). The CLI Reference should show the "
         "multi-level command hierarchy with subgroups. The API Reference "
         "should show Engine (class) and run_task (function)."
+    ),
+    "gdtest_cli_typer": (
+        "A package whose CLI is built with Typer (which vendors its own copy of "
+        "Click) and cli.enabled=true in config. The sidebar should show a CLI "
+        "Reference section documenting the Typer commands: top-level format and "
+        "version commands, plus a nested db group (clear, info). The API "
+        "Reference should show Formatter (class) and format_text (function)."
     ),
     "gdtest_explicit_ref": (
         "Reference structure is defined in great-docs.yml with two sections: "

--- a/test-packages/synthetic/specs/gdtest_cli_typer.py
+++ b/test-packages/synthetic/specs/gdtest_cli_typer.py
@@ -1,0 +1,151 @@
+"""
+gdtest_cli_typer — Typer CLI documentation.
+
+Dimensions: A1, B1, C1, D1, E1+E6, F6, G1, H7
+Focus: Typer CLI discovery and documentation generation.
+
+Typer vendors its own copy of Click, so the app object is not a plain
+`click.Command`; great-docs converts it via `typer.main.get_command` and then
+reuses the same Click introspection path. The app has a nested sub-app
+(`add_typer`) so the grouped/nested sidebar structure is exercised too.
+"""
+
+SPEC = {
+    "name": "gdtest_cli_typer",
+    "description": "Typer CLI with a nested sub-app and CLI docs enabled",
+    "dimensions": ["A1", "B1", "C1", "D1", "E1", "E6", "F6", "G1", "H7"],
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-cli-typer",
+            "version": "0.1.0",
+            "description": "A package with a Typer CLI",
+            "scripts": {
+                "gdtest-typer": "gdtest_cli_typer.cli:app",
+            },
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    },
+    "files": {
+        "gdtest_cli_typer/__init__.py": '''\
+            """A package with Typer CLI support."""
+
+            __version__ = "0.1.0"
+            __all__ = ["Formatter", "format_text"]
+
+
+            class Formatter:
+                """
+                A text formatter.
+
+                Parameters
+                ----------
+                style
+                    The formatting style to use.
+                """
+
+                def __init__(self, style: str = "default"):
+                    self.style = style
+
+                def apply(self, text: str) -> str:
+                    """
+                    Apply formatting to text.
+
+                    Parameters
+                    ----------
+                    text
+                        The text to format.
+
+                    Returns
+                    -------
+                    str
+                        Formatted text.
+                    """
+                    return text
+
+
+            def format_text(text: str, style: str = "default") -> str:
+                """
+                Format text with a given style.
+
+                Parameters
+                ----------
+                text
+                    The text to format.
+                style
+                    The style to apply.
+
+                Returns
+                -------
+                str
+                    Formatted text.
+                """
+                return Formatter(style).apply(text)
+        ''',
+        "gdtest_cli_typer/cli.py": '''\
+            """CLI entry point using Typer."""
+
+            import typer
+
+            app = typer.Typer(help="Format and manage text with the gdtest-cli-typer tool.")
+
+            db_app = typer.Typer(help="Manage the formatting cache database.")
+            app.add_typer(db_app, name="db")
+
+
+            @app.command()
+            def format(
+                text: str,
+                style: str = typer.Option("default", "--style", "-s", help="Formatting style."),
+                verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output."),
+            ) -> None:
+                """Format TEXT using the configured formatter."""
+                if verbose:
+                    typer.echo(f"Formatting with style: {style}")
+                typer.echo(text)
+
+
+            @app.command()
+            def version() -> None:
+                """Show the tool version and exit."""
+                typer.echo("0.1.0")
+
+
+            @db_app.command()
+            def clear(force: bool = typer.Option(False, "--force", help="Skip confirmation.")) -> None:
+                """Clear the formatting cache."""
+                typer.echo("cleared" if force else "confirm?")
+
+
+            @db_app.command()
+            def info() -> None:
+                """Show cache database info."""
+                typer.echo("cache info")
+        ''',
+        "README.md": """\
+            # gdtest-cli-typer
+
+            A test package with Typer CLI support.
+        """,
+    },
+    "config": {
+        "cli": {
+            "enabled": True,
+        },
+    },
+    "expected": {
+        "detected_name": "gdtest-cli-typer",
+        "detected_module": "gdtest_cli_typer",
+        "detected_parser": "numpy",
+        "export_names": ["Formatter", "format_text"],
+        "num_exports": 2,
+        "section_titles": ["Classes", "Functions"],
+        "has_user_guide": False,
+        "cli_enabled": True,
+        "cli_has_groups": True,
+        "cli_group_names": ["db"],
+        "coverage_exclude": ["nodoc", "bigcl", "ug", "supp", "hdg"],
+    },
+}

--- a/tests/test_typer_cli.py
+++ b/tests/test_typer_cli.py
@@ -10,6 +10,7 @@ CLI.
 from __future__ import annotations
 
 import importlib
+import sys
 import types
 from pathlib import Path
 from unittest.mock import patch
@@ -94,6 +95,25 @@ class TestTyperHelpers:
         assert to_click_command("nope") is None
         assert to_click_command(object()) is None
         assert to_click_command(None) is None
+
+    def test_is_typer_app_false_when_typer_not_installed(self, monkeypatch):
+        """Graceful degradation: no Typer installed -> not a Typer app (no raise)."""
+        from great_docs._typer_cli import is_typer_app
+
+        # A None entry in sys.modules makes `import typer` raise ImportError.
+        monkeypatch.setitem(sys.modules, "typer", None)
+
+        assert is_typer_app(object()) is False
+
+    def test_to_click_command_returns_none_when_typer_not_installed(self, monkeypatch):
+        """A non-Click object cannot be coerced when Typer is unavailable."""
+        from great_docs._typer_cli import to_click_command
+
+        monkeypatch.setitem(sys.modules, "typer", None)
+
+        # Click is still importable, so this reaches (and survives) the failed
+        # Typer import before returning None.
+        assert to_click_command(object()) is None
 
     def test_is_cli_command(self):
         from great_docs._typer_cli import is_cli_command

--- a/tests/test_typer_cli.py
+++ b/tests/test_typer_cli.py
@@ -1,0 +1,243 @@
+# pyright: reportPrivateUsage=false
+"""Tests for Typer CLI support (`great_docs._typer_cli` and discovery paths).
+
+Typer vendors its own copy of Click, so a `typer.Typer` app converts to a command whose classes are
+*not* instances of the top-level `click` package. These tests exercise the conversion and the
+duck-typed introspection helpers, as well as the discovery/snapshot code paths that document a Typer
+CLI.
+"""
+
+from __future__ import annotations
+
+import importlib
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import click
+import pytest
+
+from great_docs import GreatDocs
+
+typer = pytest.importorskip("typer")
+
+
+def _make_gd(tmp_path: Path) -> GreatDocs:
+    (tmp_path / "great-docs.yml").write_text("module: mypkg\n", encoding="utf-8")
+    return GreatDocs(project_path=str(tmp_path))
+
+
+def _sample_app() -> "typer.Typer":
+    """A Typer app with two top-level commands and a nested sub-app."""
+    app = typer.Typer(help="Root help.")
+
+    @app.command()
+    def greet(name: str, count: int = 1, loud: bool = False):
+        """Greet NAME."""
+
+    @app.command()
+    def version():
+        """Show the version."""
+
+    db = typer.Typer(help="Database commands.")
+    app.add_typer(db, name="db")
+
+    @db.command()
+    def migrate(revision: str = "head"):
+        """Run migrations."""
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Helpers in _typer_cli
+# ---------------------------------------------------------------------------
+
+
+class TestTyperHelpers:
+    def test_is_typer_app_true(self):
+        from great_docs._typer_cli import is_typer_app
+
+        assert is_typer_app(typer.Typer()) is True
+
+    def test_is_typer_app_false_for_other_objects(self):
+        from great_docs._typer_cli import is_typer_app
+
+        assert is_typer_app(click.Command("x")) is False
+        assert is_typer_app("not an app") is False
+
+    def test_to_click_command_converts_typer_app(self):
+        from great_docs._typer_cli import is_cli_group, to_click_command
+
+        cmd = to_click_command(_sample_app())
+
+        assert cmd is not None
+
+        # The converted top-level command is a group with the registered commands.
+        assert is_cli_group(cmd)
+        assert set(cmd.commands) == {"greet", "version", "db"}
+
+    def test_to_click_command_passthrough_for_click(self):
+        from great_docs._typer_cli import to_click_command
+
+        c = click.Command("x")
+
+        assert to_click_command(c) is c
+
+        g = click.Group("g")
+
+        assert to_click_command(g) is g
+
+    def test_to_click_command_returns_none_for_non_cli(self):
+        from great_docs._typer_cli import to_click_command
+
+        assert to_click_command("nope") is None
+        assert to_click_command(object()) is None
+        assert to_click_command(None) is None
+
+    def test_is_cli_command(self):
+        from great_docs._typer_cli import is_cli_command
+
+        assert is_cli_command(_sample_app()) is True
+        assert is_cli_command(click.Command("x")) is True
+        assert is_cli_command(42) is False
+
+    def test_is_cli_group_leaf_vs_group(self):
+        from great_docs._typer_cli import is_cli_group, to_click_command
+
+        # A single-command Typer app converts to a leaf command (no subcommands).
+        leaf_app = typer.Typer()
+
+        @leaf_app.command()
+        def only(name: str):
+            """Just one command."""
+
+        leaf = to_click_command(leaf_app)
+
+        assert is_cli_group(leaf) is False
+
+        group = to_click_command(_sample_app())
+
+        assert is_cli_group(group) is True
+
+    def test_param_kind_classifies_typer_params(self):
+        from great_docs._typer_cli import param_kind, to_click_command
+
+        cmd = to_click_command(_sample_app())
+        greet = cmd.commands["greet"]
+        kinds = {p.name: param_kind(p) for p in greet.params}
+
+        assert kinds["name"] == "argument"
+        assert kinds["count"] == "option"
+        assert kinds["loud"] == "option"
+
+
+# ---------------------------------------------------------------------------
+# Discovery + extraction through the GreatDocs API
+# ---------------------------------------------------------------------------
+
+
+class TestTyperDiscovery:
+    def _patch_typer_module(self, monkeypatch):
+        """Return a fake `mypkg.cli` module exposing a Typer `app`."""
+        fake_mod = types.ModuleType("mypkg.cli")
+        fake_mod.app = _sample_app()
+        real_import = importlib.import_module
+
+        def mock_import(name, *args, **kwargs):
+            if name == "mypkg.cli":
+                return fake_mod
+            return real_import(name, *args, **kwargs)
+
+        return fake_mod, mock_import
+
+    def test_find_click_cli_obj_returns_converted_typer(self, tmp_path, monkeypatch):
+        gd = _make_gd(tmp_path)
+        monkeypatch.setattr(
+            gd,
+            "_get_package_metadata",
+            lambda: {"cli_enabled": True, "cli_module": "mypkg.cli"},
+        )
+        _fake, mock_import = self._patch_typer_module(monkeypatch)
+
+        with patch("importlib.import_module", side_effect=mock_import):
+            obj = gd._find_click_cli_obj("mypkg")
+
+        assert obj is not None
+
+        # Converted object is introspectable as a Click-style group.
+        assert hasattr(obj, "commands")
+        assert set(obj.commands) == {"greet", "version", "db"}
+
+    def test_discover_click_cli_extracts_typer_tree(self, tmp_path, monkeypatch):
+        gd = _make_gd(tmp_path)
+        monkeypatch.setattr(
+            gd,
+            "_get_package_metadata",
+            lambda: {"cli_enabled": True, "cli_module": "mypkg.cli"},
+        )
+        # No [project.scripts] in the temp project -> falls back to display name.
+        monkeypatch.setattr(gd, "_get_cli_entry_point_name", lambda _pkg: "mytool")
+        _fake, mock_import = self._patch_typer_module(monkeypatch)
+
+        with patch("importlib.import_module", side_effect=mock_import):
+            info = gd._discover_click_cli("mypkg", display_name="mypkg")
+
+        assert info is not None
+        assert info["is_group"] is True
+        assert info["entry_point_name"] == "mytool"
+
+        names = {c["name"] for c in info["commands"]}
+
+        assert names == {"greet", "version", "db"}
+
+        greet = next(c for c in info["commands"] if c["name"] == "greet")
+
+        assert [a["name"] for a in greet["arguments"]] == ["name"]
+
+        opt_names = {o["name_display"] for o in greet["options"]}
+
+        assert "--count" in opt_names
+
+        # The boolean flag carries no value-type (regression: Typer reports
+        # the type name "boolean", which must not leak through as a type). Typer
+        # renders a bool option as a `--loud/--no-loud` pair.
+        loud = next(o for o in greet["options"] if "--loud" in o["names"])
+
+        assert loud["is_flag"] is True
+        assert loud["type"] is None
+
+        # Nested sub-app becomes a nested group with its own subcommands.
+        db = next(c for c in info["commands"] if c["name"] == "db")
+
+        assert db["is_group"] is True
+        assert [c["name"] for c in db["commands"]] == ["migrate"]
+
+
+# ---------------------------------------------------------------------------
+# API-diff CLI snapshots
+# ---------------------------------------------------------------------------
+
+
+class TestTyperSnapshot:
+    def test_snapshot_cli_from_click_accepts_typer_app(self):
+        from great_docs._api_diff import snapshot_cli_from_click
+
+        snap = snapshot_cli_from_click(_sample_app())
+
+        assert snap is not None
+        assert snap.is_group is True
+
+        sub_names = {c.name for c in snap.subcommands}
+
+        assert sub_names == {"greet", "version", "db"}
+
+        db = next(c for c in snap.subcommands if c.name == "db")
+
+        assert db.is_group is True
+        assert {c.name for c in db.subcommands} == {"migrate"}
+
+    def test_snapshot_cli_from_click_rejects_non_cli(self):
+        from great_docs._api_diff import snapshot_cli_from_click
+
+        assert snapshot_cli_from_click("not a cli") is None


### PR DESCRIPTION
This PR adds support for adding Typer CLIs in the reference docs. This detects a `typer.Typer` app during CLI discovery and converts it to a Click command tree via `typer.main.get_command()`. Then, it reuses the existing extraction/rendering path. Works through the same `cli.enabled` config (so no new options).

Fixes: https://github.com/posit-dev/great-docs/issues/332