### PR TITLE
feat: ordering config for API sections

### DIFF
--- a/great_docs/assets/great-docs.default.yml
+++ b/great_docs/assets/great-docs.default.yml
@@ -197,6 +197,14 @@ mcp:
   #     "Data tools": [load, save]
   categories: {}
 
+# Reference Section Order
+# -----------------------
+# Controls the display order of API subsections (the switcher tabs) in the
+# Reference area. Valid values: "api", "cli", "mcp". Sections listed here
+# that don't exist in the project are silently ignored. When empty or omitted,
+# the default order is: api, cli, mcp.
+ref_section_order: []
+
 # Dark Mode Toggle
 # ----------------
 # Enable/disable the dark mode toggle in navbar (default: true)

--- a/great_docs/config.py
+++ b/great_docs/config.py
@@ -1339,6 +1339,18 @@ class Config:
         return None
 
     @property
+    def ref_section_order(self) -> list[str] | None:
+        """Custom display order for reference subsection tabs (api, cli, mcp)."""
+        try:
+            raw = self["ref_section_order"]
+        except KeyError:
+            return None
+        if isinstance(raw, list) and all(isinstance(item, str) for item in raw):
+            valid = [s for s in raw if s in ("api", "cli", "mcp")]
+            return valid if valid else None
+        return None
+
+    @property
     def content_style(self) -> dict[str, str] | None:
         """The content-area gradient config, or None when no preset is set"""
         preset = self["content_style.preset"]

--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -12732,15 +12732,41 @@ anchor-sections: true
                 ]
 
             # Build the sections list for the data attribute.
-            # Only include "api" if a Python API reference was actually generated.
-            ref_sections = []
+            # Only include sections that are actually present in this build.
+            available_sections = []
             if self._has_api_reference:
-                ref_sections.append("api")
+                available_sections.append("api")
             if cli_enabled or go_cli_enabled or rust_cli_enabled:
-                ref_sections.append("cli")
+                available_sections.append("cli")
             if mcp_enabled:
-                ref_sections.append("mcp")
+                available_sections.append("mcp")
+
+            custom_order = self._config.ref_section_order
+            if custom_order:
+                ref_sections = [s for s in custom_order if s in available_sections]
+                for s in available_sections:
+                    if s not in ref_sections:
+                        ref_sections.append(s)
+            else:
+                ref_sections = available_sections
             sections_attr = ",".join(ref_sections)
+
+            # When the first ref section isn't "api", update the navbar
+            # "Reference" link to point to the first section's index page.
+            _SECTION_INDEX = {
+                "api": "reference/index.qmd",
+                "cli": "reference/cli/index.qmd",
+                "mcp": "reference/mcp/index.qmd",
+            }
+            if ref_sections and ref_sections[0] != "api":
+                first_href = _SECTION_INDEX.get(ref_sections[0], "reference/index.qmd")
+                navbar = config.get("website", {}).get("navbar", {})
+                for item in navbar.get("left", []):
+                    if isinstance(item, dict) and (item.get("href") or "").startswith(
+                        "reference/"
+                    ):
+                        item["href"] = first_href
+                        break
 
             # Inject data-gd-ref-sections on <body> via include-in-header script
             if "include-in-header" not in config["format"]["html"]:

--- a/test-packages/synthetic/catalog.py
+++ b/test-packages/synthetic/catalog.py
@@ -419,6 +419,8 @@ ALL_PACKAGES: list[str] = [
     "gdtest_mcp",  # 208
     # 209: Build-time D2 diagrams (separate light/dark SVGs)
     "gdtest_d2_diagrams",  # 209
+    # 210: Custom reference section ordering (CLI before API)
+    "gdtest_ref_section_order",  # 210
 ]
 
 
@@ -2336,6 +2338,12 @@ PACKAGE_DESCRIPTIONS: dict[str, str] = {
         "container holding two `<img>` elements — a light-theme and a dark-theme SVG "
         "swapped via `.light-mode-only` / `.dark-mode-only` — with the generated "
         "`d2-<hash>-{light,dark}.svg` files copied into the site."
+    ),
+    "gdtest_ref_section_order": (
+        "CLI-first package with ref_section_order: [cli, api, mcp] in config. "
+        "The reference switcher tabs should appear CLI-first (cli,api) instead "
+        "of the default (api,cli). The data-gd-ref-sections body attribute "
+        "should be 'cli,api' since there is no MCP server."
     ),
 }
 

