### PR TITLE
fix: pyyaml -> yaml12

### DIFF
--- a/great_docs/_api_diff.py
+++ b/great_docs/_api_diff.py
@@ -828,9 +828,9 @@ def _read_cli_module_at_tag(
             else:
                 # great-docs.yml — simple yaml parse
                 try:
-                    import yaml
+                    from yaml12 import parse_yaml
 
-                    data = yaml.safe_load(content) or {}
+                    data = parse_yaml(content) or {}
                     cli_cfg = data.get("cli", {})
                     if cli_cfg.get("enabled"):
                         return cli_cfg.get("module")

--- a/great_docs/_lint.py
+++ b/great_docs/_lint.py
@@ -552,7 +552,7 @@ def _check_stale_versions(project_root: Path, result: LintResult) -> None:
         where X is very old
       - `upcoming: "X"` frontmatter where X is already released
     """
-    import yaml
+    from yaml12 import read_yaml
 
     # Load great-docs.yml for versions list and optional lint config
     config_path = project_root / "great-docs.yml"
@@ -560,7 +560,7 @@ def _check_stale_versions(project_root: Path, result: LintResult) -> None:
         return
 
     try:
-        raw_config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        raw_config = read_yaml(config_path) or {}
     except Exception:
         return
 

--- a/great_docs/_skill_install.py
+++ b/great_docs/_skill_install.py
@@ -65,12 +65,7 @@ def _parse_frontmatter(content: str) -> tuple[dict, str]:
 
     Returns (frontmatter_dict, body_text).
     """
-    try:
-        from py_yaml12 import loads as parse_yaml
-    except ImportError:  # pragma: no cover
-        import yaml
-
-        parse_yaml = yaml.safe_load  # type: ignore[assignment]
+    from yaml12 import parse_yaml
 
     normalized = content.lstrip()
     if not normalized.startswith("---"):
@@ -673,16 +668,9 @@ def _stamp_install_metadata(content: str, pkg_version: str) -> str:
     metadata["content_hash"] = _content_hash(content)
 
     # Re-serialize frontmatter
-    try:
-        from py_yaml12 import dumps as format_yaml
-    except ImportError:  # pragma: no cover
-        import yaml
-
-        format_yaml = yaml.dump  # type: ignore[assignment]
+    from yaml12 import format_yaml
 
     fm_text = format_yaml(fm)
-    if isinstance(fm_text, bytes):
-        fm_text = fm_text.decode("utf-8")  # pragma: no cover
     return f"---\n{fm_text.rstrip()}\n---\n\n{body}"
 
 

--- a/great_docs/_term_player/script.py
+++ b/great_docs/_term_player/script.py
@@ -157,10 +157,10 @@ def load_script(path: str | Path) -> Script:
     Script
         Parsed script object.
     """
-    import yaml
+    from yaml12 import read_yaml
 
     p = Path(path)
-    data = yaml.safe_load(p.read_text(encoding="utf-8"))
+    data = read_yaml(p)
     if not isinstance(data, dict):
         return Script()
 

--- a/great_docs/_versioned_build.py
+++ b/great_docs/_versioned_build.py
@@ -354,9 +354,9 @@ def _prune_quarto_cli_sidebar(dest_dir: Path, valid_stems: set[str]) -> None:
         return
 
     try:
-        import yaml
+        from yaml12 import read_yaml, write_yaml
 
-        content = yaml.safe_load(quarto_yml.read_text(encoding="utf-8"))
+        content = read_yaml(quarto_yml)
         if not content:
             return
 
@@ -382,13 +382,7 @@ def _prune_quarto_cli_sidebar(dest_dir: Path, valid_stems: set[str]) -> None:
             break
 
         if modified:
-            yaml.dump(
-                content,
-                quarto_yml.open("w", encoding="utf-8"),
-                default_flow_style=False,
-                sort_keys=False,
-                allow_unicode=True,
-            )
+            write_yaml(content, quarto_yml)
     except Exception:  # pragma: no cover
         pass  # pragma: no cover
 
@@ -985,9 +979,9 @@ def _prune_quarto_sidebar(dest_dir: Path, section: str, valid_symbols: set[str])
         return
 
     try:
-        import yaml
+        from yaml12 import read_yaml, write_yaml
 
-        content = yaml.safe_load(quarto_yml.read_text(encoding="utf-8"))
+        content = read_yaml(quarto_yml)
         if not content:
             return
 
@@ -1050,13 +1044,7 @@ def _prune_quarto_sidebar(dest_dir: Path, section: str, valid_symbols: set[str])
                 modified = True
 
         if modified:
-            yaml.dump(
-                content,
-                quarto_yml.open("w", encoding="utf-8"),
-                default_flow_style=False,
-                sort_keys=False,
-                allow_unicode=True,
-            )
+            write_yaml(content, quarto_yml)
     except Exception:  # pragma: no cover
         pass  # pragma: no cover
 

--- a/great_docs/assets/_extensions/color-swatch/_color_swatch_shortcode.py
+++ b/great_docs/assets/_extensions/color-swatch/_color_swatch_shortcode.py
@@ -327,10 +327,10 @@ def compute_contrast_info(hex_str: str) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 try:
-    import yaml as _yaml
+    from yaml12 import parse_yaml as _parse_yaml_raw
 
     def _parse_yaml(text: str) -> list[dict[str, Any]]:
-        data = _yaml.safe_load(text)
+        data = _parse_yaml_raw(text)
         if isinstance(data, list):
             return data
         return []

--- a/great_docs/assets/post-render.py
+++ b/great_docs/assets/post-render.py
@@ -2460,10 +2460,10 @@ def inject_page_metadata():
                 if content.startswith("---"):
                     parts = content.split("---", 2)
                     if len(parts) >= 3:
-                        import yaml
+                        from yaml12 import parse_yaml
 
                         try:
-                            frontmatter = yaml.safe_load(parts[1]) or {}
+                            frontmatter = parse_yaml(parts[1]) or {}
                         except Exception:
                             pass
             except Exception:
@@ -3348,9 +3348,9 @@ for html_file in glob.glob("_site/**/*.html", recursive=True):
         parts = qmd_content.split("---", 2)
         if len(parts) < 3:
             continue
-        import yaml
+        from yaml12 import parse_yaml
 
-        fm = yaml.safe_load(parts[1]) or {}
+        fm = parse_yaml(parts[1]) or {}
     except Exception:
         continue
 

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -2709,10 +2709,7 @@ class GreatDocs:
         if not quarto_yml.is_file():
             return
 
-        import yaml
-
-        with open(quarto_yml, encoding="utf-8") as f:
-            config = yaml.safe_load(f)
+        config = read_yaml(quarto_yml)
 
         if "format" not in config or "html" not in config.get("format", {}):
             return  # pragma: no cover
@@ -2749,8 +2746,7 @@ class GreatDocs:
         else:
             entries.append(inline_entry)  # pragma: no cover
 
-        with open(quarto_yml, "w", encoding="utf-8") as f:
-            yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+        write_yaml(config, quarto_yml)
 
     @staticmethod
     def _tag_slug(tag_name: str) -> str:
@@ -2938,10 +2934,7 @@ class GreatDocs:
         if not quarto_yml.is_file():
             return
 
-        import yaml
-
-        with open(quarto_yml, encoding="utf-8") as f:
-            config = yaml.safe_load(f)
+        config = read_yaml(quarto_yml)
 
         if "format" not in config or "html" not in config.get("format", {}):
             return  # pragma: no cover
@@ -2976,8 +2969,7 @@ class GreatDocs:
         else:
             entries.append(inline_entry)
 
-        with open(quarto_yml, "w", encoding="utf-8") as f:
-            yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+        write_yaml(config, quarto_yml)
 
     def _process_page_statuses(self) -> bool:
         """

--- a/tests/test_api_diff.py
+++ b/tests/test_api_diff.py
@@ -1957,11 +1957,10 @@ def test_python_bridge_exists():
 
 
 def test_extension_yml_declares_shortcode():
-    import yaml
+    from yaml12 import read_yaml
 
     ext_yml = _ext_dir() / "_extension.yml"
-    with open(ext_yml) as f:
-        data = yaml.safe_load(f)
+    data = read_yaml(ext_yml)
 
     assert "contributes" in data
     assert "shortcodes" in data["contributes"]
@@ -3864,7 +3863,7 @@ def test_read_cli_module_yaml_parse_exception():
 
     with (
         patch("great_docs._api_diff.subprocess.run", side_effect=fake_run),
-        patch("yaml.safe_load", side_effect=Exception("yaml parse error")),
+        patch("yaml12.parse_yaml", side_effect=Exception("yaml parse error")),
     ):
         result = _read_cli_module_at_tag(Path("/project"), "v1.0", "mypkg")
 

--- a/tests/test_color_swatch.py
+++ b/tests/test_color_swatch.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 import pytest
-import yaml
+from yaml12 import read_yaml
 
 
 def _ext_dir() -> Path:
@@ -37,7 +37,7 @@ class TestColorSwatchExtensionFiles:
 
     def test_extension_yml_declares_shortcode(self):
         ext_yml = _ext_dir() / "_extension.yml"
-        data = yaml.safe_load(ext_yml.read_text())
+        data = read_yaml(ext_yml)
         assert "contributes" in data
         assert "shortcodes" in data["contributes"]
         assert "color-swatch.lua" in data["contributes"]["shortcodes"]

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -34175,10 +34175,10 @@ def _make_function_page(name="my_func"):
 
 def _front_matter_title(rendered: str) -> str:
     """Return the parsed YAML front-matter title, format-independent."""
-    import re, yaml
+    import re
 
     m = re.match(r"^---\n(.*?)\n---\n", rendered, re.DOTALL)
-    return yaml.safe_load(m.group(1)).get("title", "") if m else ""
+    return parse_yaml(m.group(1)).get("title", "") if m else ""
 
 
 def _make_class_page_with_members(name="MyClass"):
@@ -43159,10 +43159,7 @@ def test_add_section_sidebar_with_sidebar_groups():
             sidebar_groups=sidebar_groups,
         )
 
