### PR TITLE
Link llms.txt and llms-full.txt only when they are generated

### DIFF
--- a/great_docs/core.py
+++ b/great_docs/core.py
@@ -10339,11 +10339,13 @@ class GreatDocs:
                 '<path d="M20 3v4"/><path d="M22 5h-4"/></svg>'
             )
             ai_items.append(f'<a href="skills.html">Skills{_sparkle_svg}</a><br>')
-        ai_items.append("[llms.txt](llms.txt)<br>")
-        ai_items.append("[llms-full.txt](llms-full.txt)<br>")
+        if self._llms_txt_available():
+            ai_items.append("[llms.txt](llms.txt)<br>")
+            ai_items.append("[llms-full.txt](llms-full.txt)<br>")
 
-        margin_sections.append(f"\n#### {get_translation('ai_agents', lang)}\n")
-        margin_sections.extend(ai_items)
+        if ai_items:
+            margin_sections.append(f"\n#### {get_translation('ai_agents', lang)}\n")
+            margin_sections.extend(ai_items)
 
         # ── 3. Developers (Authors + Funding) ────────────────────────────
         authors_to_display = metadata.get("rich_authors") or metadata.get("authors", [])
@@ -13671,6 +13673,28 @@ anchor-sections: true
         with open(index_path, "w") as f:
             f.write(content)
 