--- a/test-packages/synthetic/specs/gdtest_ref_section_order.py
+++ b/test-packages/synthetic/specs/gdtest_ref_section_order.py
@@ -1,0 +1,121 @@
+"""
+gdtest_ref_section_order — Custom reference section ordering.
+
+Dimensions: A1, B1, C1, D1, E1+E6, F6, G1, H7
+Focus: ref_section_order config key. The reference switcher tabs should
+appear in the order specified by the config (cli, api) instead of the
+default (api, cli). The data-gd-ref-sections body attribute should
+reflect this custom ordering.
+"""
+
+SPEC = {
+    "name": "gdtest_ref_section_order",
+    "description": "CLI-first reference section ordering via ref_section_order config",
+    "dimensions": ["A1", "B1", "C1", "D1", "E1", "E6", "F6", "G1", "H7"],
+    "pyproject_toml": {
+        "project": {
+            "name": "gdtest-ref-section-order",
+            "version": "0.1.0",
+            "description": "A package demonstrating custom ref section order",
+            "scripts": {
+                "gdtest-rso": "gdtest_ref_section_order.cli:main",
+            },
+        },
+        "build-system": {
+            "requires": ["setuptools"],
+            "build-backend": "setuptools.build_meta",
+        },
+    },
+    "files": {
+        "gdtest_ref_section_order/__init__.py": '''\
+            """A CLI-first package with custom reference section ordering."""
+
+            __version__ = "0.1.0"
+            __all__ = ["run_task", "TaskConfig"]
+
+
+            class TaskConfig:
+                """
+                Configuration for a task.
+
+                Parameters
+                ----------
+                name
+                    The task name.
+                timeout
+                    Timeout in seconds.
+                """
+
+                def __init__(self, name: str, timeout: int = 30):
+                    self.name = name
+                    self.timeout = timeout
+
+
+            def run_task(config: TaskConfig) -> str:
+                """
+                Run a task with the given configuration.
+
+                Parameters
+                ----------
+                config
+                    The task configuration.
+
+                Returns
+                -------
+                str
+                    Task result message.
+                """
+                return f"Task {config.name} completed"
+        ''',
+        "gdtest_ref_section_order/cli.py": '''\
+            """CLI entry point using Click."""
+
+            import click
+
+
+            @click.group()
+            def main() -> None:
+                """gdtest-rso: a CLI-first tool for running tasks."""
+
+
+            @main.command()
+            @click.argument("name")
+            @click.option("--timeout", "-t", default=30, help="Timeout in seconds.")
+            def run(name: str, timeout: int) -> None:
+                """Run a named task."""
+                click.echo(f"Running {name} (timeout={timeout}s)")
+
+
+            @main.command()
+            def list() -> None:
+                """List available tasks."""
+                click.echo("task-a\\ntask-b\\ntask-c")
+        ''',
+        "README.md": """\
+            # gdtest-ref-section-order
+
+            A CLI-first test package demonstrating custom reference section ordering.
+        """,
+    },
+    "config": {
+        "cli": {
+            "enabled": True,
+        },
+        "mcp": {
+            "enabled": False,
+        },
+        "ref_section_order": ["cli", "api"],
+    },
+    "expected": {
+        "detected_name": "gdtest-ref-section-order",
+        "detected_module": "gdtest_ref_section_order",
+        "detected_parser": "numpy",
+        "export_names": ["TaskConfig", "run_task"],
+        "num_exports": 2,
+        "section_titles": ["Classes", "Functions"],
+        "has_user_guide": False,
+        "cli_enabled": True,
+        "ref_section_order": ["cli", "api"],
+        "coverage_exclude": ["nodoc", "bigcl", "ug", "supp", "hdg"],
+    },
+}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1848,6 +1848,35 @@ class TestNavbarOrder:
         assert cfg.navbar_order == ["Reference", "Guide", "Changelog"]
 
 
+# ref_section_order
+
+
+class TestRefSectionOrder:
+    def test_default_none(self, tmp_path):
+        assert Config(tmp_path).ref_section_order is None
+
+    def test_valid_list(self, tmp_path):
+        cfg = _make_config(tmp_path, "ref_section_order:\n  - cli\n  - api\n  - mcp\n")
+        assert cfg.ref_section_order == ["cli", "api", "mcp"]
+
+    def test_filters_invalid_values(self, tmp_path):
+        cfg = _make_config(tmp_path, "ref_section_order:\n  - cli\n  - bogus\n  - api\n")
+        assert cfg.ref_section_order == ["cli", "api"]
+
+    def test_all_invalid_returns_none(self, tmp_path):
+        cfg = _make_config(tmp_path, "ref_section_order:\n  - bogus\n  - nope\n")
+        assert cfg.ref_section_order is None
+
+    def test_non_list_returns_none(self, tmp_path):
+        cfg = _make_config(tmp_path, "ref_section_order: cli\n")
+        assert cfg.ref_section_order is None
+
+    def test_key_missing_returns_none(self, tmp_path):
+        cfg = Config(tmp_path)
+        del cfg._config["ref_section_order"]
+        assert cfg.ref_section_order is None
+
+
 # scale_to_fit branches
 
 