-        import yaml as pyyaml
-
-        with open(quarto_yml, encoding="utf-8") as f:
-            config = pyyaml.safe_load(f)
+        config = read_yaml(quarto_yml)
 
         sidebars = config["website"]["sidebar"]
         recipe_sidebar = next((s for s in sidebars if s.get("id") == "recipes"), None)
@@ -43209,10 +43206,7 @@ def test_add_section_sidebar_with_sidebar_groups_ungrouped_pages():
             sidebar_groups=sidebar_groups,
         )
 
-        import yaml as pyyaml
-
-        with open(quarto_yml, encoding="utf-8") as f:
-            config = pyyaml.safe_load(f)
+        config = read_yaml(quarto_yml)
 
         sidebars = config["website"]["sidebar"]
         guide_sidebar = next((s for s in sidebars if s.get("id") == "guides"), None)

--- a/tests/test_icon_shortcode.py
+++ b/tests/test_icon_shortcode.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 import pytest
-import yaml
+from yaml12 import read_yaml
 
 
 def _ext_dir() -> Path:
@@ -28,7 +28,7 @@ class TestIconExtensionFiles:
 
     def test_extension_yml_declares_shortcode(self):
         ext_yml = _ext_dir() / "_extension.yml"
-        data = yaml.safe_load(ext_yml.read_text())
+        data = read_yaml(ext_yml)
         assert "contributes" in data
         assert "shortcodes" in data["contributes"]
         assert "icon.lua" in data["contributes"]["shortcodes"]