+    def _llms_txt_available(self) -> bool:
+        """
+        Whether `llms.txt` and `llms-full.txt` will be generated for this project.
+
+        Both generators return early unless `_quarto.yml` carries an `api-reference`
+        block with a `package` and at least one section. Every place that links to
+        the files (the metadata margin, SKILL.md resources, the build log) should ask
+        this instead of assuming, so links and files cannot drift apart.
+        """
+        quarto_yml = self.project_path / "_quarto.yml"
+        if not quarto_yml.exists():
+            return False
+        try:
+            with open(quarto_yml, "r") as f:
+                config = read_yaml(f) or {}
+        except Exception:
+            return False
+        api_ref_config = config.get("api-reference")
+        if not isinstance(api_ref_config, dict):
+            return False
+        return bool(api_ref_config.get("package")) and bool(api_ref_config.get("sections"))
+
     def _generate_llms_txt(self) -> None:
         """
         Generate an llms.txt file for LLM documentation indexing.
@@ -14211,8 +14235,9 @@ anchor-sections: true
         lines.append("")
         if site_url:
             lines.append(f"- [Full documentation]({site_url})")
-        lines.append("- [llms.txt](llms.txt) — Indexed API reference for LLMs")
-        lines.append("- [llms-full.txt](llms-full.txt) — Comprehensive documentation for LLMs")
+        if self._llms_txt_available():
+            lines.append("- [llms.txt](llms.txt) — Indexed API reference for LLMs")
+            lines.append("- [llms-full.txt](llms-full.txt) — Comprehensive documentation for LLMs")
         if repo_url:
             lines.append(f"- [Source code]({repo_url})")
         lines.append("")
@@ -16160,10 +16185,13 @@ anchor-sections: true
             # ── Step 3: Generate llms.txt / llms-full.txt ──────────────
             step += 1
             log.step_start(step, "Generate llms.txt / llms-full.txt")
-            with _quiet_prints():
-                self._generate_llms_txt()
-                self._generate_llms_full_txt()
-            log.step_done("Created llms.txt + llms-full.txt")
+            if self._llms_txt_available():
+                with _quiet_prints():
+                    self._generate_llms_txt()
+                    self._generate_llms_full_txt()
+                log.step_done("Created llms.txt + llms-full.txt")
+            else:
+                log.step_skip(step, "no API reference")
 
             # ── Step 4: Generate SKILL.md ──────────────────────────────
             step += 1

--- a/tests/test_great_docs.py
+++ b/tests/test_great_docs.py
@@ -13954,15 +13954,53 @@ def test_build_metadata_margin_with_authors():
 
 
 def test_build_metadata_margin_llms_links():
-    """_build_metadata_margin always includes llms.txt links."""
+    """_build_metadata_margin links llms.txt only when the files will be generated."""
     with tempfile.TemporaryDirectory() as tmp_dir:
         gd_dir = Path(tmp_dir) / "great-docs"
         gd_dir.mkdir()
+        (gd_dir / "_quarto.yml").write_text(
+            "api-reference:\n  package: pkg\n  sections:\n    - title: Core\n      contents: [pkg.f]\n",
+            encoding="utf-8",
+        )
         docs = GreatDocs(project_path=tmp_dir)
         result = docs._build_metadata_margin()
 
         assert "llms.txt" in result
         assert "llms-full.txt" in result
+
+
+def test_build_metadata_margin_no_llms_links_without_api_reference():
+    """A docs-only site gets no llms.txt links, because no files are generated (#350)."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        gd_dir = Path(tmp_dir) / "great-docs"
+        gd_dir.mkdir()
+        (gd_dir / "_quarto.yml").write_text(
+            "project:\n  type: website\nwebsite:\n  title: Docs only\n", encoding="utf-8"
+        )
+        docs = GreatDocs(project_path=tmp_dir)
+        result = docs._build_metadata_margin()
+
+        assert "llms.txt" not in result
+        assert "llms-full.txt" not in result
+
+
+def test_llms_txt_available_matches_generators():
+    """The predicate agrees with the generators' own early returns."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        gd_dir = Path(tmp_dir) / "great-docs"
+        gd_dir.mkdir()
+        docs = GreatDocs(project_path=tmp_dir)
+        assert docs._llms_txt_available() is False  # no _quarto.yml
+        quarto = gd_dir / "_quarto.yml"
+        quarto.write_text("project:\n  type: website\n", encoding="utf-8")
+        assert docs._llms_txt_available() is False  # no api-reference
+        quarto.write_text("api-reference:\n  package: pkg\n  sections: []\n", encoding="utf-8")
+        assert docs._llms_txt_available() is False  # no sections
+        quarto.write_text(
+            "api-reference:\n  package: pkg\n  sections:\n    - title: Core\n      contents: [pkg.f]\n",
+            encoding="utf-8",
+        )
+        assert docs._llms_txt_available() is True
 
 
 def test_build_metadata_margin_authors_with_rich_metadata():
@@ -39612,6 +39650,12 @@ def test_homepage_sidebar_skills_link_position():
 
         great_docs_dir = Path(tmp_dir) / "great-docs"
         great_docs_dir.mkdir()
+        # llms.txt links are only shown when the files will be generated (#350)
+        (great_docs_dir / "_quarto.yml").write_text(
+            "api-reference:\n  package: test_package\n  sections:\n"
+            "    - title: Core\n      contents: [test_package.f]\n",
+            encoding="utf-8",
+        )
 
         margin = docs._build_metadata_margin()
 


### PR DESCRIPTION
# Summary

Docs-only sites (no `api-reference` in `_quarto.yml`) advertised `llms.txt` and `llms-full.txt` in the *AI / Agents* margin and in `SKILL.md`, while both generators return early and write nothing, so every such site shipped two dead links and a build log that said the files were created.

This takes the issue's "minimal version": the links and the log are gated on the same condition the generators use, so they cannot drift apart again.

- New `GreatDocs._llms_txt_available()`: true only when `_quarto.yml` has an `api-reference` with a `package` and at least one section, mirroring the generators' early returns.
- `_build_metadata_margin`: appends the two links only when available; omits the *AI / Agents* heading when it would be empty.
- `_generate_skill_md`: same gate on the two Resources lines.
- Build step 3: logs `no API reference` (via `step_skip`) instead of `Created llms.txt + llms-full.txt` when nothing is written.

The generators themselves are unchanged. The issue's better option, generating a section index for non-API projects, would be a separate change; this one just stops the lie.

Tests: the existing margin test now sets up an `api-reference`; a new test covers the docs-only case; a third checks the predicate against each early return the generators have. `test_homepage_sidebar_skills_link_position` gains the `api-reference` it implicitly relied on. Core suite: 6983 passed, 754 skipped. `ruff check` reports the same 9 pre-existing findings on `main` and on this branch; `ruff format --check` passes for the two touched files.

# Related GitHub Issues and PRs

- Ref: #350

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [x] I have added **pytest** unit tests for any new functionality.

---

Written by tally, an agent, from its human's GitHub account. If merged, tally will file a public receipt for this work at https://mandajayde.github.io/receipts naming whoever merges it as the person who judged it, and would ask them once to reply "accept" or "decline" there. Optional; the change stands on its own.