--- a/tests/test_config_defaults.py
+++ b/tests/test_config_defaults.py
@@ -97,6 +97,7 @@ FROZEN_DEFAULT_CONFIG: dict[str, Any] = {
     "navbar_style": None,
     "navbar_color": None,
     "navbar_order": None,
+    "ref_section_order": [],
     "content_style": {"preset": None, "pages": "all"},
     "scale_to_fit": None,
     "scale_to_fit_min_scale": None,

--- a/tests/test_gdg_rendered.py
+++ b/tests/test_gdg_rendered.py
@@ -7898,8 +7898,7 @@ def test_DED_interlinks_userguide_full_qualified():
     link_texts = [a.get_text(strip=True) for a in gdls_links]
 
     assert "gdtest_interlinks.BaseStore" in link_texts, (
-        f"Advanced: full qualified 'gdtest_interlinks.BaseStore' not found. "
-        f"Found: {link_texts}"
+        f"Advanced: full qualified 'gdtest_interlinks.BaseStore' not found. Found: {link_texts}"
     )
 
 
@@ -11606,3 +11605,36 @@ def test_DED_d2_block_replaced_not_left_as_code():
     html = page.read_text(encoding="utf-8")
     _skip_if_no_diagrams(html)
     assert "Decision" not in html, "d2 source leaked into HTML — block was not pre-rendered"
+
+
+# ── ref_section_order ───────────────────────────────────────────────────────
+
+
+@pytest.mark.dedicated
+def test_DED_ref_section_order_cli_first():
+    """gdtest_ref_section_order: data-gd-ref-sections has cli before api."""
+    pkg = "gdtest_ref_section_order"
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+
+    quarto_yml = _RENDERED_DIR / pkg / "great-docs" / "_quarto.yml"
+    assert quarto_yml.exists(), "_quarto.yml missing"
+    content = quarto_yml.read_text(encoding="utf-8")
+    assert "data-gd-ref-sections','cli,api'" in content, (
+        "Expected cli,api order in data-gd-ref-sections but got something else"
+    )
+
+
+@pytest.mark.dedicated
+def test_DED_ref_section_order_navbar_links_to_first_section():
+    """gdtest_ref_section_order: navbar Reference link points to CLI index."""
+    pkg = "gdtest_ref_section_order"
+    if not _has_rendered_site(pkg):
+        pytest.skip(f"{pkg} not rendered")
+
+    quarto_yml = _RENDERED_DIR / pkg / "great-docs" / "_quarto.yml"
+    assert quarto_yml.exists(), "_quarto.yml missing"
+    content = quarto_yml.read_text(encoding="utf-8")
+    assert "href: reference/cli/index.qmd" in content, (
+        "Navbar Reference link should point to reference/cli/index.qmd when CLI is first"
+    )

--- a/user_guide/05-configuration.qmd
+++ b/user_guide/05-configuration.qmd
@@ -782,6 +782,25 @@ Items are matched by their display text. Any navbar items not listed are appende
 their original order. This is useful when you want a specific item (like the User Guide) to appear
 first.
 
+## Reference Section Order
+
+When your site includes multiple reference sections (Python API, CLI, MCP Server), the default
+ordering of sections is: Python API, CLI, MCP Server. You may prefer a different order and we can
+use `ref_section_order` to change this. For example, a CLI-first tool might want this particular
+ordering of reference pages:
+
+```{.yaml filename="great-docs.yml"}
+ref_section_order:
+  - cli
+  - api
+  - mcp
+```
+
+Valid values are `api`, `cli`, and `mcp`. Sections listed here that don't exist in your project are
+silently ignored, so it's safe to include `mcp` even if your package has no MCP server. Sections not
+listed are appended at the end in the default order. The navbar "Reference" link will point to
+whichever section is first.
+
 ## Author Information
 
 Customize author display in the landing page sidebar:
@@ -1128,6 +1147,12 @@ navbar_order:
   - Examples
   - Tutorials
   - Changelog
+
+# Reference Section Order (within the Reference area)
+ref_section_order:
+  - cli
+  - api
+  - mcp
 
 # API Reference Structure
 reference:


### PR DESCRIPTION
This PR adds a `ref_section_order` config key to `great-docs.yml` that controls the display order of reference subsection tabs (Python API, CLI, MCP Server). By default the order is `api`, `cli`, `mcp`. Setting `ref_section_order: [cli, api, mcp]` puts CLI first (and this is useful for CLI-heavy packages). Sections that don't exist in the project are silently ignored. The navbar "Reference" link automatically points to whichever section is listed first.