--- a/tests/test_keys_shortcode.py
+++ b/tests/test_keys_shortcode.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-import yaml
+from yaml12 import read_yaml
 
 
 def _ext_dir() -> Path:
@@ -21,14 +21,14 @@ class TestKeysExtensionFiles:
 
     def test_extension_yml_declares_shortcode(self):
         ext_yml = _ext_dir() / "_extension.yml"
-        data = yaml.safe_load(ext_yml.read_text())
+        data = read_yaml(ext_yml)
         assert "contributes" in data
         assert "shortcodes" in data["contributes"]
         assert "keys.lua" in data["contributes"]["shortcodes"]
 
     def test_extension_yml_metadata(self):
         ext_yml = _ext_dir() / "_extension.yml"
-        data = yaml.safe_load(ext_yml.read_text())
+        data = read_yaml(ext_yml)
         assert data["title"] == "Keyboard Keys"
         assert data["author"] == "Great Docs"
         assert "version" in data

--- a/tests/test_tbl_preview.py
+++ b/tests/test_tbl_preview.py
@@ -601,10 +601,10 @@ class TestShortcodeExtensionFiles:
         assert (self._ext_dir() / "_tbl_preview_shortcode.py").exists()
 
     def test_extension_yml_declares_shortcode(self):
-        import yaml
+        from yaml12 import read_yaml
 
         ext_yml = self._ext_dir() / "_extension.yml"
