### PR TITLE
Set is_error on MCP tool call failures

### DIFF
--- a/great_docs/mcp.py
+++ b/great_docs/mcp.py
@@ -370,6 +370,16 @@ async def list_tools() -> list[Tool]:
 # ---------------------------------------------------------------------------
 
 
+class _ToolCallContent(list[TextContent]):
+    """list[TextContent] that also carries whether the call ended in error.
+
+    call_tool() is tested directly as a plain list of TextContent, so this
+    stays a list subclass; is_error just rides along for callers that check.
+    """
+
+    is_error: bool = False
+
+
 @_handler("call_tool")
 async def call_tool(name: str, arguments: dict) -> list[TextContent]:
     """Dispatch tool calls to their implementations."""
@@ -391,9 +401,13 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         elif name == "gd_api_diff":
             return await _handle_api_diff(arguments)
         else:
-            return [TextContent(type="text", text=f"Unknown tool: {name}")]
+            result = _ToolCallContent([TextContent(type="text", text=f"Unknown tool: {name}")])
+            result.is_error = True
+            return result
     except Exception as e:
-        return [TextContent(type="text", text=f"Error: {e}")]
+        result = _ToolCallContent([TextContent(type="text", text=f"Error: {e}")])
+        result.is_error = True
+        return result
 
 
 async def _handle_build(arguments: dict) -> list[TextContent]:
@@ -1322,7 +1336,10 @@ if not _MCP_V1 and _V2_HANDLERS:
             getattr(params, "name", ""),
             getattr(params, "arguments", {}) or {},
         )
-        return CallToolResult(content=list(content or []))  # pragma: no cover
+        return CallToolResult(  # pragma: no cover
+            content=list(content or []),
+            is_error=getattr(content, "is_error", False),
+        )
 
     async def _on_list_prompts(ctx: Any, params: Any = None) -> Any:  # pragma: no cover
         return ListPromptsResult(prompts=await _raw["list_prompts"]())  # pragma: no cover

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pydantic import AnyUrl
 
+import great_docs.mcp as mcp_module
 from great_docs._utils import QUARTO_YML_HEADER
 from great_docs.mcp import (
     _build_output_dirs,
@@ -30,7 +31,6 @@ from great_docs.mcp import (
     list_tools,
     read_resource,
 )
-
 
 # ---------------------------------------------------------------------------
 # _get_project_root
@@ -148,11 +148,57 @@ class TestCallTool:
         assert len(result) == 1
         assert "Unknown tool" in result[0].text
 
+    def test_unknown_tool_marks_is_error(self):
+        result = asyncio.run(call_tool("no_such_tool", {}))
+        assert result.is_error is True
+
     def test_exception_in_handler_returns_error_text(self):
         with patch("great_docs.mcp._handle_build", side_effect=RuntimeError("boom")):
             result = asyncio.run(call_tool("gd_build", {}))
         assert "Error" in result[0].text
         assert "boom" in result[0].text
+
+    def test_exception_in_handler_marks_is_error(self):
+        with patch("great_docs.mcp._handle_build", side_effect=RuntimeError("boom")):
+            result = asyncio.run(call_tool("gd_build", {}))
+        assert result.is_error is True
+
+    def test_successful_call_does_not_mark_is_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        result = asyncio.run(call_tool("gd_status", {}))
+        assert getattr(result, "is_error", False) is False
+
+
+@pytest.mark.skipif(
+    mcp_module._MCP_V1, reason="_on_call_tool only exists on the mcp v2 handler path"
+)
+class TestOnCallToolIsError:
+    """CallToolResult.is_error must reflect a failed dispatch (issue: it never did)."""
+
+    def _params(self, name: str, arguments: dict):
+        params = MagicMock()
+        params.name = name
+        params.arguments = arguments
+        return params
+
+    def test_unknown_tool_sets_is_error(self):
+        result = asyncio.run(mcp_module._on_call_tool(None, self._params("bogus_tool_name", {})))
+        assert result.is_error is True
+        assert "Unknown tool" in result.content[0].text
+
+    def test_handler_exception_sets_is_error(self):
+        params = self._params("gd_build", {"project_path": "/does/not/exist"})
+        result = asyncio.run(mcp_module._on_call_tool(None, params))
+        assert result.is_error is True
+
+    def test_successful_call_leaves_is_error_false(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        result = asyncio.run(mcp_module._on_call_tool(None, self._params("gd_status", {})))
+        assert result.is_error is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`call_tool()` catches its own exceptions and the unknown-tool case and returns them as ordinary `TextContent`, so `_on_call_tool` never sees a raise and `CallToolResult.is_error` stays `False` either way. An agent client can only tell success from failure by pattern-matching the text.

Kept the friendly `"Unknown tool: ..."` / `"Error: ..."` text (existing tests assert on it) but wrapped it in a small list subclass that carries `is_error`, and had `_on_call_tool` pass that through into `CallToolResult`.

Left the old `mcp<2.0` decorator path alone: that one is registered directly with the SDK, which only sets `isError` when the handler raises, and `call_tool()` can't raise without breaking the tests that call it directly for the text. It's already marked `pragma: no cover` in this file, so it isn't exercised either way.

Added tests for both branches (unknown tool, handler exception) on `call_tool()` and on `_on_call_tool`, plus one confirming a successful call leaves `is_error` false. `make test` passes on 3.11 and 3.13, `ruff check`/`format` clean.

Fixes #340
