### PR TITLE
build: replace jupyter with ipykernel and nbclient

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ requires-python = ">=3.11"
 dependencies = [
     "ipykernel>=6.0",
     "nbclient>=0.10",
+    "pyyaml>=6.0",
     "py-yaml12>=0.1.0",
     "click>=8.0.0",
     "griffe~=2.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "jupyter>=1.1.1",
+    "ipykernel>=6.0",
+    "nbclient>=0.10",
     "py-yaml12>=0.1.0",
     "click>=8.0.0",
     "griffe~=2.1.0",
@@ -74,7 +75,6 @@ dev = [
     "typer>=0.12.0",
 ]
 docs = [
-    "jupyter>=1.0.0",
     "plotnine>=0.13.0",
 ]
 
@@ -215,4 +215,3 @@ module = [
     "griffe.*",
 ]
 ignore_missing_imports = true
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ requires-python = ">=3.11"
 dependencies = [
     "ipykernel>=6.0",
     "nbclient>=0.10",
-    "pyyaml>=6.0",
     "py-yaml12>=0.1.0",
     "click>=8.0.0",
     "griffe~=2.1.0",


### PR DESCRIPTION
# Summary

Drop all dependencies from the `jupyter` meta-package that are not required by `great-docs` and the build-backend `quarto`. `pyyaml` was missing as a direct dependency.

# Related GitHub Issues and PRs

- Ref: #343 

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [ ] I have added **pytest** unit tests for any new functionality. (no new code).