-        config = yaml.safe_load(ext_yml.read_text())
+        config = read_yaml(ext_yml)
         shortcodes = config.get("contributes", {}).get("shortcodes", [])
         assert "tbl-preview.lua" in shortcodes
 

--- a/tests/test_term_editor.py
+++ b/tests/test_term_editor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import yaml
+from yaml12 import parse_yaml
 import pytest
 
 from great_docs._term_player.editor import _build_editor_data, _serialize_script
@@ -180,7 +180,7 @@ class TestSerializeScript:
             "snippets": [],
         }
         yaml_str = _serialize_script(script_data, "demo.termshow")
-        parsed = yaml.safe_load(yaml_str)
+        parsed = parse_yaml(yaml_str)
         assert parsed["source"] == "demo.termshow"
         assert parsed["settings"]["window_chrome"] == "colorful"
         assert "prompt" not in parsed["settings"]
@@ -202,7 +202,7 @@ class TestSerializeScript:
             "snippets": [],
         }
         yaml_str = _serialize_script(script_data, "demo.termshow")
-        parsed = yaml.safe_load(yaml_str)
+        parsed = parse_yaml(yaml_str)
         assert parsed["settings"]["prompt"] == "❯"
         assert "prompt_pattern" not in parsed["settings"]
 
@@ -221,7 +221,7 @@ class TestSerializeScript:
             "snippets": [],
         }
         yaml_str = _serialize_script(script_data, "demo.termshow")
-        parsed = yaml.safe_load(yaml_str)
+        parsed = parse_yaml(yaml_str)
         assert parsed["settings"]["prompt"] == "→"
         assert parsed["settings"]["prompt_pattern"] == r"^\$ "
 
@@ -240,7 +240,7 @@ class TestSerializeScript:
             "snippets": [],
         }
         yaml_str = _serialize_script(script_data, "demo.termshow")
-        parsed = yaml.safe_load(yaml_str)
+        parsed = parse_yaml(yaml_str)
         assert parsed["settings"]["font_family"] == "JetBrains Mono"
 
     def test_font_family_comma_list(self):
@@ -258,7 +258,7 @@ class TestSerializeScript:
             "snippets": [],
         }
         yaml_str = _serialize_script(script_data, "demo.termshow")
-        parsed = yaml.safe_load(yaml_str)
+        parsed = parse_yaml(yaml_str)
         assert parsed["settings"]["font_family"] == "JetBrains Mono, Fira Code, monospace"
 
     def test_speed_non_default_serialized(self):
@@ -276,7 +276,7 @@ class TestSerializeScript:
             "snippets": [],
         }
         yaml_str = _serialize_script(script_data, "demo.termshow")
-        parsed = yaml.safe_load(yaml_str)
+        parsed = parse_yaml(yaml_str)
         assert parsed["settings"]["speed"] == 2.0
 
     def test_speed_default_omitted(self):
@@ -294,7 +294,7 @@ class TestSerializeScript:
             "snippets": [],
         }
         yaml_str = _serialize_script(script_data, "demo.termshow")
-        parsed = yaml.safe_load(yaml_str)
+        parsed = parse_yaml(yaml_str)
         assert "speed" not in parsed["settings"]
 
     def test_chapters_serialized_sorted(self):
@@ -315,7 +315,7 @@ class TestSerializeScript:
             "snippets": [],
         }
         yaml_str = _serialize_script(script_data, "demo.termshow")
-        parsed = yaml.safe_load(yaml_str)
+        parsed = parse_yaml(yaml_str)
         assert parsed["chapters"][0]["label"] == "First"
         assert parsed["chapters"][1]["label"] == "Second"
 
@@ -336,7 +336,7 @@ class TestSerializeScript:
             ],
         }
         yaml_str = _serialize_script(script_data, "demo.termshow")
-        parsed = yaml.safe_load(yaml_str)
+        parsed = parse_yaml(yaml_str)
         assert parsed["snippets"][0]["match"] == r"\$ (.+)"
         assert parsed["snippets"][0]["label"] == "cmd"
 
@@ -367,7 +367,7 @@ class TestSerializeScript:
             ],
         }
         yaml_str = _serialize_script(script_data, "rec.termshow")
-        parsed = yaml.safe_load(yaml_str)
+        parsed = parse_yaml(yaml_str)
         s = parsed["settings"]
         assert s["speed"] == 3.0
         assert s["window_chrome"] == "simple"
@@ -395,7 +395,7 @@ class TestSerializeScript:
             "snippets": [],
         }
         yaml_str = _serialize_script(script_data, "x.termshow")
-        parsed = yaml.safe_load(yaml_str)
+        parsed = parse_yaml(yaml_str)
         assert parsed["source"] == "x.termshow"
         # No chapters/annotations/cuts/snippets keys when empty
         assert parsed.get("chapters") is None
@@ -405,7 +405,7 @@ class TestSerializeScript:
 
 
 # ---------------------------------------------------------------------------
-# Round-trip: _build_editor_data → _serialize_script → yaml.safe_load
+# Round-trip: _build_editor_data → _serialize_script → parse_yaml
 # ---------------------------------------------------------------------------
 
 
@@ -422,7 +422,7 @@ class TestEditorRoundTrip:
         )
         data = _build_editor_data(_make_recording(), script)
         yaml_str = _serialize_script(data["script"], "demo.termshow")
-        parsed = yaml.safe_load(yaml_str)
+        parsed = parse_yaml(yaml_str)
         s = parsed["settings"]
         assert s["speed"] == 1.5
         assert s["window_chrome"] == "simple"
@@ -434,7 +434,7 @@ class TestEditorRoundTrip:
         script = _make_script(prompt=None, prompt_pattern=None)
         data = _build_editor_data(_make_recording(), script)
         yaml_str = _serialize_script(data["script"], "demo.termshow")
-        parsed = yaml.safe_load(yaml_str)
+        parsed = parse_yaml(yaml_str)
         assert "prompt" not in parsed["settings"]
         assert "prompt_pattern" not in parsed["settings"]
 
@@ -442,7 +442,7 @@ class TestEditorRoundTrip:
         script = _make_script(font_family="JetBrains Mono, Fira Code, monospace")
         data = _build_editor_data(_make_recording(), script)
         yaml_str = _serialize_script(data["script"], "demo.termshow")
-        parsed = yaml.safe_load(yaml_str)
+        parsed = parse_yaml(yaml_str)
         assert parsed["settings"]["font_family"] == "JetBrains Mono, Fira Code, monospace"
 
     def test_full_round_trip(self):
@@ -462,7 +462,7 @@ class TestEditorRoundTrip:
         )
         data = _build_editor_data(_make_recording(), script)
         yaml_str = _serialize_script(data["script"], "demo.termshow")
-        parsed = yaml.safe_load(yaml_str)
+        parsed = parse_yaml(yaml_str)
 
         assert parsed["settings"]["prompt"] == ">"
         assert parsed["settings"]["font_family"] == "Menlo"
@@ -549,7 +549,7 @@ class TestSerializeScriptMissingBranches:
             {"time": 2.0, "duration": 3.0, "text": "echo hello", "match": "", "label": ""},
         ]
         result = _serialize_script(data, "demo.termshow")
-        parsed = yaml.safe_load(result)
+        parsed = parse_yaml(result)
         assert parsed["snippets"][0]["text"] == "echo hello"
         assert "match" not in result or "match: ''" not in result
 

--- a/tests/test_versioned_build.py
+++ b/tests/test_versioned_build.py
@@ -1516,7 +1516,7 @@ class TestRewriteCliIndex:
 
 class TestPruneQuartoCliSidebar:
     def test_removes_invalid_sidebar_entries(self, tmp_path: Path):
-        import yaml
+        from yaml12 import format_yaml, parse_yaml
 
         from great_docs._versioned_build import _prune_quarto_cli_sidebar
 
@@ -1535,11 +1535,11 @@ class TestPruneQuartoCliSidebar:
                 ]
             }
         }
-        quarto.write_text(yaml.dump(config), encoding="utf-8")
+        quarto.write_text(format_yaml(config), encoding="utf-8")
 
         _prune_quarto_cli_sidebar(tmp_path, {"index", "build"})
 
-        result = yaml.safe_load(quarto.read_text())
+        result = parse_yaml(quarto.read_text())
         contents = result["website"]["sidebar"][0]["contents"]
         stems = [Path(c).stem for c in contents]
         assert "build" in stems
@@ -1785,7 +1785,7 @@ class TestPruneReferenceIndex:
 
 class TestPruneQuartoSidebar:
     def test_removes_invalid_reference_entries(self, tmp_path: Path):
-        import yaml
+        from yaml12 import format_yaml, parse_yaml
 
         from great_docs._versioned_build import _prune_quarto_sidebar
 
@@ -1804,11 +1804,11 @@ class TestPruneQuartoSidebar:
                 ]
             }
         }
-        quarto.write_text(yaml.dump(config), encoding="utf-8")
+        quarto.write_text(format_yaml(config), encoding="utf-8")
 
         _prune_quarto_sidebar(tmp_path, "reference", {"MyFunc", "MyClass"})
 
-        result = yaml.safe_load(quarto.read_text())
+        result = parse_yaml(quarto.read_text())
         contents = result["website"]["sidebar"][0]["contents"]
         stems = [Path(c).stem for c in contents]
         assert "MyFunc" in stems
@@ -1816,7 +1816,7 @@ class TestPruneQuartoSidebar:
         assert "OldFunc" not in stems
 
     def test_removes_empty_section_groups(self, tmp_path: Path):
-        import yaml
+        from yaml12 import format_yaml, parse_yaml
 
         from great_docs._versioned_build import _prune_quarto_sidebar
 
@@ -1837,11 +1837,11 @@ class TestPruneQuartoSidebar:
                 ]
             }
         }
-        quarto.write_text(yaml.dump(config), encoding="utf-8")
+        quarto.write_text(format_yaml(config), encoding="utf-8")
 
         _prune_quarto_sidebar(tmp_path, "reference", {"Kept"})
 
-        result = yaml.safe_load(quarto.read_text())
+        result = parse_yaml(quarto.read_text())
         contents = result["website"]["sidebar"][0]["contents"]
         # The section group with "OldFunc" should be removed
         assert len(contents) == 1
@@ -2572,7 +2572,7 @@ class TestPruneReferenceIndexDefinitionList:
 class TestPruneQuartoSidebarSubPath:
     def test_keeps_sub_paths(self, tmp_path: Path):
         """Sub-paths like reference/cli/build.qmd are kept (not pruned)."""
-        import yaml
+        from yaml12 import format_yaml, parse_yaml
 
         from great_docs._versioned_build import _prune_quarto_sidebar
 
@@ -2591,29 +2591,29 @@ class TestPruneQuartoSidebarSubPath:
                 ]
             }
         }
-        quarto.write_text(yaml.dump(config), encoding="utf-8")
+        quarto.write_text(format_yaml(config), encoding="utf-8")
 
         _prune_quarto_sidebar(tmp_path, "reference", {"MyFunc"})
 
-        result = yaml.safe_load(quarto.read_text())
+        result = parse_yaml(quarto.read_text())
         contents = result["website"]["sidebar"][0]["contents"]
         assert "reference/MyFunc.qmd" in contents
         assert "reference/cli/build.qmd" in contents  # sub-path kept
         assert "reference/Removed.qmd" not in contents
 
     def test_no_matching_sidebar_does_nothing(self, tmp_path: Path):
-        import yaml
+        from yaml12 import format_yaml, parse_yaml
 
         from great_docs._versioned_build import _prune_quarto_sidebar
 
         quarto = tmp_path / "_quarto.yml"
         config = {"website": {"sidebar": [{"id": "other", "contents": ["guide.qmd"]}]}}
-        quarto.write_text(yaml.dump(config), encoding="utf-8")
+        quarto.write_text(format_yaml(config), encoding="utf-8")
 
         _prune_quarto_sidebar(tmp_path, "reference", {"func"})
 
         # File should be unchanged since no sidebar matches
-        result = yaml.safe_load(quarto.read_text())
+        result = parse_yaml(quarto.read_text())
         assert result["website"]["sidebar"][0]["contents"] == ["guide.qmd"]
 
     def test_no_quarto_yml_does_nothing(self, tmp_path: Path):
@@ -3600,7 +3600,7 @@ class TestPreprocessVersionGitRef:
 
 class TestPruneQuartoSidebarNestedSectionGroup:
     def test_removes_empty_section_group(self, tmp_path: Path):
-        import yaml
+        from yaml12 import format_yaml, parse_yaml
 
         from great_docs._versioned_build import _prune_quarto_sidebar
 
@@ -3624,18 +3624,18 @@ class TestPruneQuartoSidebarNestedSectionGroup:
                 ]
             }
         }
-        quarto.write_text(yaml.dump(config), encoding="utf-8")
+        quarto.write_text(format_yaml(config), encoding="utf-8")
 
         _prune_quarto_sidebar(tmp_path, "reference", {"kept"})
 
-        result = yaml.safe_load(quarto.read_text())
+        result = parse_yaml(quarto.read_text())
         contents = result["website"]["sidebar"][0]["contents"]
         # The section group should be entirely removed since all its entries are invalid
         assert len(contents) == 1
         assert contents[0] == "reference/kept.qmd"
 
     def test_partially_prunes_section_group(self, tmp_path: Path):
-        import yaml
+        from yaml12 import format_yaml, parse_yaml
 
         from great_docs._versioned_build import _prune_quarto_sidebar
 
@@ -3658,11 +3658,11 @@ class TestPruneQuartoSidebarNestedSectionGroup:
                 ]
             }
         }
-        quarto.write_text(yaml.dump(config), encoding="utf-8")
+        quarto.write_text(format_yaml(config), encoding="utf-8")
 
         _prune_quarto_sidebar(tmp_path, "reference", {"kept"})
 
-        result = yaml.safe_load(quarto.read_text())
+        result = parse_yaml(quarto.read_text())
         contents = result["website"]["sidebar"][0]["contents"]
         assert len(contents) == 1
         section = contents[0]
@@ -4167,7 +4167,7 @@ class TestPruneQuartoCliSidebarEdges:
         _prune_quarto_cli_sidebar(tmp_path, {"index"})
 
     def test_non_cli_sidebar_skipped(self, tmp_path: Path):
-        import yaml
+        from yaml12 import format_yaml, parse_yaml
 
         from great_docs._versioned_build import _prune_quarto_cli_sidebar
 
@@ -4179,13 +4179,13 @@ class TestPruneQuartoCliSidebarEdges:
                 ]
             }
         }
-        quarto.write_text(yaml.dump(config), encoding="utf-8")
+        quarto.write_text(format_yaml(config), encoding="utf-8")
         _prune_quarto_cli_sidebar(tmp_path, {"index"})
-        result = yaml.safe_load(quarto.read_text())
+        result = parse_yaml(quarto.read_text())
         assert len(result["website"]["sidebar"][0]["contents"]) == 2
 
     def test_dict_item_in_contents_kept(self, tmp_path: Path):
-        import yaml
+        from yaml12 import format_yaml, parse_yaml
 
         from great_docs._versioned_build import _prune_quarto_cli_sidebar
 
@@ -4204,9 +4204,9 @@ class TestPruneQuartoCliSidebarEdges:
                 ]
             }
         }
-        quarto.write_text(yaml.dump(config), encoding="utf-8")
+        quarto.write_text(format_yaml(config), encoding="utf-8")
         _prune_quarto_cli_sidebar(tmp_path, {"index"})
-        result = yaml.safe_load(quarto.read_text())
+        result = parse_yaml(quarto.read_text())
         contents = result["website"]["sidebar"][0]["contents"]
         has_dict = any(isinstance(c, dict) for c in contents)
         assert has_dict


### PR DESCRIPTION
This PR replaces all PyYAML usage with `py-yaml12` across several source and test files. Every `yaml.safe_load()` becomes `read_yaml()` or `parse_yaml()`. Every `yaml.dump()` becomes `write_yaml()` or `format_yaml()`.  With this, pyyaml is no longer imported anywhere in the codebase.